### PR TITLE
Resolve schemas from the repo KQL-validation tables first

### DIFF
--- a/soc-optimizationtoolkit/apps/cribl-app/package.json
+++ b/soc-optimizationtoolkit/apps/cribl-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "soc-optimizationtoolkit",
   "private": true,
-  "version": "1.2.139",
+  "version": "1.2.140",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/soc-optimizationtoolkit/packages/core/src/domain/field-matcher/index.ts
+++ b/soc-optimizationtoolkit/packages/core/src/domain/field-matcher/index.ts
@@ -89,6 +89,15 @@ export {
   tablesFromArmJson,
 } from "./solution-schema-catalog";
 
+// KQL-validation schema tier (2026-07-14): the Azure-Sentinel repo's own
+// CI-validated table schemas resolve FIRST when a table is defined there.
+export {
+  KQL_VALIDATION_TABLES_DIR,
+  createKqlValidationSchemaCatalog,
+  mapValidationColumnType,
+  parseKqlValidationTable,
+} from "./kql-validation-schema-catalog";
+
 // NOTE: match-to-catalog's matchSampleToTable (the legacy direct-catalog
 // match path) is deliberately NOT re-exported: the app goes through
 // analyzeSamples, and the name collides with gap-analysis' log-type router

--- a/soc-optimizationtoolkit/packages/core/src/domain/field-matcher/kql-validation-schema-catalog.test.ts
+++ b/soc-optimizationtoolkit/packages/core/src/domain/field-matcher/kql-validation-schema-catalog.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Pins for the KQL-validation schema tier (user direction 2026-07-14): the
+ * Azure-Sentinel repo's CI-validated table schemas
+ * (.script/tests/KqlvalidationsTests/CustomTables) resolve FIRST when a
+ * table is defined there. Fixture shape mirrors the live Cloudflare_CL.json
+ * (verified 2026-07-14: {Name, Properties[{Name,Type}]}, Pascal-ish types
+ * with casing drift - Datetime AND DateTime in one file).
+ */
+
+import { describe, expect, it } from "vitest";
+import { FakeSentinelContent } from "../../testing/index";
+import type { SchemaCatalog } from "../../ports/schema-catalog";
+import {
+  KQL_VALIDATION_TABLES_DIR,
+  createKqlValidationSchemaCatalog,
+  mapValidationColumnType,
+  parseKqlValidationTable,
+} from "./kql-validation-schema-catalog";
+
+const CLOUDFLARE_FIXTURE = JSON.stringify({
+  Name: "Cloudflare_CL",
+  Properties: [
+    { Name: "TimeGenerated", Type: "Datetime" },
+    { Name: "BotScore_d", Type: "Double" },
+    { Name: "BotScoreSrc_s", Type: "String" },
+    { Name: "EdgeStartTimestamp_t", Type: "DateTime" },
+    { Name: "CacheTieredFill_b", Type: "Bool" },
+    { Name: "TenantId", Type: "String" },
+    { Name: "Type", Type: "String" },
+  ],
+});
+
+const BASE_MISS: SchemaCatalog = { resolveSchema: async () => null };
+
+function baseWith(columns: Array<{ name: string; type: string }>): SchemaCatalog {
+  return { resolveSchema: async () => columns };
+}
+
+describe("parseKqlValidationTable / mapValidationColumnType", () => {
+  it("maps the Pascal-ish validation types (casing drift included) to the DCR vocabulary", () => {
+    expect(mapValidationColumnType("Datetime")).toBe("datetime");
+    expect(mapValidationColumnType("DateTime")).toBe("datetime");
+    expect(mapValidationColumnType("Double")).toBe("real");
+    expect(mapValidationColumnType("Bool")).toBe("boolean");
+    expect(mapValidationColumnType("Dynamic")).toBe("dynamic");
+    expect(mapValidationColumnType("Guid")).toBe("string");
+    expect(mapValidationColumnType("SomethingNew")).toBe("string");
+  });
+
+  it("parses the file shape, keeps TimeGenerated, filters system columns", () => {
+    const columns = parseKqlValidationTable(CLOUDFLARE_FIXTURE);
+    expect(columns).toEqual([
+      { name: "TimeGenerated", type: "datetime" },
+      { name: "BotScore_d", type: "real" },
+      { name: "BotScoreSrc_s", type: "string" },
+      { name: "EdgeStartTimestamp_t", type: "datetime" },
+      { name: "CacheTieredFill_b", type: "boolean" },
+    ]);
+  });
+
+  it("reads junk and foreign shapes as null", () => {
+    expect(parseKqlValidationTable("not json")).toBeNull();
+    expect(parseKqlValidationTable('{"columns": []}')).toBeNull();
+    expect(parseKqlValidationTable('{"Name":"X","Properties":[]}')).toBeNull();
+  });
+});
+
+describe("createKqlValidationSchemaCatalog", () => {
+  const content = new FakeSentinelContent({
+    files: {
+      [`${KQL_VALIDATION_TABLES_DIR}/Cloudflare_CL.json`]: CLOUDFLARE_FIXTURE,
+    },
+  });
+
+  it("resolves a defined table from the validation dir, AHEAD of the base", async () => {
+    const base = baseWith([{ name: "FromBase", type: "string" }]);
+    const catalog = createKqlValidationSchemaCatalog(content, base);
+    const columns = await catalog.resolveSchema("Cloudflare_CL");
+    expect(columns?.map((c) => c.name)).toContain("BotScore_d");
+    expect(columns?.map((c) => c.name)).not.toContain("FromBase");
+  });
+
+  it("falls through to the base for tables the dir does not define", async () => {
+    const base = baseWith([{ name: "CommonSecurityLog_Col", type: "string" }]);
+    const catalog = createKqlValidationSchemaCatalog(content, base);
+    const columns = await catalog.resolveSchema("CommonSecurityLog");
+    expect(columns?.map((c) => c.name)).toEqual(["CommonSecurityLog_Col"]);
+  });
+
+  it("matches case-insensitively via the directory listing fallback", async () => {
+    const catalog = createKqlValidationSchemaCatalog(content, BASE_MISS);
+    const columns = await catalog.resolveSchema("CLOUDFLARE_cl");
+    expect(columns?.map((c) => c.name)).toContain("BotScore_d");
+  });
+
+  it("returns fresh column copies per resolve (cache is never aliased)", async () => {
+    const catalog = createKqlValidationSchemaCatalog(content, BASE_MISS);
+    const first = await catalog.resolveSchema("Cloudflare_CL");
+    first![0].name = "MUTATED";
+    const second = await catalog.resolveSchema("Cloudflare_CL");
+    expect(second?.[0].name).toBe("TimeGenerated");
+  });
+});

