### PR TITLE
Channel API: fix web-mode 404s and unify the dual-transport registry

### DIFF
--- a/Cribl-Microsoft_IntegrationSolution/src/api/channels.ts
+++ b/Cribl-Microsoft_IntegrationSolution/src/api/channels.ts
@@ -1,0 +1,16 @@
+// Channel/path conversion -- the one place that knows how an IPC channel name maps to a web
+// API route. Channels are colon-separated ('auth:status'); web routes are slash-separated
+// ('auth/status'). This rule was previously duplicated in api-client.ts (call) and
+// api-router.ts (middleware); both now import from here.
+//
+// This module is renderer-safe (no electron import) so the web client can use it.
+
+/** 'auth:cribl-connect' -> 'auth/cribl-connect' (for fetch URLs). */
+export function channelToPath(channel: string): string {
+  return channel.replace(/:/g, '/');
+}
+
+/** 'auth/cribl-connect' -> 'auth:cribl-connect' (for routing an incoming request to a handler). */
+export function pathToChannel(path: string): string {
+  return path.replace(/\//g, ':');
+}

--- a/Cribl-Microsoft_IntegrationSolution/src/api/registry.ts
+++ b/Cribl-Microsoft_IntegrationSolution/src/api/registry.ts
@@ -1,0 +1,62 @@
+// Handler-module registry -- the single ordered list of IPC handler modules.
+//
+// Both transports consume this list: the Electron main process (src/main/ipc/index.ts) and
+// the web server (src/server/api-router.ts). Driving both from one array makes the two
+// registration lists impossible to drift apart (the bug that previously left 7 channels
+// 404ing in web mode). Add a new handler module here exactly once.
+//
+// Renderer code must never import this file -- it pulls in every main-process handler module.
+
+import type { IpcMain } from 'electron';
+
+import { registerAppPathsHandlers } from '../main/ipc/app-paths';
+import { registerDepsHandlers } from '../main/ipc/deps';
+import { registerPowerShellHandlers } from '../main/ipc/powershell';
+import { registerConfigHandlers } from '../main/ipc/config';
+import { registerGitHubHandlers } from '../main/ipc/github';
+import { registerPackBuilderHandlers } from '../main/ipc/pack-builder';
+import { registerVendorResearchHandlers } from '../main/ipc/vendor-research';
+import { registerRegistrySyncHandlers } from '../main/ipc/registry-sync';
+import { registerChangeDetectionHandlers } from '../main/ipc/change-detection';
+import { registerAzureDeployHandlers } from '../main/ipc/azure-deploy';
+import { registerParamFormHandlers } from '../main/ipc/param-forms';
+import { registerAuthHandlers } from '../main/ipc/auth';
+import { registerE2EHandlers } from '../main/ipc/e2e-orchestrator';
+import { registerSentinelRepoHandlers } from '../main/ipc/sentinel-repo';
+import { registerSampleParserHandlers } from '../main/ipc/sample-parser';
+import { registerPermissionCheckHandlers } from '../main/ipc/permission-check';
+import { registerDefaultSampleHandlers } from '../main/ipc/default-samples';
+import { registerFieldMatcherHandlers } from '../main/ipc/field-matcher';
+import { registerSiemMigrationHandlers } from '../main/ipc/siem-migration';
+import { registerSampleResolverHandlers } from '../main/ipc/sample-resolver';
+
+export interface ModuleRegistration {
+  /** Short module name, matching the source file (e.g. 'pack-builder'). */
+  name: string;
+  /** Registers this module's ipcMain.handle() channels. */
+  register: (ipcMain: IpcMain) => void;
+}
+
+// Order is cosmetic (channel names are unique), but preserved from the original index.ts.
+export const HANDLER_MODULES: readonly ModuleRegistration[] = [
+  { name: 'app-paths', register: registerAppPathsHandlers },
+  { name: 'deps', register: registerDepsHandlers },
+  { name: 'powershell', register: registerPowerShellHandlers },
+  { name: 'config', register: registerConfigHandlers },
+  { name: 'github', register: registerGitHubHandlers },
+  { name: 'pack-builder', register: registerPackBuilderHandlers },
+  { name: 'vendor-research', register: registerVendorResearchHandlers },
+  { name: 'registry-sync', register: registerRegistrySyncHandlers },
+  { name: 'change-detection', register: registerChangeDetectionHandlers },
+  { name: 'azure-deploy', register: registerAzureDeployHandlers },
+  { name: 'param-forms', register: registerParamFormHandlers },
+  { name: 'auth', register: registerAuthHandlers },
+  { name: 'e2e', register: registerE2EHandlers },
+  { name: 'sentinel-repo', register: registerSentinelRepoHandlers },
+  { name: 'sample-parser', register: registerSampleParserHandlers },
+  { name: 'permission-check', register: registerPermissionCheckHandlers },
+  { name: 'default-samples', register: registerDefaultSampleHandlers },
+  { name: 'field-matcher', register: registerFieldMatcherHandlers },
+  { name: 'siem-migration', register: registerSiemMigrationHandlers },
+  { name: 'sample-resolver', register: registerSampleResolverHandlers },
+];

--- a/Cribl-Microsoft_IntegrationSolution/src/main/ipc/index.ts
+++ b/Cribl-Microsoft_IntegrationSolution/src/main/ipc/index.ts
@@ -1,49 +1,20 @@
 import { IpcMain, BrowserWindow } from 'electron';
-import { initAppPaths, registerAppPathsHandlers } from './app-paths';
-import { registerPowerShellHandlers } from './powershell';
-import { registerConfigHandlers } from './config';
-import { registerGitHubHandlers } from './github';
-import { registerPackBuilderHandlers } from './pack-builder';
-import { registerDepsHandlers } from './deps';
-import { registerVendorResearchHandlers } from './vendor-research';
-import { registerRegistrySyncHandlers, performFullSync } from './registry-sync';
-import { registerChangeDetectionHandlers, runChangeDetection } from './change-detection';
-import { registerAzureDeployHandlers } from './azure-deploy';
-import { registerParamFormHandlers } from './param-forms';
-import { registerAuthHandlers } from './auth';
-import { registerE2EHandlers } from './e2e-orchestrator';
-import { registerSentinelRepoHandlers, autoUpdate as autoUpdateRepo } from './sentinel-repo';
-import { registerSampleParserHandlers } from './sample-parser';
-import { registerPermissionCheckHandlers } from './permission-check';
-import { registerDefaultSampleHandlers } from './default-samples';
-import { registerFieldMatcherHandlers } from './field-matcher';
-import { registerSiemMigrationHandlers } from './siem-migration';
-import { autoUpdateElasticRepo, registerSampleResolverHandlers } from './sample-resolver';
+import { HANDLER_MODULES } from '../../api/registry';
+import { initAppPaths } from './app-paths';
+import { performFullSync } from './registry-sync';
+import { runChangeDetection } from './change-detection';
+import { autoUpdate as autoUpdateRepo } from './sentinel-repo';
+import { autoUpdateElasticRepo } from './sample-resolver';
 
 export function registerIpcHandlers(ipcMain: IpcMain) {
   // Initialize app data directories and bundle templates if repo is detected
   initAppPaths();
 
-  registerAppPathsHandlers(ipcMain);
-  registerDepsHandlers(ipcMain);
-  registerPowerShellHandlers(ipcMain);
-  registerConfigHandlers(ipcMain);
-  registerGitHubHandlers(ipcMain);
-  registerPackBuilderHandlers(ipcMain);
-  registerVendorResearchHandlers(ipcMain);
-  registerRegistrySyncHandlers(ipcMain);
-  registerChangeDetectionHandlers(ipcMain);
-  registerAzureDeployHandlers(ipcMain);
-  registerParamFormHandlers(ipcMain);
-  registerAuthHandlers(ipcMain);
-  registerE2EHandlers(ipcMain);
-  registerSentinelRepoHandlers(ipcMain);
-  registerSampleParserHandlers(ipcMain);
-  registerPermissionCheckHandlers(ipcMain);
-  registerDefaultSampleHandlers(ipcMain);
-  registerFieldMatcherHandlers(ipcMain);
-  registerSiemMigrationHandlers(ipcMain);
-  registerSampleResolverHandlers(ipcMain);
+  // Register every handler module from the single shared registry (same list the web
+  // server uses in src/server/api-router.ts).
+  for (const mod of HANDLER_MODULES) {
+    mod.register(ipcMain);
+  }
 
   // Broadcast a startup log message to the renderer
   function startupLog(message: string, level: 'info' | 'error' = 'info') {

--- a/Cribl-Microsoft_IntegrationSolution/src/renderer/api-client.ts
+++ b/Cribl-Microsoft_IntegrationSolution/src/renderer/api-client.ts
@@ -1,11 +1,13 @@
 // API Client - Replaces window.api (Electron preload) with fetch() calls.
 // Every method matches the same signature as the preload bridge.
 
+import { channelToPath } from '../api/channels';
+
 const API_BASE = '/api';
 
 async function call(channel: string, args?: unknown): Promise<any> {
   // Convert colon-separated channel to URL path: auth:status -> auth/status
-  const urlPath = channel.replace(/:/g, '/');
+  const urlPath = channelToPath(channel);
   const resp = await fetch(`${API_BASE}/${urlPath}`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },

--- a/Cribl-Microsoft_IntegrationSolution/src/renderer/api-client.ts
+++ b/Cribl-Microsoft_IntegrationSolution/src/renderer/api-client.ts
@@ -83,8 +83,13 @@ export function createApiClient() {
       solutions: () => call('sentinel-repo:solutions'),
       connectors: (solutionName: string) => call('sentinel-repo:connectors', { solutionName }),
       readFile: (relativePath: string) => call('sentinel-repo:read-file', { relativePath }),
+      resetError: () => call('sentinel-repo:reset-error'),
+      blocklist: () => call('sentinel-repo:blocklist'),
+      blocklistRetry: (solutionName: string) => call('sentinel-repo:blocklist-retry', { solutionName }),
+      blocklistAdd: (solutionName: string, reason: string) => call('sentinel-repo:blocklist-add', { solutionName, reason }),
       onStatus: (cb: (status: any) => void) => onEvent('sentinel-repo:status', cb),
       onProgress: (cb: (data: string) => void) => onEvent('sentinel-repo:progress', cb),
+      onFetchProgress: (cb: (data: { done: number; total: number; pct: number }) => void) => onEvent('sentinel-repo:fetch-progress', cb),
     },
     packBuilder: {
       scaffold: (options: unknown) => call('pack:scaffold', options),
@@ -160,6 +165,8 @@ export function createApiClient() {
       azureSubscriptions: () => call('auth:azure-subscriptions'),
       azureWorkspaces: (subscriptionId?: string) => call('auth:azure-workspaces', { subscriptionId }),
       azureCreateResourceGroup: (name: string, location: string, subscriptionId?: string) => call('auth:azure-create-resource-group', { name, location, subscriptionId }),
+      azureCreateWorkspace: (name: string, resourceGroup: string, location: string, subscriptionId?: string) => call('auth:azure-create-workspace', { name, resourceGroup, location, subscriptionId }),
+      azureEnableSentinel: (workspaceName: string, resourceGroup: string, subscriptionId?: string) => call('auth:azure-enable-sentinel', { workspaceName, resourceGroup, subscriptionId }),
       azureResourceGroups: (subscriptionId?: string) => call('auth:azure-resource-groups', { subscriptionId }),
       azureSelectWorkspace: (workspace: any) => call('auth:azure-select-workspace', workspace),
       criblCreateDestination: (destination: Record<string, unknown>, workerGroup?: string) => call('auth:cribl-create-destination', { destination, workerGroup }),
@@ -210,6 +217,8 @@ export function createApiClient() {
         });
       },
       parseFeedConfig: (configText: string) => call('samples:parse-feed-config', { configText }),
+      parseCsvWithHeaders: (csvContent: string, headers: string[], skipFirstRow: boolean) =>
+        call('samples:parse-csv-with-headers', { csvContent, headers, skipFirstRow }),
       tagSample: (vendor: string, logType: string, content: string, sourceName?: string) =>
         call('samples:tag-sample', { vendor, logType, content, sourceName }),
       getTagged: (vendor: string) => call('samples:get-tagged', { vendor }),
@@ -240,5 +249,17 @@ export function createApiClient() {
       buildPack: (solutionName: string, packName?: string, userSamples?: Array<{ logType: string; content: string; fileName: string }>) => call('siem:build-pack', { solutionName, packName, userSamples }),
       exportReport: (plan: unknown) => call('siem:export-report', { plan }),
     },
+    sampleResolver: {
+      listAvailable: (solutionName: string) => call('samples:list-available', { solutionName }),
+      loadSelected: (solutionName: string, selectedIds: string[]) => call('samples:load-selected', { solutionName, selectedIds }),
+    },
+    elasticRepo: {
+      status: () => call('elastic-repo:status'),
+      clone: () => call('elastic-repo:clone'),
+      resetError: () => call('elastic-repo:reset-error'),
+      onStatus: (cb: (status: { state: string; packageCount: number; error: string }) => void) => onEvent('elastic-repo:status', cb),
+      onFetchProgress: (cb: (data: { done: number; total: number; pct: number }) => void) => onEvent('elastic-repo:fetch-progress', cb),
+    },
+    onStartupLog: (cb: (log: { message: string; level: string; timestamp: number }) => void) => onEvent('startup:log', cb),
   };
 }

--- a/Cribl-Microsoft_IntegrationSolution/src/renderer/types/index.ts
+++ b/Cribl-Microsoft_IntegrationSolution/src/renderer/types/index.ts
@@ -138,11 +138,13 @@ declare global {
         solutions: () => Promise<Array<{ name: string; path: string }>>;
         connectors: (solutionName: string) => Promise<Array<{ name: string; path: string; size: number }>>;
         readFile: (relativePath: string) => Promise<string | null>;
+        resetError: () => Promise<unknown>;
         blocklist: () => Promise<Array<{ name: string; reason: string; source: string }>>;
         blocklistRetry: (solutionName: string) => Promise<{ removed: boolean; blocklist: Array<{ name: string; reason: string; source: string }> }>;
         blocklistAdd: (solutionName: string, reason: string) => Promise<{ added: boolean; blocklist: Array<{ name: string; reason: string; source: string }> }>;
         onStatus: (callback: (status: { state: string; solutionCount: number; error: string; blockedCount: number; fetchedCount: number }) => void) => () => void;
         onProgress: (callback: (data: string) => void) => () => void;
+        onFetchProgress: (callback: (data: { done: number; total: number; pct: number }) => void) => () => void;
       };
       packBuilder: {
         scaffold: (options: PackScaffoldOptions) => Promise<{ packDir: string; crblPath: string }>;
@@ -258,8 +260,8 @@ declare global {
           cloud: { clientId: string; organizationId: string; hasSecret: boolean } | null;
           selfManaged: { clientId: string; baseUrl: string; hasSecret: boolean } | null;
         } | null>;
-        azureStatus: () => Promise<{ loggedIn: boolean; accountId: string; subscriptionId: string; subscriptionName: string; tenantId: string }>;
-        azureLogin: () => Promise<{ loggedIn: boolean; accountId: string; subscriptionId: string; subscriptionName: string; tenantId: string }>;
+        azureStatus: () => Promise<{ loggedIn: boolean; accountId: string; subscriptionId: string; subscriptionName: string; tenantId: string; error?: string }>;
+        azureLogin: () => Promise<{ loggedIn: boolean; accountId: string; subscriptionId: string; subscriptionName: string; tenantId: string; error?: string }>;
         azureSetSubscription: (subscriptionId: string) => Promise<{ success: boolean }>;
         azureSubscriptions: () => Promise<{ success: boolean; subscriptions: Array<{ id: string; name: string; state: string }>; error?: string }>;
         azureWorkspaces: (subscriptionId?: string) => Promise<{ success: boolean; workspaces: Array<{ name: string; resourceGroup: string; location: string; customerId: string; sku: string }>; error?: string }>;
@@ -431,6 +433,24 @@ declare global {
           success: boolean; filePath: string; report: string; error?: string;
         }>;
       };
+      sampleResolver: {
+        listAvailable: (solutionName: string) => Promise<Array<{
+          id: string; tier: string; source: string; logType: string;
+          format: string; eventCount: number; fileName: string;
+        }>>;
+        loadSelected: (solutionName: string, selectedIds: string[]) => Promise<Array<{
+          tableName: string; format: string; rawEvents: string[];
+          source: string; tier: string; logType?: string;
+        }>>;
+      };
+      elasticRepo: {
+        status: () => Promise<{ state: string; packageCount: number; lastUpdated: number; error: string }>;
+        clone: () => Promise<boolean>;
+        resetError: () => Promise<unknown>;
+        onStatus: (callback: (status: { state: string; packageCount: number; error: string }) => void) => () => void;
+        onFetchProgress: (callback: (data: { done: number; total: number; pct: number }) => void) => () => void;
+      };
+      onStartupLog: (callback: (log: { message: string; level: string; timestamp: number }) => void) => () => void;
     };
   }
 }

