### PR TITLE
Coverage sections honor derived custom-table schemas

### DIFF
--- a/soc-optimizationtoolkit/apps/cribl-app/package.json
+++ b/soc-optimizationtoolkit/apps/cribl-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "soc-optimizationtoolkit",
   "private": true,
-  "version": "1.2.136",
+  "version": "1.2.137",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/soc-optimizationtoolkit/packages/ui/src/index.ts
+++ b/soc-optimizationtoolkit/packages/ui/src/index.ts
@@ -317,6 +317,7 @@ export {
   isRuleYamlFileName,
   missingFieldChips,
   parseCustomRuleUploads,
+  resolveSchemaUnion,
   ruleFieldSet,
   severityTone,
 } from "./screens/rule-coverage/rule-coverage-state";

--- a/soc-optimizationtoolkit/packages/ui/src/screens/rule-coverage/rule-coverage-section.tsx
+++ b/soc-optimizationtoolkit/packages/ui/src/screens/rule-coverage/rule-coverage-section.tsx
@@ -52,7 +52,6 @@ import {
   parseParserYaml,
   parserFieldSynonyms,
   suggestCloseMatches,
-  unionSchemaColumns,
 } from "@soc/core";
 import type { CloseMatchCandidate } from "@soc/core";
 import type {
@@ -80,6 +79,7 @@ import {
   isRuleYamlFileName,
   missingFieldChips,
   parseCustomRuleUploads,
+  resolveSchemaUnion,
   ruleFieldSet,
 } from "./rule-coverage-state";
 import type { CoverageSectionView } from "./rule-coverage-state";
@@ -240,25 +240,6 @@ async function fetchParserFunctions(
     }
   }
   return { parsers, unparsed };
-}
-
-/**
- * Union the schemas of every destination table (the analyzer's schemaUnion):
- * a rule referencing a sibling table's column classifies
- * missing-from-reduced-schema, not unknown.
- */
-async function resolveSchemaUnion(
-  catalog: SchemaCatalog,
-  tableNames: readonly string[],
-): Promise<string[]> {
-  const schemas: Array<Array<{ name: string }>> = [];
-  for (const table of tableNames) {
-    const columns = await catalog.resolveSchema(table);
-    if (columns !== null) {
-      schemas.push(columns.map((c) => ({ name: c.name })));
-    }
-  }
-  return unionSchemaColumns(schemas);
 }
 
 /** One expandable coverage section (rule section or workbook section). */