--- a/soc-optimizationtoolkit/packages/core/src/domain/field-matcher/kql-validation-schema-catalog.ts
+++ b/soc-optimizationtoolkit/packages/core/src/domain/field-matcher/kql-validation-schema-catalog.ts
@@ -1,0 +1,172 @@
+/**
+ * KQL-VALIDATION schema tier (user direction 2026-07-14): the Azure-Sentinel
+ * repo ships the table schemas its own CI validates every solution's KQL
+ * against, under `.script/tests/KqlvalidationsTests/CustomTables/<Table>.json`
+ * - ~1000 files of shape {"Name": "<table>", "Properties": [{"Name","Type"}]}
+ * (verified live: Cloudflare_CL.json = 104 columns of the legacy suffixed
+ * schema, plus CloudflareV2_CL.json and the Cloudflare.json parser-output
+ * shape). When a table is DEFINED THERE, it is the schema the solution's
+ * rules and workbooks were written against - so this tier resolves FIRST,
+ * ahead of the solution's connector-ARM tables and the bundled snapshot,
+ * and ahead of sample-derived schemas (which stay the last-resort fallback
+ * for tables the repo does not define).
+ *
+ * Resolution strategy per table (cached per catalog instance, misses too):
+ *   1. DIRECT read of `<dir>/<tableName>.json` through the SentinelContent
+ *      port (raw fetch by exact name - immune to the GitHub contents API's
+ *      1000-entry directory listing cap, which this directory exceeds).
+ *   2. Case-insensitive fallback: one cached directory listing, matched on
+ *      `<tableName>.json` ignoring case. BEST-EFFORT: the listing itself is
+ *      subject to the 1000-entry cap, so an exotic casing beyond the cap can
+ *      miss - the base catalog then answers.
+ *   3. Anything unreadable/unparseable falls through to the base catalog
+ *      (never throws - the ladder degrades tier by tier).
+ *
+ * Type vocabulary: the files use Pascal-cased KQL-ish types with observed
+ * casing drift (Datetime AND DateTime in one file). Mapped case-insensitively
+ * to the 7-value DCR vocabulary; unknown types default to string (RULE 3
+ * convention). System columns are filtered like the Wave E solution tier -
+ * TimeGenerated is a REAL column and stays.
+ *
+ * Pure decisions + port orchestration; the IO lives behind SentinelContent.
+ */
+
+import type { SentinelContent } from "../../ports/sentinel-content";
+import type { DcrSchemaColumn, SchemaCatalog } from "../../ports/schema-catalog";
+import { DCR_SCHEMA_SYSTEM_COLUMNS } from "./bundled-schema-catalog";
+
+/** The validation-schema directory in the Azure-Sentinel repo. */
+export const KQL_VALIDATION_TABLES_DIR =
+  ".script/tests/KqlvalidationsTests/CustomTables";
+
+// Exact-case system-column filter, same contract as the bundled tier.
+const SYSTEM_COLUMNS: ReadonlySet<string> = new Set(DCR_SCHEMA_SYSTEM_COLUMNS);
+
+/** Pascal-ish validation type -> DCR vocabulary (case-insensitive keys). */
+const VALIDATION_TYPE_MAP = new Map<string, string>([
+  ["string", "string"],
+  ["datetime", "datetime"],
+  ["date", "datetime"],
+  ["double", "real"],
+  ["real", "real"],
+  ["int", "int"],
+  ["integer", "int"],
+  ["long", "long"],
+  ["bool", "boolean"],
+  ["boolean", "boolean"],
+  ["dynamic", "dynamic"],
+  ["object", "dynamic"],
+  ["guid", "string"],
+]);
+
+/** Map one validation-file type to the DCR vocabulary (unknown -> string). */
+export function mapValidationColumnType(type: string): string {
+  return VALIDATION_TYPE_MAP.get(type.trim().toLowerCase()) ?? "string";
+}
+
+/**
+ * Parse one KqlvalidationsTests/CustomTables file into DCR schema columns,
+ * or null for anything that is not the {Name, Properties[{Name,Type}]}
+ * shape. System columns Azure auto-populates are filtered (TimeGenerated is
+ * NOT one of them - it stays, matching the Wave E solution tier).
+ */
+export function parseKqlValidationTable(text: string): DcrSchemaColumn[] | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== "object" || parsed === null) {
+    return null;
+  }
+  const properties = (parsed as { Properties?: unknown }).Properties;
+  if (!Array.isArray(properties)) {
+    return null;
+  }
+  const columns: DcrSchemaColumn[] = [];
+  for (const entry of properties) {
+    if (typeof entry !== "object" || entry === null) continue;
+    const name = (entry as { Name?: unknown }).Name;
+    const type = (entry as { Type?: unknown }).Type;
+    if (typeof name !== "string" || name === "") continue;
+    if (SYSTEM_COLUMNS.has(name)) continue;
+    columns.push({
+      name,
+      type: typeof type === "string" ? mapValidationColumnType(type) : "string",
+    });
+  }
+  return columns.length > 0 ? columns : null;
+}
+
+/**
+ * Wrap `base` with the KQL-validation tier: a table defined in the repo's
+ * validation schemas resolves from there FIRST; everything else falls
+ * through to `base`. Results (including misses) are cached per instance.
+ */
+export function createKqlValidationSchemaCatalog(
+  content: SentinelContent,
+  base: SchemaCatalog,
+): SchemaCatalog {
+  const cache = new Map<string, DcrSchemaColumn[] | null>();
+  let listing: Promise<ReadonlyMap<string, string>> | null = null;
+
+  // Lowercased file name -> repo path, fetched at most once (best-effort:
+  // the contents API caps a directory listing at 1000 entries).
+  const loadListing = (): Promise<ReadonlyMap<string, string>> => {
+    listing ??= (async () => {
+      try {
+        const files = await content.listRepoFiles(KQL_VALIDATION_TABLES_DIR);
+        return new Map(files.map((f) => [f.name.toLowerCase(), f.path]));
+      } catch {
+        return new Map<string, string>();
+      }
+    })();
+    return listing;
+  };
+
+  const resolveFromValidation = async (
+    tableName: string,
+  ): Promise<DcrSchemaColumn[] | null> => {
+    // 1) Direct exact-name read (no listing, no 1000-entry cap).
+    try {
+      const direct = await content.readFile(
+        `${KQL_VALIDATION_TABLES_DIR}/${tableName}.json`,
+      );
+      if (direct !== null) {
+        const columns = parseKqlValidationTable(direct);
+        if (columns !== null) return columns;
+      }
+    } catch {
+      // Fall through to the listing fallback / base.
+    }
+    // 2) Case-insensitive fallback via the cached listing.
+    try {
+      const byLower = await loadListing();
+      const path = byLower.get(`${tableName.toLowerCase()}.json`);
+      if (path !== undefined) {
+        const text = await content.readFile(path);
+        if (text !== null) {
+          return parseKqlValidationTable(text);
+        }
+      }
+    } catch {
+      // Base answers.
+    }
+    return null;
+  };
+
+  return {
+    async resolveSchema(tableName: string): Promise<DcrSchemaColumn[] | null> {
+      const key = tableName.toLowerCase();
+      if (!cache.has(key)) {
+        cache.set(key, await resolveFromValidation(tableName));
+      }
+      const hit = cache.get(key) ?? null;
+      if (hit !== null) {
+        return hit.map((c) => ({ ...c }));
+      }
+      return base.resolveSchema(tableName);
+    },
+  };
+}