--- a/Cribl-Microsoft_IntegrationSolution/src/server/api-router.ts
+++ b/Cribl-Microsoft_IntegrationSolution/src/server/api-router.ts
@@ -52,6 +52,9 @@ export function createApiRouter(eventBus: EventBus): Router {
     const { registerDefaultSampleHandlers } = await import('../main/ipc/default-samples');
     const { registerFieldMatcherHandlers } = await import('../main/ipc/field-matcher');
     const { registerAppPathsHandlers } = await import('../main/ipc/app-paths');
+    const { registerPowerShellHandlers } = await import('../main/ipc/powershell');
+    const { registerSiemMigrationHandlers } = await import('../main/ipc/siem-migration');
+    const { registerSampleResolverHandlers } = await import('../main/ipc/sample-resolver');
 
     registerAppPathsHandlers(fakeIpcMain as any);
     registerDepsHandlers(fakeIpcMain as any);
@@ -70,6 +73,9 @@ export function createApiRouter(eventBus: EventBus): Router {
     registerPermissionCheckHandlers(fakeIpcMain as any);
     registerDefaultSampleHandlers(fakeIpcMain as any);
     registerFieldMatcherHandlers(fakeIpcMain as any);
+    registerPowerShellHandlers(fakeIpcMain as any);
+    registerSiemMigrationHandlers(fakeIpcMain as any);
+    registerSampleResolverHandlers(fakeIpcMain as any);
 
     console.log(`Registered ${handlers.size} API handlers`);
   };

--- a/Cribl-Microsoft_IntegrationSolution/src/server/api-router.ts
+++ b/Cribl-Microsoft_IntegrationSolution/src/server/api-router.ts
@@ -4,6 +4,7 @@
 
 import { Router, Request, Response } from 'express';
 import { EventBus, createFakeEvent } from './event-bus';
+import { pathToChannel } from '../api/channels';
 
 // Collected handlers from the registration phase
 const handlers = new Map<string, (event: any, args: any) => Promise<any>>();
@@ -29,54 +30,15 @@ export function createApiRouter(eventBus: EventBus): Router {
   const router = Router();
   const fakeIpcMain = createFakeIpcMain();
 
-  // Register all IPC handler modules using the fake IpcMain.
-  // Each module's registerXxxHandlers(ipcMain) call will populate the handlers map.
-  // We do this synchronously during server startup.
-
-  // Import and register all modules
+  // Register all IPC handler modules from the single shared registry (the same list the
+  // Electron main process uses in src/main/ipc/index.ts), so the two transports cannot drift.
+  // Loaded lazily via dynamic import so the electron stub installed in server/index.ts is in
+  // place before the handler modules import 'electron'.
   const registerAll = async () => {
-    const { registerDepsHandlers } = await import('../main/ipc/deps');
-    const { registerConfigHandlers } = await import('../main/ipc/config');
-    const { registerGitHubHandlers } = await import('../main/ipc/github');
-    const { registerPackBuilderHandlers } = await import('../main/ipc/pack-builder');
-    const { registerVendorResearchHandlers } = await import('../main/ipc/vendor-research');
-    const { registerRegistrySyncHandlers } = await import('../main/ipc/registry-sync');
-    const { registerChangeDetectionHandlers } = await import('../main/ipc/change-detection');
-    const { registerAzureDeployHandlers } = await import('../main/ipc/azure-deploy');
-    const { registerParamFormHandlers } = await import('../main/ipc/param-forms');
-    const { registerAuthHandlers } = await import('../main/ipc/auth');
-    const { registerE2EHandlers } = await import('../main/ipc/e2e-orchestrator');
-    const { registerSentinelRepoHandlers } = await import('../main/ipc/sentinel-repo');
-    const { registerSampleParserHandlers } = await import('../main/ipc/sample-parser');
-    const { registerPermissionCheckHandlers } = await import('../main/ipc/permission-check');
-    const { registerDefaultSampleHandlers } = await import('../main/ipc/default-samples');
-    const { registerFieldMatcherHandlers } = await import('../main/ipc/field-matcher');
-    const { registerAppPathsHandlers } = await import('../main/ipc/app-paths');
-    const { registerPowerShellHandlers } = await import('../main/ipc/powershell');
-    const { registerSiemMigrationHandlers } = await import('../main/ipc/siem-migration');
-    const { registerSampleResolverHandlers } = await import('../main/ipc/sample-resolver');
-
-    registerAppPathsHandlers(fakeIpcMain as any);
-    registerDepsHandlers(fakeIpcMain as any);
-    registerConfigHandlers(fakeIpcMain as any);
-    registerGitHubHandlers(fakeIpcMain as any);
-    registerPackBuilderHandlers(fakeIpcMain as any);
-    registerVendorResearchHandlers(fakeIpcMain as any);
-    registerRegistrySyncHandlers(fakeIpcMain as any);
-    registerChangeDetectionHandlers(fakeIpcMain as any);
-    registerAzureDeployHandlers(fakeIpcMain as any);
-    registerParamFormHandlers(fakeIpcMain as any);
-    registerAuthHandlers(fakeIpcMain as any);
-    registerE2EHandlers(fakeIpcMain as any);
-    registerSentinelRepoHandlers(fakeIpcMain as any);
-    registerSampleParserHandlers(fakeIpcMain as any);
-    registerPermissionCheckHandlers(fakeIpcMain as any);
-    registerDefaultSampleHandlers(fakeIpcMain as any);
-    registerFieldMatcherHandlers(fakeIpcMain as any);
-    registerPowerShellHandlers(fakeIpcMain as any);
-    registerSiemMigrationHandlers(fakeIpcMain as any);
-    registerSampleResolverHandlers(fakeIpcMain as any);
-
+    const { HANDLER_MODULES } = await import('../api/registry');
+    for (const mod of HANDLER_MODULES) {
+      mod.register(fakeIpcMain as any);
+    }
     console.log(`Registered ${handlers.size} API handlers`);
   };
 
@@ -89,7 +51,7 @@ export function createApiRouter(eventBus: EventBus): Router {
   // Channel derived from URL path: /auth/status -> auth:status
   router.use((req: Request, res: Response) => {
     const rawPath = req.path.replace(/^\/+/, '');
-    const channel = rawPath.replace(/\//g, ':');
+    const channel = pathToChannel(rawPath);
 
     // Root listing
     if (!channel) {

--- a/Cribl-Microsoft_IntegrationSolution/tests/channel-parity.test.ts
+++ b/Cribl-Microsoft_IntegrationSolution/tests/channel-parity.test.ts
@@ -1,0 +1,148 @@
+// Channel parity test -- the drift guard for the dual-transport API surface.
+//
+// The app exposes its backend over two transports: Electron IPC (preload.ts -> window.api,
+// handlers registered in ipc/index.ts) and a web server (api-client.ts -> fetch, handlers
+// registered in server/api-router.ts). The channel contract is currently hand-mirrored across
+// those files. This test fails the moment they drift, so a missing handler registration or an
+// out-of-sync client method is caught in CI instead of as a silent runtime 404.
+//
+// It is intentionally hermetic: it parses source text rather than importing/executing modules.
+
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+
+const SRC = path.resolve(__dirname, '..', 'src');
+const IPC_DIR = path.join(SRC, 'main', 'ipc');
+
+function read(rel: string): string {
+  return fs.readFileSync(path.join(SRC, rel), 'utf-8');
+}
+
+// Extract the first capture group of every match of `pattern` in `src`, deduped and sorted.
+function extract(pattern: RegExp, src: string): string[] {
+  const re = new RegExp(pattern.source, 'g');
+  const out = new Set<string>();
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(src)) !== null) out.add(m[1]);
+  return [...out].sort();
+}
+
+// All `.handle('channel', ...)` declarations across the IPC handler modules (the universe of
+// channels a transport can register).
+function allHandlerChannels(): string[] {
+  const out = new Set<string>();
+  for (const file of fs.readdirSync(IPC_DIR)) {
+    if (!file.endsWith('.ts') || file.endsWith('.test.ts')) continue;
+    const src = fs.readFileSync(path.join(IPC_DIR, file), 'utf-8');
+    for (const ch of extract(/\.handle\(\s*'([^']+)'/, src)) out.add(ch);
+  }
+  return [...out].sort();
+}
+
+function setDiff(a: string[], b: string[]): { onlyA: string[]; onlyB: string[] } {
+  const bs = new Set(b);
+  const as = new Set(a);
+  return { onlyA: a.filter((x) => !bs.has(x)), onlyB: b.filter((x) => !as.has(x)) };
+}
+
+// --- Source-derived channel sets ------------------------------------------------------------
+
+const preloadSrc = read(path.join('main', 'preload.ts'));
+const clientSrc = read(path.join('renderer', 'api-client.ts'));
+const indexSrc = read(path.join('main', 'ipc', 'index.ts'));
+const routerSrc = read(path.join('server', 'api-router.ts'));
+
+const handlerChannels = allHandlerChannels();
+
+const preloadInvoke = extract(/ipcRenderer\.invoke\(\s*'([^']+)'/, preloadSrc);
+const preloadOn = extract(/ipcRenderer\.on\(\s*'([^']+)'/, preloadSrc);
+
+const clientCall = extract(/\bcall\(\s*'([^']+)'/, clientSrc);
+const clientOnEvent = extract(/onEvent\(\s*'([^']+)'/, clientSrc);
+
+// Channels the web client serves through a bespoke path rather than the generic call() helper
+// (e.g. samples:parse-files uses an HTML file input + multipart upload). They are still part of
+// the web surface, so count them toward invoke parity.
+const BESPOKE_CLIENT_CHANNELS = ['samples:parse-files'];
+const clientInvoke = [...new Set([...clientCall, ...BESPOKE_CLIENT_CHANNELS])].sort();
+
+// Handler modules registered by each transport's registration list. Excludes the wrapper
+// (registerIpcHandlers) and the `registerXxxHandlers` placeholder that appears in a comment.
+const NON_MODULE_REGISTRARS = new Set(['registerIpcHandlers', 'registerXxxHandlers']);
+function registeredModules(src: string): string[] {
+  return extract(/\b(register\w+Handlers)\b/, src).filter((n) => !NON_MODULE_REGISTRARS.has(n));
+}
+const electronModules = registeredModules(indexSrc);
+const webModules = registeredModules(routerSrc);
+
+// Handlers that exist but are intentionally not bridged to either renderer (internal/main-only).
+const UNEXPOSED_HANDLERS = new Set([
+  'app:paths',
+  'app:link-repo',
+  'app:unlink-repo',
+  'changes:delete-snapshot',
+  'samples:list-libraries',
+  'samples:load-library-file',
+]);
+
+describe('Channel parity (dual-transport API surface)', () => {
+  it('registers the same handler modules in Electron (ipc/index.ts) and web (api-router.ts)', () => {
+    const { onlyA, onlyB } = setDiff(electronModules, webModules);
+    expect(
+      { electronOnly: onlyA, webOnly: onlyB },
+      `Handler module registration lists drifted. Electron-only: ${onlyA.join(', ') || '(none)'}; ` +
+        `web-only: ${onlyB.join(', ') || '(none)'}. Both ipc/index.ts and server/api-router.ts must register the same modules.`,
+    ).toEqual({ electronOnly: [], webOnly: [] });
+  });
+
+  it('exposes identical invoke channels in preload (Electron) and api-client (web)', () => {
+    const { onlyA, onlyB } = setDiff(preloadInvoke, clientInvoke);
+    expect(
+      { preloadOnly: onlyA, clientOnly: onlyB },
+      `Invoke-channel drift. In preload but not web client: ${onlyA.join(', ') || '(none)'}; ` +
+        `in web client but not preload: ${onlyB.join(', ') || '(none)'}.`,
+    ).toEqual({ preloadOnly: [], clientOnly: [] });
+  });
+
+  it('exposes identical push (event) channels in preload and api-client', () => {
+    const { onlyA, onlyB } = setDiff(preloadOn, clientOnEvent);
+    expect(
+      { preloadOnly: onlyA, clientOnly: onlyB },
+      `Push-channel drift. In preload but not web client: ${onlyA.join(', ') || '(none)'}; ` +
+        `in web client but not preload: ${onlyB.join(', ') || '(none)'}.`,
+    ).toEqual({ preloadOnly: [], clientOnly: [] });
+  });
+
+  it('has a registered handler for every channel the renderers invoke (no dangling calls)', () => {
+    const handlerSet = new Set(handlerChannels);
+    const danglingPreload = preloadInvoke.filter((c) => !handlerSet.has(c));
+    const danglingClient = clientCall.filter((c) => !handlerSet.has(c));
+    expect(
+      { danglingPreload, danglingClient },
+      `Renderer invokes a channel with no ipcMain.handle(): preload=${danglingPreload.join(', ') || '(none)'}, ` +
+        `client=${danglingClient.join(', ') || '(none)'}.`,
+    ).toEqual({ danglingPreload: [], danglingClient: [] });
+  });
+
+  it('exposes every renderer-facing handler through both transports (no unbridged channels)', () => {
+    // Every handler channel that is meant for the renderer should be reachable from preload.
+    const exposable = handlerChannels.filter((c) => !UNEXPOSED_HANDLERS.has(c));
+    const preloadSet = new Set(preloadInvoke);
+    const unbridged = exposable.filter((c) => !preloadSet.has(c));
+    expect(
+      unbridged,
+      `Handler channels exist but are not exposed via preload (add to preload + api-client, or to ` +
+        `UNEXPOSED_HANDLERS if intentionally main-only): ${unbridged.join(', ') || '(none)'}.`,
+    ).toEqual([]);
+  });
+
+  it('guards against a broken regex by asserting minimum channel counts', () => {
+    expect(handlerChannels.length).toBeGreaterThanOrEqual(130);
+    expect(preloadInvoke.length).toBeGreaterThanOrEqual(130);
+    expect(clientInvoke.length).toBeGreaterThanOrEqual(130);
+    expect(preloadOn.length).toBeGreaterThanOrEqual(10);
+    expect(clientOnEvent.length).toBeGreaterThanOrEqual(10);
+    expect(electronModules.length).toBeGreaterThanOrEqual(20);
+  });
+});

--- a/Cribl-Microsoft_IntegrationSolution/tests/channel-parity.test.ts
+++ b/Cribl-Microsoft_IntegrationSolution/tests/channel-parity.test.ts
@@ -67,14 +67,26 @@ const clientOnEvent = extract(/onEvent\(\s*'([^']+)'/, clientSrc);
 const BESPOKE_CLIENT_CHANNELS = ['samples:parse-files'];
 const clientInvoke = [...new Set([...clientCall, ...BESPOKE_CLIENT_CHANNELS])].sort();
 
-// Handler modules registered by each transport's registration list. Excludes the wrapper
-// (registerIpcHandlers) and the `registerXxxHandlers` placeholder that appears in a comment.
-const NON_MODULE_REGISTRARS = new Set(['registerIpcHandlers', 'registerXxxHandlers']);
-function registeredModules(src: string): string[] {
-  return extract(/\b(register\w+Handlers)\b/, src).filter((n) => !NON_MODULE_REGISTRARS.has(n));
+// Both transports now register handler modules by looping over the single shared registry
+// (src/api/registry.ts). The invariant is therefore: the registry lists every handler module,
+// and nothing more. Excludes the registerIpcHandlers wrapper.
+const registrySrc = read(path.join('api', 'registry.ts'));
+const NON_MODULE_REGISTRARS = new Set(['registerIpcHandlers']);
+
+// Every register*Handlers function exported by an IPC handler module.
+function allExportedRegistrars(): string[] {
+  const out = new Set<string>();
+  for (const file of fs.readdirSync(IPC_DIR)) {
+    if (!file.endsWith('.ts') || file.endsWith('.test.ts')) continue;
+    const src = fs.readFileSync(path.join(IPC_DIR, file), 'utf-8');
+    for (const n of extract(/export\s+(?:async\s+)?function\s+(register\w+Handlers)/, src)) out.add(n);
+  }
+  return [...out].filter((n) => !NON_MODULE_REGISTRARS.has(n)).sort();
 }
-const electronModules = registeredModules(indexSrc);
-const webModules = registeredModules(routerSrc);
+const exportedRegistrars = allExportedRegistrars();
+const registryRegistrars = extract(/\b(register\w+Handlers)\b/, registrySrc).filter(
+  (n) => !NON_MODULE_REGISTRARS.has(n),
+);
 
 // Handlers that exist but are intentionally not bridged to either renderer (internal/main-only).
 const UNEXPOSED_HANDLERS = new Set([
@@ -87,13 +99,19 @@ const UNEXPOSED_HANDLERS = new Set([
 ]);
 
 describe('Channel parity (dual-transport API surface)', () => {
-  it('registers the same handler modules in Electron (ipc/index.ts) and web (api-router.ts)', () => {
-    const { onlyA, onlyB } = setDiff(electronModules, webModules);
+  it('lists every IPC handler module in the shared registry (src/api/registry.ts)', () => {
+    const { onlyA, onlyB } = setDiff(exportedRegistrars, registryRegistrars);
     expect(
-      { electronOnly: onlyA, webOnly: onlyB },
-      `Handler module registration lists drifted. Electron-only: ${onlyA.join(', ') || '(none)'}; ` +
-        `web-only: ${onlyB.join(', ') || '(none)'}. Both ipc/index.ts and server/api-router.ts must register the same modules.`,
-    ).toEqual({ electronOnly: [], webOnly: [] });
+      { handlerModulesMissingFromRegistry: onlyA, registryEntriesWithoutAModule: onlyB },
+      `Registry drift. Handler modules not in registry.ts: ${onlyA.join(', ') || '(none)'}; ` +
+        `registry entries with no matching exported handler: ${onlyB.join(', ') || '(none)'}. ` +
+        `Add new handler modules to src/api/registry.ts exactly once.`,
+    ).toEqual({ handlerModulesMissingFromRegistry: [], registryEntriesWithoutAModule: [] });
+  });
+
+  it('drives both transports from the shared registry (no hand-maintained lists)', () => {
+    expect(indexSrc.includes('HANDLER_MODULES'), 'src/main/ipc/index.ts must register via HANDLER_MODULES').toBe(true);
+    expect(routerSrc.includes('HANDLER_MODULES'), 'src/server/api-router.ts must register via HANDLER_MODULES').toBe(true);
   });
 
   it('exposes identical invoke channels in preload (Electron) and api-client (web)', () => {
@@ -143,6 +161,7 @@ describe('Channel parity (dual-transport API surface)', () => {
     expect(clientInvoke.length).toBeGreaterThanOrEqual(130);
     expect(preloadOn.length).toBeGreaterThanOrEqual(10);
     expect(clientOnEvent.length).toBeGreaterThanOrEqual(10);
-    expect(electronModules.length).toBeGreaterThanOrEqual(20);
+    expect(registryRegistrars.length).toBeGreaterThanOrEqual(20);
+    expect(exportedRegistrars.length).toBeGreaterThanOrEqual(20);
   });
 });


### PR DESCRIPTION
## Context

First slice of the architecture-deepening review. The app exposes its backend over two
transports -- Electron IPC (`preload.ts` -> `window.api`, handlers registered in
`ipc/index.ts`) and a web server (`api-client.ts` -> fetch, handlers registered in
`server/api-router.ts`). The 138-channel contract was hand-mirrored across those files and had
already drifted, including a live web-mode bug.

## What this does

**Phase 0 -- fix the live bug + add a safety net**
- `api-router.ts` registered only 17 of 20 handler modules, so 7 channels (`ps:*`, `siem:*`,
  `samples:list-available`/`load-selected`, `elastic-repo:*`) silently 404'd in web-server
  mode. All 3 missing modules are now registered.
- Closed the renderer drift: added the missing `api-client.ts` invoke/push channels and the
  `sampleResolver`/`elasticRepo` modules + `onStartupLog`, and completed the matching
  `Window['api']` types (including the `azure status/login` `error` field).
- Added `tests/channel-parity.test.ts`: asserts the registration list and the
  preload/api-client invoke+push surfaces stay in sync, so this drift class now fails CI.

**Phase 1 -- one source of truth for registration**
- `src/api/registry.ts` exports `HANDLER_MODULES`, the single ordered list of all 20 handler
  modules. Both transports loop over it, so the two lists cannot drift apart again.
- `src/api/channels.ts` owns `channelToPath`/`pathToChannel` (previously duplicated in
  `api-client.ts` and `api-router.ts`).
- Net -103 lines of duplicated registration boilerplate.

## Testing

- `npm run typecheck`: clean.
- `npm test`: 196 passing (the one failing `CrowdStrike has Analytic Rules` test is
  environmental -- it `fs.existsSync`-checks a local Sentinel-repo clone -- and is unrelated to
  this change).
- Booted the web server: registers the full 136 handlers via the shared registry; verified the
  4 previously-404 channels now return HTTP 200.

## Notes

- No emojis (project rule). Behaviour-preserving refactor; no public signatures changed.
- Follow-on work (manifest codegen, HttpClient/CredentialVault seams, SentinelIntegration
  hooks, pack-builder decomposition) lands as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)