### PR TITLE
Rename the coverage Unknown line to say no action needed

### DIFF
--- a/soc-optimizationtoolkit/apps/cribl-app/package.json
+++ b/soc-optimizationtoolkit/apps/cribl-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "soc-optimizationtoolkit",
   "private": true,
-  "version": "1.2.138",
+  "version": "1.2.139",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/soc-optimizationtoolkit/packages/ui/src/screens/rule-coverage/rule-coverage-section.tsx
+++ b/soc-optimizationtoolkit/packages/ui/src/screens/rule-coverage/rule-coverage-section.tsx
@@ -324,7 +324,9 @@ function CoverageSectionBody({
             )}
             {item.unknown.length > 0 && (
               <div className="coverage-line coverage-line-unknown">
-                Unknown (computed or other-table): {item.unknown.join(", ")}
+                No action needed (query-computed or joined-table):{" "}
+                {item.unknown.join(", ")}
+                <InfoTip text="Names this rule references that are NOT columns of the destination table: variables the query computes itself (extend/summarize aliases, like CompleteUrl = strcat(...)) or columns it reads from OTHER tables it joins (watchlists, IdentityInfo, threat intel). There is nothing for the pipeline to supply, so they are excluded from the coverage percentage. Worth a quick scan for a real vendor field hiding under a different spelling - if you spot one, map a source onto it in the Gap Analysis." />
               </div>
             )}
             {item.queries.length > 0 && (


### PR DESCRIPTION
UX copy per user feedback: the per-rule "Unknown (computed or other-table)" line in the coverage sections now reads "No action needed (query-computed or joined-table):" with an InfoTip explaining exactly what lands there (extend/summarize aliases, joined-table columns), that these are excluded from the coverage percentage, and the one case worth scanning for. Core three-way model vocabulary unchanged. Packaged as 1.2.139.

🤖 Generated with [Claude Code](https://claude.com/claude-code)