--- a/soc-optimizationtoolkit/packages/ui/src/screens/mapping-review/mapping-review-section.tsx
+++ b/soc-optimizationtoolkit/packages/ui/src/screens/mapping-review/mapping-review-section.tsx
@@ -60,6 +60,7 @@ import {
   DEFAULT_GAP_PROFILE,
   collectGapReports,
   createBundledSchemaCatalog,
+  createKqlValidationSchemaCatalog,
   createSolutionSchemaCatalog,
   detectVendorIdentity,
   dropSavingsLine,
@@ -275,15 +276,21 @@ export function MappingReviewSection({
   logger,
 }: MappingReviewSectionProps) {
   const activeContent = content ?? EMPTY_SENTINEL_CONTENT;
-  // Wave E: the solution's OWN table ARM definitions resolve ahead of the
-  // bundled snapshot (or the injected catalog) - CCP custom tables work even
-  // when absent from the bundle. Degrades to the base catalog on any failure.
+  // Schema ladder (outermost wins): the Azure-Sentinel repo's CI-VALIDATED
+  // table schemas (KqlvalidationsTests/CustomTables - the schema the
+  // solution's rules were written against; user direction 2026-07-14) ->
+  // Wave E solution connector-ARM tables -> the bundled snapshot (or the
+  // injected catalog). Sample-DERIVED schemas remain the analyzeSamples
+  // fallback for tables none of these define. Degrades tier by tier.
   const activeCatalog = useMemo(
     () =>
-      createSolutionSchemaCatalog(
+      createKqlValidationSchemaCatalog(
         activeContent,
-        solutionName,
-        catalog ?? createBundledSchemaCatalog(),
+        createSolutionSchemaCatalog(
+          activeContent,
+          solutionName,
+          catalog ?? createBundledSchemaCatalog(),
+        ),
       ),
     [activeContent, solutionName, catalog],
   );

--- a/soc-optimizationtoolkit/packages/ui/src/screens/rule-coverage/rule-coverage-section.tsx
+++ b/soc-optimizationtoolkit/packages/ui/src/screens/rule-coverage/rule-coverage-section.tsx
@@ -45,6 +45,7 @@ import {
   analyticRuleToContentItem,
   analyzeContentCoverage,
   createBundledSchemaCatalog,
+  createKqlValidationSchemaCatalog,
   deriveContentRequirements,
   createSolutionSchemaCatalog,
   mergeCustomContentItems,
@@ -358,14 +359,18 @@ export function RuleCoverageSection({
 }: RuleCoverageSectionProps) {
   const { ports } = usePorts();
   const activeContent = content ?? ports.content;
-  // Wave E: same solution-aware schema tier the mapping review resolves with,
-  // so both panels see identical columns for a solution's custom tables.
-  // Without a content port the base catalog serves alone.
+  // Same schema ladder the mapping review resolves with (KQL-validation
+  // tier -> Wave E solution tier -> bundled), so both panels see identical
+  // columns for a solution's custom tables. Without a content port the base
+  // catalog serves alone.
   const activeCatalog = useMemo(() => {
     const base = catalog ?? createBundledSchemaCatalog();
     return activeContent === undefined
       ? base
-      : createSolutionSchemaCatalog(activeContent, solutionName, base);
+      : createKqlValidationSchemaCatalog(
+          activeContent,
+          createSolutionSchemaCatalog(activeContent, solutionName, base),
+        );
   }, [activeContent, solutionName, catalog]);
   // What this instance covers. Custom-YAML upload and the RULE-badge report are
   // rules-only concerns; workbooks are a separate diagnostic.


### PR DESCRIPTION
## Summary

Per user direction: the Azure-Sentinel repo defines the table schemas its own CI validates solution KQL against under `.script/tests/KqlvalidationsTests/CustomTables` (verified live: ~1000 definitions; Cloudflare has `Cloudflare_CL.json` with the full 104-column legacy schema, `CloudflareV2_CL.json`, and the `Cloudflare.json` parser-output shape). When a table is defined there, we default to it.

- New `createKqlValidationSchemaCatalog` core tier: direct exact-name raw read through the SentinelContent port (immune to the GitHub contents API 1000-entry listing cap), cached case-insensitive listing fallback, Pascal-type mapping (`Datetime`/`DateTime` drift, `Double`->real, `Bool`->boolean), system-column filter, TimeGenerated kept. Misses cache too; everything degrades to the base catalog.
- Composed as the OUTERMOST tier in both the mapping review and the rule/workbook coverage panels: KQL-validation -> Wave E solution connector-ARM -> bundled snapshot; sample-DERIVED schemas remain the last-resort fallback for tables the repo does not define.
- 7 new pins (parse shape, type map, tier precedence, case-insensitive fallback, cache aliasing).

Effect on the live Cloudflare case: `Cloudflare_CL` now resolves the real 104-column suffixed schema (`BotScore_d`, `ClientIP_s`...) instead of deriving from the sample; the matcher maps unsuffixed sample fields onto the suffixed columns via its affix-stripping ladder, and rule coverage classifies against the schema the rules were actually written for.

Packaged as soc-optimizationtoolkit-1.2.140. Gates green: typecheck, oxlint, core 2221 / ui 534.

🤖 Generated with [Claude Code](https://claude.com/claude-code)