### PR TITLE
Make the coverage no-schema note self-diagnosing

### DIFF
--- a/soc-optimizationtoolkit/apps/cribl-app/package.json
+++ b/soc-optimizationtoolkit/apps/cribl-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "soc-optimizationtoolkit",
   "private": true,
-  "version": "1.2.137",
+  "version": "1.2.138",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/soc-optimizationtoolkit/packages/ui/src/screens/rule-coverage/rule-coverage-section.tsx
+++ b/soc-optimizationtoolkit/packages/ui/src/screens/rule-coverage/rule-coverage-section.tsx
@@ -484,9 +484,16 @@ export function RuleCoverageSection({
         if (schemaUnion.length === 0) {
           // Without a resolvable destination schema every field classifies
           // "unknown" and the percentages are meaningless - say so instead
-          // of rendering an empty-denominator 100%.
+          // of rendering an empty-denominator 100%. The count suffix makes a
+          // report of this message self-diagnosing: reports carrying 0
+          // destination columns = the gap analysis predates schema
+          // derivation (or never ran against this table) - Re-Analyze first.
+          const reportColumns = reports.reduce(
+            (n, r) => n + r.destSchema.length,
+            0,
+          );
           setSchemaNote(
-            `No schema could be resolved for destination table(s) ${destinationTableNamesFromReports(reports).join(", ")} - fields cannot be classified and coverage percentages would be meaningless. Re-run the DCR Gap Analysis or check the destination table selection.`,
+            `No schema could be resolved for destination table(s) ${destinationTableNamesFromReports(reports).join(", ")} - fields cannot be classified and coverage percentages would be meaningless. Re-run the DCR Gap Analysis (section 3) first - its report supplies the schema (including derived custom-table schemas) - then re-run this analysis. Diagnostic: ${reports.length} gap report(s) carried ${reportColumns} destination column(s); the schema catalog resolved none.`,
           );
           return;
         }


### PR DESCRIPTION
Follow-up to #35: the note now names the fix path (re-run the DCR Gap Analysis first - its reports supply the schema, including derived custom-table schemas) and appends a diagnostic count of gap reports / destination columns seen, so a screenshot of the note distinguishes stale in-memory reports from stale code. Packaged as 1.2.138.

🤖 Generated with [Claude Code](https://claude.com/claude-code)