@@ -496,10 +477,10 @@ export function RuleCoverageSection({
         const items = mergeCustomContentItems(repoAndWorkbooks, custom);
         onContentRequirementsChange?.(deriveContentRequirements(items));
 
-        const schemaUnion = await resolveSchemaUnion(
-          activeCatalog,
-          destinationTableNamesFromReports(reports),
-        );
+        // The union includes each report's OWN destSchema, so DERIVED
+        // schemas (unresolvable _CL destinations defined by the sample +
+        // content references) classify fields here too.
+        const schemaUnion = await resolveSchemaUnion(activeCatalog, reports);
         if (schemaUnion.length === 0) {
           // Without a resolvable destination schema every field classifies
           // "unknown" and the percentages are meaningless - say so instead

--- a/soc-optimizationtoolkit/packages/ui/src/screens/rule-coverage/rule-coverage-state.test.ts
+++ b/soc-optimizationtoolkit/packages/ui/src/screens/rule-coverage/rule-coverage-state.test.ts
@@ -35,6 +35,7 @@ import {
   isRuleYamlFileName,
   missingFieldChips,
   parseCustomRuleUploads,
+  resolveSchemaUnion,
   ruleFieldSet,
   severityTone,
 } from "./rule-coverage-state";
@@ -488,5 +489,42 @@ describe("end-to-end over the real analyzer", () => {
     for (const chip of missingFieldChips(report.summary)) {
       expect(["TargetUserName", "DeviceName"]).toContain(chip);
     }
+  });
+});
+
+describe("resolveSchemaUnion", () => {
+  it("includes each report's OWN destSchema even when the catalog misses (derived schemas)", async () => {
+    // Live regression 2026-07-14: Cloudflare_CL derived 81 columns in the
+    // gap analysis while coverage still said "No schema could be resolved" -
+    // the union only consulted the catalog, and a DERIVED schema exists only
+    // on the report.
+    const report = gapReport({
+      tableName: "Cloudflare_CL",
+      fieldMappings: [],
+      destSchema: [
+        { name: "ClientIP", type: "string" },
+        { name: "TimeGenerated", type: "datetime" },
+      ],
+    });
+    const missCatalog = { resolveSchema: async () => null };
+    const union = await resolveSchemaUnion(missCatalog, [report]);
+    expect(union).toContain("ClientIP");
+    expect(union).toContain("TimeGenerated");
+  });
+
+  it("still unions catalog-resolved schemas across destination tables", async () => {
+    const reports = [
+      gapReport({ tableName: "TableA", fieldMappings: [], destSchema: [] }),
+      gapReport({ tableName: "TableB", fieldMappings: [], destSchema: [] }),
+    ];
+    const catalog = {
+      resolveSchema: async (table: string) =>
+        table === "TableA"
+          ? [{ name: "ColA", type: "string" }]
+          : [{ name: "ColB", type: "string" }],
+    };
+    const union = await resolveSchemaUnion(catalog, reports);
+    expect(union).toContain("ColA");
+    expect(union).toContain("ColB");
   });
 });

--- a/soc-optimizationtoolkit/packages/ui/src/screens/rule-coverage/rule-coverage-state.ts
+++ b/soc-optimizationtoolkit/packages/ui/src/screens/rule-coverage/rule-coverage-state.ts
@@ -26,7 +26,11 @@
  * Pure: no IO, no fetch, no React, no Date, no crypto, no Math.random.
  */
 
-import { analyticRuleToContentItem, parseRuleUploadFile } from "@soc/core";
+import {
+  analyticRuleToContentItem,
+  parseRuleUploadFile,
+  unionSchemaColumns,
+} from "@soc/core";
 import type {
   ContentItem,
   ContentItemType,
@@ -34,6 +38,7 @@ import type {
   CoverageSummary,
   GapReport,
   ItemCoverage,
+  SchemaCatalog,
 } from "@soc/core";
 
 // ---------------------------------------------------------------------------
@@ -103,6 +108,34 @@ export function destinationTableNamesFromReports(
   reports: readonly GapReport[],
 ): string[] {
   return [...new Set(reports.map((report) => report.tableName))].sort();
+}
+
+/**
+ * Union the destination schemas the analyzer classifies against: each
+ * report's OWN destSchema first - the analysis's source of truth, and the
+ * only place a DERIVED schema exists (an unresolvable _CL destination
+ * defined by the sample + content references resolves NOWHERE else; live
+ * regression 2026-07-14: Cloudflare_CL derived 81 columns in the gap
+ * analysis while this section still said "No schema could be resolved") -
+ * then each table through the SchemaCatalog for sibling-table completeness.
+ */
+export async function resolveSchemaUnion(
+  catalog: SchemaCatalog,
+  reports: readonly GapReport[],
+): Promise<string[]> {
+  const schemas: Array<Array<{ name: string }>> = [];
+  for (const report of reports) {
+    if (report.destSchema.length > 0) {
+      schemas.push(report.destSchema.map((c) => ({ name: c.name })));
+    }
+  }
+  for (const table of destinationTableNamesFromReports(reports)) {
+    const columns = await catalog.resolveSchema(table);
+    if (columns !== null) {
+      schemas.push(columns.map((c) => ({ name: c.name })));
+    }
+  }
+  return unionSchemaColumns(schemas);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Live regression found on 1.2.136 (Cloudflare_CL): the DCR Gap Analysis derived an 81-column schema for the unresolvable custom table, but the Analytics Rule / Workbook Coverage sections still reported "No schema could be resolved" - their schema union only consulted the SchemaCatalog, and a DERIVED schema exists only on the gap report.

Fix: `resolveSchemaUnion` moved into the pure `rule-coverage-state` module and now unions each report's own `destSchema` ahead of the catalog resolution (catalog stays for sibling-table completeness). Pinned with the live-regression case plus the existing catalog-union behavior.

Packaged as soc-optimizationtoolkit-1.2.137.tgz.

## Test plan
- typecheck + oxlint clean; ui suite 534 passing (2 new pins)
- Live: re-run rule/workbook coverage on Cloudflare after a gap analysis - fields should classify against the derived schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)