### PR TITLE
Enable Sentinel content install (solution, rules, workbooks)

### DIFF
--- a/soc-optimizationtoolkit/apps/cribl-app/package.json
+++ b/soc-optimizationtoolkit/apps/cribl-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "soc-optimizationtoolkit",
   "private": true,
-  "version": "1.2.142",
+  "version": "1.2.143",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/soc-optimizationtoolkit/packages/core/src/domain/content-install/content-install.test.ts
+++ b/soc-optimizationtoolkit/packages/core/src/domain/content-install/content-install.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Pins for the content-install domain (2026-07-14): the analytics-rule and
+ * workbook ARM bodies, the duration/operator/severity/tactic normalizations,
+ * upload parsing, installed-state partitioning, and the outcome summary -
+ * grounded in the verified ARM shapes (SecurityInsights 2025-09-01 scheduled
+ * required set; NRT omits the scheduling block; tactics space-free enum;
+ * workbook serializedData verbatim).
+ */
+
+import { describe, expect, it } from "vitest";
+import type { ParsedAnalyticRule } from "../coverage-analysis/index";
+import {
+  alertRuleResourceFromParsed,
+  parserResourceBody,
+  parserResourceFromYaml,
+  partitionByInstalled,
+  parseWorkbookUpload,
+  summarizeInstallOutcomes,
+  toArmSeverity,
+  toArmTriggerOperator,
+  toIsoDuration,
+  workbookResourceBody,
+} from "./index";
+
+function rule(over: Partial<ParsedAnalyticRule>): ParsedAnalyticRule {
+  return {
+    id: "id",
+    name: "Rule",
+    severity: "Medium",
+    tactics: [],
+    dataTypes: [],
+    query: "Table | where 1 == 1",
+    entityFields: [],
+    fileName: "r.yaml",
+    ...over,
+  };
+}
+
+describe("duration / operator / severity codecs", () => {
+  it("converts YAML durations to ISO8601 with a fallback", () => {
+    expect(toIsoDuration("1h", "PT1H")).toBe("PT1H");
+    expect(toIsoDuration("30m", "PT1H")).toBe("PT30M");
+    expect(toIsoDuration("5d", "PT1H")).toBe("P5D");
+    expect(toIsoDuration("PT2H", "PT1H")).toBe("PT2H");
+    expect(toIsoDuration(undefined, "PT1H")).toBe("PT1H");
+    expect(toIsoDuration("garbage", "PT1H")).toBe("PT1H");
+  });
+
+  it("maps trigger operators and severities to the ARM enums", () => {
+    expect(toArmTriggerOperator("gt")).toBe("GreaterThan");
+    expect(toArmTriggerOperator("lt")).toBe("LessThan");
+    expect(toArmTriggerOperator("NotEqual")).toBe("NotEqual");
+    expect(toArmTriggerOperator(undefined)).toBe("GreaterThan");
+    expect(toArmSeverity("high")).toBe("High");
+    expect(toArmSeverity("weird")).toBe("Medium");
+  });
+});
+
+describe("alertRuleResourceFromParsed", () => {
+  it("builds a Scheduled body with the required scheduling block and space-free tactics", () => {
+    const res = alertRuleResourceFromParsed(
+      rule({
+        kind: "Scheduled",
+        severity: "High",
+        queryFrequency: "1h",
+        queryPeriod: "1h",
+        triggerOperator: "gt",
+        triggerThreshold: 5,
+        tactics: ["Lateral Movement", "None"],
+        techniques: ["T1078"],
+        id: "9b8f1e2a-1111-2222-3333-444455556666",
+        version: "1.0.2",
+      }),
+    );
+    expect(res.supported).toBe(true);
+    if (!res.supported) return;
+    expect(res.kind).toBe("Scheduled");
+    const props = res.body.properties as Record<string, unknown>;
+    expect(props.queryFrequency).toBe("PT1H");
+    expect(props.triggerOperator).toBe("GreaterThan");
+    expect(props.triggerThreshold).toBe(5);
+    expect(props.tactics).toEqual(["LateralMovement"]); // space stripped, None dropped
+    expect(props.suppressionEnabled).toBe(false);
+    expect(props.suppressionDuration).toBe("PT5H");
+    // GUID id -> template linkage.
+    expect(props.alertRuleTemplateName).toBe("9b8f1e2a-1111-2222-3333-444455556666");
+    expect(props.templateVersion).toBe("1.0.2");
+  });
+
+  it("OMITS the scheduling block for NRT (not on the NRT schema)", () => {
+    const res = alertRuleResourceFromParsed(rule({ kind: "NRT" }));
+    expect(res.supported).toBe(true);
+    if (!res.supported) return;
+    expect(res.kind).toBe("NRT");
+    const props = res.body.properties as Record<string, unknown>;
+    expect(props).not.toHaveProperty("queryFrequency");
+    expect(props).not.toHaveProperty("triggerOperator");
+    expect(props.displayName).toBe("Rule");
+  });
+
+  it("refuses unsupported kinds and empty queries with an honest reason", () => {
+    const fusion = alertRuleResourceFromParsed(rule({ kind: "Fusion" }));
+    expect(fusion.supported).toBe(false);
+    if (!fusion.supported) expect(fusion.reason).toContain("Fusion");
+    const empty = alertRuleResourceFromParsed(rule({ query: "  " }));
+    expect(empty.supported).toBe(false);
+  });
+
+  it("passes structured entity mappings through", () => {
+    const res = alertRuleResourceFromParsed(
+      rule({
+        entityMappings: [
+          { entityType: "Host", fieldMappings: [{ identifier: "FullName", columnName: "Computer" }] },
+        ],
+      }),
+    );
+    expect(res.supported).toBe(true);
+    if (!res.supported) return;
+    const props = res.body.properties as Record<string, unknown>;
+    expect(props.entityMappings).toEqual([
+      { entityType: "Host", fieldMappings: [{ identifier: "FullName", columnName: "Computer" }] },
+    ]);
+  });
+});
+
+describe("workbookResourceBody", () => {
+  it("links the workbook to the workspace as a shared sentinel workbook", () => {
+    const body = workbookResourceBody({
+      displayName: "Cloudflare Overview",
+      serializedData: '{"version":"Notebook/1.0"}',
+      workspaceResourceId: "/subscriptions/s/resourceGroups/rg/providers/Microsoft.OperationalInsights/workspaces/law",
+      location: "eastus",
+    });
+    expect(body.location).toBe("eastus");
+    expect(body.kind).toBe("shared");
+    const props = body.properties as Record<string, unknown>;
+    expect(props.category).toBe("sentinel");
+    expect(props.sourceId).toContain("workspaces/law");
+    expect(props.serializedData).toBe('{"version":"Notebook/1.0"}');
+  });
+});
+
+describe("parseWorkbookUpload", () => {
+  it("uses a raw gallery template body verbatim as serializedData", () => {
+    const text = '{"version":"Notebook/1.0","items":[]}';
+    expect(parseWorkbookUpload("My Board.json", text)).toEqual({
+      displayName: "My Board",
+      serializedData: text,
+    });
+  });
+
+  it("extracts serializedData from a portal ARM template export", () => {
+    const arm = JSON.stringify({
+      resources: [
+        {
+          type: "microsoft.insights/workbooks",
+          properties: { displayName: "Exported", serializedData: '{"items":[]}' },
+        },
+      ],
+    });
+    expect(parseWorkbookUpload("export.json", arm)).toEqual({
+      displayName: "Exported",
+      serializedData: '{"items":[]}',
+    });
+  });
+
+  it("returns null for non-workbook JSON and junk", () => {
+    expect(parseWorkbookUpload("x.json", "not json")).toBeNull();
+    expect(parseWorkbookUpload("x.json", '{"foo":1}')).toBeNull();
+  });
+});
+
+describe("parserResourceFromYaml", () => {
+  it("extracts the alias, dedented query, and function body from a parser YAML", () => {
+    const yaml = [
+      "id: p-1",
+      "FunctionName: Cloudflare",
+      "FunctionAlias: Cloudflare",
+      "FunctionQuery: |",
+      "    Cloudflare_CL",
+      "    | extend ClientIP = ClientIP_s",
+      "version: 1",
+    ].join("\n");
+    const parser = parserResourceFromYaml(yaml);
+    expect(parser).not.toBeNull();
+    expect(parser?.alias).toBe("Cloudflare");
+    expect(parser?.query).toBe("Cloudflare_CL\n| extend ClientIP = ClientIP_s");
+    const body = parserResourceBody(parser!);
+    const props = body.properties as Record<string, unknown>;
+    expect(props.category).toBe("Function");
+    expect(props.functionAlias).toBe("Cloudflare");
+  });
+
+  it("returns null for a file that is not an installable function", () => {
+    expect(parserResourceFromYaml("just some text")).toBeNull();
+    expect(parserResourceFromYaml("FunctionAlias: X\n")).toBeNull(); // no query
+  });
+});
+
+describe("partitionByInstalled / summarizeInstallOutcomes", () => {
+  it("splits available content on case-insensitive installed names", () => {
+    const { installed, installable } = partitionByInstalled(
+      [{ n: "Rule A" }, { n: "Rule B" }],
+      new Set(["rule a"]),
+      (x) => x.n,
+    );
+    expect(installed.map((x) => x.n)).toEqual(["Rule A"]);
+    expect(installable.map((x) => x.n)).toEqual(["Rule B"]);
+  });
+
+  it("summarizes outcomes with installed/failed/skipped counts", () => {
+    expect(
+      summarizeInstallOutcomes(
+        [
+          { name: "a", ok: true, detail: "installed" },
+          { name: "b", ok: false, detail: "HTTP 400" },
+        ],
+        1,
+      ),
+    ).toBe("1 installed, 1 FAILED, 1 skipped");
+  });
+});

--- a/soc-optimizationtoolkit/packages/core/src/domain/content-install/content-install.ts
+++ b/soc-optimizationtoolkit/packages/core/src/domain/content-install/content-install.ts
@@ -1,0 +1,367 @@
+/**
+ * Sentinel content-install domain (user feature 2026-07-14): the PURE
+ * transforms behind enabling a solution's content in the workspace -
+ * analytics rules and workbooks - plus installed-state partitioning and the
+ * per-item outcome vocabulary the UI reports success/failure with.
+ *
+ *  - {@link alertRuleResourceFromParsed}: a repo/custom ParsedAnalyticRule ->
+ *    the ARM alertRules PUT body. Kinds Scheduled (the YAML default) and NRT
+ *    are supported; anything else returns an honest unsupported reason
+ *    instead of a doomed PUT. YAML durations ("1h") convert to ISO8601
+ *    ("PT1H"), YAML operators ("gt") to ARM spellings ("GreaterThan"),
+ *    "None" tactics/techniques are dropped, entity mappings pass through
+ *    when the tolerant parse produced them.
+ *  - {@link workbookResourceBody}: a workbook document (the repo template
+ *    file body IS the serializedData) -> the ARM workbooks PUT body linked
+ *    to the workspace.
+ *  - {@link parseWorkbookUpload}: accept a user-uploaded workbook as either
+ *    a raw gallery-template JSON or a portal ARM export (template or single
+ *    resource) and extract {displayName, serializedData}.
+ *  - {@link partitionByInstalled}: case-insensitive display-name matching of
+ *    available content against what the workspace already has - "which ones
+ *    COULD I install".
+ *  - {@link ContentInstallOutcome} + {@link summarizeInstallOutcomes}: the per-item
+ *    success/failure feedback contract.
+ *
+ * Pure: no IO, no fetch, no React, no Date/crypto (ids are shell-minted).
+ */
+
+import type { ParsedAnalyticRule } from "../coverage-analysis/index";
+
+/** One install attempt's outcome - the UI's per-item feedback row. */
+export interface ContentInstallOutcome {
+  /** Display name of the rule/workbook/solution. */
+  name: string;
+  ok: boolean;
+  /** Success detail ("created") or the verbatim failure (HTTP status + body). */
+  detail: string;
+}
+
+/** "N installed, M failed" (+ skip note when present). */
+export function summarizeInstallOutcomes(
+  outcomes: readonly ContentInstallOutcome[],
+  skipped = 0,
+): string {
+  const ok = outcomes.filter((o) => o.ok).length;
+  const failed = outcomes.length - ok;
+  const parts = [`${ok} installed`];
+  if (failed > 0) parts.push(`${failed} FAILED`);
+  if (skipped > 0) parts.push(`${skipped} skipped`);
+  return parts.join(", ");
+}
+
+/**
+ * Convert a Sentinel-YAML duration ("1h", "30m", "5d", or already-ISO
+ * "PT1H"/"P1D") to ISO8601. Unparseable input yields `fallback` - a doomed
+ * PUT is worse than a sane default the reviewer can edit in the portal.
+ */
+export function toIsoDuration(raw: string | undefined, fallback: string): string {
+  if (raw === undefined || raw.trim() === "") return fallback;
+  const trimmed = raw.trim().toUpperCase();
+  if (trimmed.startsWith("P")) return trimmed;
+  const m = trimmed.match(/^(\d+)\s*([MHD])$/);
+  if (!m) return fallback;
+  const n = m[1];
+  switch (m[2]) {
+    case "M":
+      return `PT${n}M`;
+    case "H":
+      return `PT${n}H`;
+    default:
+      return `P${n}D`;
+  }
+}
+
+/** YAML trigger operator ("gt") or ARM spelling -> the ARM enum value. */
+export function toArmTriggerOperator(raw: string | undefined): string {
+  switch ((raw ?? "").trim().toLowerCase()) {
+    case "gt":
+    case "greaterthan":
+      return "GreaterThan";
+    case "lt":
+    case "lessthan":
+      return "LessThan";
+    case "eq":
+    case "equal":
+      return "Equal";
+    case "ne":
+    case "notequal":
+      return "NotEqual";
+    default:
+      return "GreaterThan";
+  }
+}
+
+const VALID_SEVERITIES = new Set(["High", "Medium", "Low", "Informational"]);
+
+/** Normalize a parsed severity to the ARM enum (unknown -> Medium). */
+export function toArmSeverity(raw: string): string {
+  const cased = raw.trim().replace(/^\w/, (c) => c.toUpperCase());
+  return VALID_SEVERITIES.has(cased) ? cased : "Medium";
+}
+
+/** Drop "None"/empty entries (the YAML placeholder) and dedupe. */
+function cleanList(values: readonly string[] | undefined): string[] {
+  return [...new Set((values ?? []).filter((v) => v && v !== "None"))];
+}
+
+/**
+ * Tactics for ARM are the space-free enum spelling ("Lateral Movement" ->
+ * "LateralMovement"); YAML usually already omits spaces but not always.
+ */
+function cleanTactics(values: readonly string[] | undefined): string[] {
+  return cleanList(values).map((t) => t.replace(/\s+/g, ""));
+}
+
+const GUID_RULE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/** The ARM alertRules PUT body, or an honest unsupported reason. */
+export type AlertRuleResource =
+  | { supported: true; kind: "Scheduled" | "NRT"; body: Record<string, unknown> }
+  | { supported: false; reason: string };
+
+/**
+ * Build the alertRules PUT body from a parsed rule. Scheduled rules carry
+ * the full scheduling block (defaults: PT1H frequency/period, GreaterThan 0
+ * trigger, suppression off at PT5H - the portal's own defaults); NRT rules
+ * MUST omit the scheduling block. Template linkage (alertRuleTemplateName +
+ * templateVersion) is included only when the YAML id is a GUID.
+ */
+export function alertRuleResourceFromParsed(
+  rule: ParsedAnalyticRule,
+): AlertRuleResource {
+  const kindRaw = (rule.kind ?? "Scheduled").trim();
+  const kind = kindRaw.toLowerCase();
+  if (kind !== "scheduled" && kind !== "nrt") {
+    return {
+      supported: false,
+      reason:
+        `kind "${kindRaw}" is not installable here (only Scheduled and NRT rules; ` +
+        "Fusion/MicrosoftSecurityIncidentCreation rules are managed by their own connectors)",
+    };
+  }
+  if (rule.query.trim() === "") {
+    return { supported: false, reason: "the rule has no query body" };
+  }
+
+  const common: Record<string, unknown> = {
+    displayName: rule.name,
+    description: rule.description ?? "",
+    severity: toArmSeverity(rule.severity),
+    enabled: true,
+    query: rule.query,
+    suppressionEnabled: false,
+    suppressionDuration: "PT5H",
+    tactics: cleanTactics(rule.tactics),
+    techniques: cleanList(rule.techniques),
+    ...(rule.entityMappings !== undefined && rule.entityMappings.length > 0
+      ? { entityMappings: rule.entityMappings }
+      : {}),
+    ...(GUID_RULE.test(rule.id)
+      ? {
+          alertRuleTemplateName: rule.id,
+          ...(rule.version !== undefined ? { templateVersion: rule.version } : {}),
+        }
+      : {}),
+  };
+
+  if (kind === "nrt") {
+    return { supported: true, kind: "NRT", body: { kind: "NRT", properties: common } };
+  }
+  return {
+    supported: true,
+    kind: "Scheduled",
+    body: {
+      kind: "Scheduled",
+      properties: {
+        ...common,
+        queryFrequency: toIsoDuration(rule.queryFrequency, "PT1H"),
+        queryPeriod: toIsoDuration(rule.queryPeriod, "PT1H"),
+        triggerOperator: toArmTriggerOperator(rule.triggerOperator),
+        triggerThreshold: rule.triggerThreshold ?? 0,
+      },
+    },
+  };
+}
+
+/** Inputs for {@link workbookResourceBody}. */
+export interface WorkbookResourceInput {
+  displayName: string;
+  /** The workbook document JSON text (a repo template file body verbatim). */
+  serializedData: string;
+  /** Full ARM resource id of the Log Analytics workspace (the sourceId link). */
+  workspaceResourceId: string;
+  /** Azure region of the workspace (workbooks are regional resources). */
+  location: string;
+}
+
+/** The ARM Microsoft.Insights/workbooks PUT body (Sentinel-linked, shared). */
+export function workbookResourceBody(
+  input: WorkbookResourceInput,
+): Record<string, unknown> {
+  return {
+    location: input.location,
+    kind: "shared",
+    properties: {
+      displayName: input.displayName,
+      serializedData: input.serializedData,
+      category: "sentinel",
+      sourceId: input.workspaceResourceId,
+      version: "Notebook/1.0",
+    },
+  };
+}
+
+/** A parsed workbook upload: what install needs. */
+export interface ParsedWorkbookUpload {
+  displayName: string;
+  serializedData: string;
+}
+
+/**
+ * Parse a user-uploaded workbook file: a raw gallery-template JSON (the
+ * document itself - used verbatim as serializedData), a portal ARM template
+ * export (resources[] containing a Microsoft.Insights/workbooks entry whose
+ * properties carry serializedData), or a single exported workbook resource.
+ * Returns null for anything else.
+ */
+export function parseWorkbookUpload(
+  fileName: string,
+  text: string,
+): ParsedWorkbookUpload | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== "object" || parsed === null) return null;
+  const obj = parsed as Record<string, unknown>;
+  const fallbackName = fileName.replace(/\.json$/i, "");
+
+  // Raw gallery template: the document itself ("version": "Notebook/1.0"
+  // and/or an items[] array).
+  if (Array.isArray(obj.items) || obj.version === "Notebook/1.0") {
+    return { displayName: fallbackName, serializedData: text };
+  }
+
+  // ARM shapes: single resource or a template's resources[].
+  const candidates: unknown[] = Array.isArray(obj.resources)
+    ? obj.resources
+    : [obj];
+  for (const raw of candidates) {
+    if (typeof raw !== "object" || raw === null) continue;
+    const res = raw as Record<string, unknown>;
+    const type = typeof res.type === "string" ? res.type.toLowerCase() : "";
+    if (!type.endsWith("microsoft.insights/workbooks")) continue;
+    const props = res.properties as Record<string, unknown> | undefined;
+    const data = props?.serializedData;
+    if (typeof data !== "string" || data === "") continue;
+    const displayName =
+      typeof props?.displayName === "string" && props.displayName !== ""
+        ? props.displayName
+        : fallbackName;
+    return { displayName, serializedData: data };
+  }
+  return null;
+}
+
+/** One installable rule extracted from a portal ARM export upload. */
+export interface ArmExportRule {
+  displayName: string;
+  /** PUT body: kind + properties, near-verbatim from the export. */
+  body: Record<string, unknown>;
+  /** Whether the export was an NRT rule (drives the preview api-version). */
+  isNrt: boolean;
+}
+
+/** The savedSearches Function body a solution parser installs as. */
+export interface ParserResource {
+  /** The functionAlias rules/workbooks reference (savedSearch id-safe). */
+  alias: string;
+  displayName: string;
+  query: string;
+  /** functionParameters string (empty when the parser takes none). */
+  functionParameters: string;
+}
+
+/**
+ * Extract the installable parser (savedSearches Function) from a Sentinel
+ * repo parser YAML. Tolerant regex-over-YAML, same approach as the rule and
+ * parser-coverage parsers: pull the alias (FunctionAlias, else FunctionName),
+ * the FunctionQuery body, the display name, and optional FunctionParameters.
+ * Returns null when it is not an installable function file (no alias/query).
+ *
+ * Parsers are a DEPENDENCY of the content, not a user choice: an analytics
+ * rule or workbook that queries `Cloudflare` (the function) fails to save or
+ * run if the function is absent, so the install flow installs the solution's
+ * parsers alongside its rules/workbooks - mirroring Content Hub, which
+ * installs parsers automatically with a solution.
+ */
+export function parserResourceFromYaml(text: string): ParserResource | null {
+  const alias =
+    text.match(/^FunctionAlias:\s*["']?([A-Za-z_][\w-]*)/m)?.[1] ??
+    text.match(/^FunctionName:\s*["']?([A-Za-z_][\w-]*)/m)?.[1];
+  if (alias === undefined) return null;
+
+  const query = text.match(
+    /^FunctionQuery:\s*\|?-?\s*\n([\s\S]*?)(?=^[A-Za-z]|(?![\s\S]))/m,
+  )?.[1];
+  if (query === undefined || query.trim() === "") return null;
+
+  const displayName =
+    text.match(/^FunctionName:\s*["']?([^"'\n]+)/m)?.[1]?.trim() ??
+    text.match(/^(?:Function )?Title:\s*["']?([^"'\n]+)/m)?.[1]?.trim() ??
+    alias;
+  const functionParameters =
+    text.match(/^FunctionParameters:\s*["']?([^"'\n]*)/m)?.[1]?.trim() ?? "";
+
+  return {
+    alias,
+    displayName: displayName.replace(/["']$/, ""),
+    query: dedentBlock(query),
+    functionParameters,
+  };
+}
+
+/** Strip the common YAML block-scalar indentation from a query body. */
+function dedentBlock(text: string): string {
+  const lines = text.replace(/\s+$/, "").split("\n");
+  const indents = lines
+    .filter((l) => l.trim() !== "")
+    .map((l) => l.match(/^ */)?.[0].length ?? 0);
+  const min = indents.length > 0 ? Math.min(...indents) : 0;
+  return lines.map((l) => l.slice(min)).join("\n").trim();
+}
+
+/** The ARM savedSearches PUT body for a parser Function. */
+export function parserResourceBody(
+  parser: ParserResource,
+): Record<string, unknown> {
+  return {
+    properties: {
+      category: "Function",
+      displayName: parser.displayName,
+      functionAlias: parser.alias,
+      query: parser.query,
+      functionParameters: parser.functionParameters,
+      version: 2,
+    },
+  };
+}
+
+/** Partition available content into already-installed vs installable. */
+export function partitionByInstalled<T>(
+  available: readonly T[],
+  installedNames: ReadonlySet<string>,
+  nameOf: (item: T) => string,
+): { installed: T[]; installable: T[] } {
+  const installed: T[] = [];
+  const installable: T[] = [];
+  for (const item of available) {
+    (installedNames.has(nameOf(item).toLowerCase()) ? installed : installable).push(
+      item,
+    );
+  }
+  return { installed, installable };
+}

--- a/soc-optimizationtoolkit/packages/core/src/domain/content-install/index.ts
+++ b/soc-optimizationtoolkit/packages/core/src/domain/content-install/index.ts
@@ -1,0 +1,27 @@
+/**
+ * content-install domain barrel (user feature 2026-07-14): pure transforms
+ * for enabling a Sentinel solution's content in the workspace - solution
+ * install, analytics-rule and workbook ARM bodies, upload parsing,
+ * installed-state partitioning, and the per-item install-outcome vocabulary.
+ * The IO half is usecases/content-install. All pure.
+ */
+
+export type {
+  AlertRuleResource,
+  ContentInstallOutcome,
+  ParsedWorkbookUpload,
+  ParserResource,
+  WorkbookResourceInput,
+} from "./content-install";
+export {
+  alertRuleResourceFromParsed,
+  parserResourceBody,
+  parserResourceFromYaml,
+  partitionByInstalled,
+  parseWorkbookUpload,
+  summarizeInstallOutcomes,
+  toArmSeverity,
+  toArmTriggerOperator,
+  toIsoDuration,
+  workbookResourceBody,
+} from "./content-install";

--- a/soc-optimizationtoolkit/packages/core/src/domain/coverage-analysis/index.ts
+++ b/soc-optimizationtoolkit/packages/core/src/domain/coverage-analysis/index.ts
@@ -22,6 +22,7 @@ export type {
   CoverageSummary,
   CoverageReport,
   ParsedAnalyticRule,
+  ParsedEntityMapping,
   WorkbookQueryExtraction,
 } from "./models";
 

--- a/soc-optimizationtoolkit/packages/core/src/domain/coverage-analysis/models.ts
+++ b/soc-optimizationtoolkit/packages/core/src/domain/coverage-analysis/models.ts
@@ -186,6 +186,32 @@ export interface ParsedAnalyticRule {
   /** Entity-mapping `columnName:` fields, KQL-builtin names filtered out. */
   entityFields: string[];
   fileName: string;
+
+  // --- INSTALL fields (content-enablement, 2026-07-14) - all OPTIONAL and
+  // additive so the coverage path's pinned extraction is unchanged. ---
+  /** Rule kind (Scheduled | NRT | ...). Absent = Scheduled by convention. */
+  kind?: string;
+  /** Description text (block or single-line form). */
+  description?: string;
+  /** Raw YAML duration (e.g. "1h", "PT1H") - converted at install time. */
+  queryFrequency?: string;
+  /** Raw YAML duration - converted at install time. */
+  queryPeriod?: string;
+  /** Raw YAML operator (gt/lt/eq/ne or the ARM spelling). */
+  triggerOperator?: string;
+  triggerThreshold?: number;
+  /** relevantTechniques (e.g. T1078). */
+  techniques?: string[];
+  /** Rule content version (e.g. 1.0.3). */
+  version?: string;
+  /** Structured entity mappings (tolerant parse; absent when unparseable). */
+  entityMappings?: ParsedEntityMapping[];
+}
+
+/** One structured entity mapping parsed from the rule YAML. */
+export interface ParsedEntityMapping {
+  entityType: string;
+  fieldMappings: Array<{ identifier: string; columnName: string }>;
 }
 
 // ---------------------------------------------------------------------------

--- a/soc-optimizationtoolkit/packages/core/src/domain/coverage-analysis/parse-analytic-rule.ts
+++ b/soc-optimizationtoolkit/packages/core/src/domain/coverage-analysis/parse-analytic-rule.ts
@@ -34,7 +34,11 @@
  */
 
 import { KQL_BUILTINS } from "./kql-builtins";
-import type { ContentItem, ParsedAnalyticRule } from "./models";
+import type {
+  ContentItem,
+  ParsedAnalyticRule,
+  ParsedEntityMapping,
+} from "./models";
 
 /**
  * Parse ONE AnalyticRule YAML document with the pinned regex extraction.
@@ -93,7 +97,104 @@ export function parseAnalyticRuleYaml(
     if (cm[1] && !KQL_BUILTINS.has(cm[1].toLowerCase())) entityFields.push(cm[1]);
   }
 
-  return { id, name, severity, tactics, dataTypes, query, entityFields, fileName };
+  // --- INSTALL fields (content-enablement, 2026-07-14): additive optional
+  // extraction with the same tolerant single-purpose regexes; a miss leaves
+  // the field absent and the coverage path is untouched. ---
+  const single = (key: string): string | undefined => {
+    const value = content.match(new RegExp(`^${key}:\\s*(.+)$`, "m"))?.[1]?.trim();
+    if (value === undefined || value === "" || value === "|" || value === ">") {
+      return undefined;
+    }
+    return value.replace(/^['"]|['"]$/g, "");
+  };
+  const block = (key: string): string | undefined => {
+    const m = content.match(
+      new RegExp(`^${key}:\\s*[|>]-?\\s*\\n([\\s\\S]*?)(?=^[a-zA-Z]|(?![\\s\\S]))`, "m"),
+    );
+    const text = m?.[1]
+      ?.split("\n")
+      .map((line) => line.replace(/^ {2,4}/, ""))
+      .join("\n")
+      .trim();
+    return text === undefined || text === "" ? undefined : text;
+  };
+  const list = (key: string): string[] => {
+    const out: string[] = [];
+    const m = content.match(new RegExp(`^${key}:\\s*\\n((?:\\s+-\\s+.+\\n?)*)`, "m"));
+    if (m) {
+      for (const line of m[1].split("\n")) {
+        const item = line.match(/^\s+-\s+(.+)/)?.[1]?.trim();
+        if (item) out.push(item);
+      }
+    }
+    return out;
+  };
+
+  const kind = single("kind");
+  const description = block("description") ?? single("description");
+  const queryFrequency = single("queryFrequency");
+  const queryPeriod = single("queryPeriod");
+  const triggerOperator = single("triggerOperator");
+  const thresholdRaw = single("triggerThreshold");
+  const triggerThreshold =
+    thresholdRaw !== undefined && Number.isFinite(Number(thresholdRaw))
+      ? Number(thresholdRaw)
+      : undefined;
+  const techniques = list("relevantTechniques");
+  const version = single("version");
+  const entityMappings = parseEntityMappings(content);
+
+  return {
+    id,
+    name,
+    severity,
+    tactics,
+    dataTypes,
+    query,
+    entityFields,
+    fileName,
+    ...(kind !== undefined ? { kind } : {}),
+    ...(description !== undefined ? { description } : {}),
+    ...(queryFrequency !== undefined ? { queryFrequency } : {}),
+    ...(queryPeriod !== undefined ? { queryPeriod } : {}),
+    ...(triggerOperator !== undefined ? { triggerOperator } : {}),
+    ...(triggerThreshold !== undefined ? { triggerThreshold } : {}),
+    ...(techniques.length > 0 ? { techniques } : {}),
+    ...(version !== undefined ? { version } : {}),
+    ...(entityMappings.length > 0 ? { entityMappings } : {}),
+  };
+}
+
+/**
+ * Tolerant structured parse of the `entityMappings:` block: each
+ * `- entityType:` entry with its identifier/columnName pairs (paired in
+ * document order). Anything surprising yields [] - the rule still installs,
+ * just without entity mappings.
+ */
+function parseEntityMappings(content: string): ParsedEntityMapping[] {
+  const blockMatch = content.match(
+    /^entityMappings:\s*\n([\s\S]*?)(?=^[a-zA-Z]|(?![\s\S]))/m,
+  );
+  if (!blockMatch) return [];
+  const out: ParsedEntityMapping[] = [];
+  const entries = blockMatch[1].split(/(?=^\s*-\s+entityType:)/m);
+  for (const entry of entries) {
+    const entityType = entry.match(/entityType:\s*(.+)/)?.[1]?.trim();
+    if (!entityType) continue;
+    const fieldMappings: Array<{ identifier: string; columnName: string }> = [];
+    const identifiers = [...entry.matchAll(/identifier:\s*(\w+)/g)];
+    const columns = [...entry.matchAll(/columnName:\s*(\w+)/g)];
+    for (let i = 0; i < Math.min(identifiers.length, columns.length); i++) {
+      fieldMappings.push({
+        identifier: identifiers[i][1],
+        columnName: columns[i][1],
+      });
+    }
+    if (fieldMappings.length > 0) {
+      out.push({ entityType, fieldMappings });
+    }
+  }
+  return out;
 }
 
 /**

--- a/soc-optimizationtoolkit/packages/core/src/domain/integrate-arc/integrate-arc.test.ts
+++ b/soc-optimizationtoolkit/packages/core/src/domain/integrate-arc/integrate-arc.test.ts
@@ -87,6 +87,7 @@ const BUILT_IDS: readonly IntegrateSectionId[] = [
   "gap-analysis",
   "rule-coverage",
   "workbook-coverage",
+  "enable-content",
   "deploy",
 ];
 // Unit 23 shipped rule-coverage; every section is built now. Kept as a named
@@ -102,9 +103,9 @@ function statusOf(id: IntegrateSectionId, i: SectionInputs): SectionStatus {
 // ---------------------------------------------------------------------------
 
 describe("INTEGRATE_SECTIONS metadata", () => {
-  it("has eight sections numbered 1..8 in page order", () => {
+  it("has nine sections numbered 1..9 in page order", () => {
     expect(INTEGRATE_SECTIONS.map((s) => s.number)).toEqual([
-      1, 2, 3, 4, 5, 6, 7, 8,
+      1, 2, 3, 4, 5, 6, 7, 8, 9,
     ]);
     expect(INTEGRATE_SECTIONS.map((s) => s.id)).toEqual([
       "solution",
@@ -114,6 +115,9 @@ describe("INTEGRATE_SECTIONS metadata", () => {
       "gap-analysis",
       "rule-coverage",
       "workbook-coverage",
+      // Enable Sentinel Content follows the coverage arc (you review what the
+      // rules/workbooks need, then install them); Sentinel-side + informational.
+      "enable-content",
       // Azure Resources and Cribl Config FOLLOW the analysis arc (user
       // direction 2026-07-13): detected tables prefill the deploy and the
       // pack is built from the approved mappings.
@@ -452,10 +456,10 @@ describe("read-ahead and single-current invariants", () => {
     }
   });
 
-  it("deriveSectionStatuses preserves page order and covers all eight", () => {
+  it("deriveSectionStatuses preserves page order and covers all nine", () => {
     const resolved = deriveSectionStatuses(inputs());
     expect(resolved.map((r) => r.section.number)).toEqual([
-      1, 2, 3, 4, 5, 6, 7, 8,
+      1, 2, 3, 4, 5, 6, 7, 8, 9,
     ]);
   });
 });

--- a/soc-optimizationtoolkit/packages/core/src/domain/integrate-arc/integrate-arc.ts
+++ b/soc-optimizationtoolkit/packages/core/src/domain/integrate-arc/integrate-arc.ts
@@ -69,6 +69,7 @@ export type IntegrateSectionId =
   | "gap-analysis"
   | "rule-coverage"
   | "workbook-coverage"
+  | "enable-content"
   | "deploy";
 
 /**
@@ -203,8 +204,26 @@ export const INTEGRATE_SECTIONS: readonly IntegrateSection[] = [
     built: true,
   },
   {
-    id: "azure-resources",
+    id: "enable-content",
     number: 6,
+    title: "Enable Sentinel Content",
+    infoTip:
+      "Enable the solution's content in your workspace: install the Content " +
+      "Hub solution itself, its analytics rules, and its workbooks - choosing " +
+      "which of each you want. The app checks what is already installed so you " +
+      "only see what is installable, and upload your own custom analytics " +
+      "rules or workbooks to install alongside. Parsers the rules and " +
+      "workbooks depend on are installed automatically. Informational and " +
+      "independent of the Cribl deploy - it never blocks a deploy.",
+    requires: "azure",
+    // INFORMATIONAL, same contract as the coverage sections: unconditionally
+    // complete, absent from SectionInputs, never gates a deploy. Content
+    // enablement is a Sentinel-side install parallel to the Cribl pipeline.
+    built: true,
+  },
+  {
+    id: "azure-resources",
+    number: 7,
     title: "Select Azure Resources",
     infoTip:
       "Choose the subscription, Log Analytics workspace, resource group, and " +
@@ -215,7 +234,7 @@ export const INTEGRATE_SECTIONS: readonly IntegrateSection[] = [
   },
   {
     id: "cribl-config",
-    number: 7,
+    number: 8,
     title: "Configure Cribl",
     infoTip:
       "Select the Cribl worker group(s) that will run the pipelines and name " +
@@ -226,7 +245,7 @@ export const INTEGRATE_SECTIONS: readonly IntegrateSection[] = [
   },
   {
     id: "deploy",
-    number: 8,
+    number: 9,
     title: "Deploy",
     infoTip:
       "Review the readiness pills - Solution, Samples, Mappings, Workspace, " +
@@ -353,6 +372,8 @@ const COMING_SOON_REASONS: Readonly<Record<IntegrateSectionId, string>> = {
   "rule-coverage": "",
   // workbook-coverage is BUILT; it is never coming-soon.
   "workbook-coverage": "",
+  // enable-content is BUILT; it is never coming-soon.
+  "enable-content": "",
   deploy: "",
 };
 
@@ -392,6 +413,11 @@ function sectionComplete(
     case "workbook-coverage":
       // INFORMATIONAL, same contract as rule-coverage: unconditionally complete,
       // no SectionInputs signal, never gates a deploy.
+      return true;
+    case "enable-content":
+      // INFORMATIONAL, same contract as the coverage sections: content
+      // enablement is a Sentinel-side install parallel to the Cribl deploy,
+      // unconditionally complete, no SectionInputs signal, never gates a deploy.
       return true;
     case "deploy":
       return inputs.deployCompleted;

--- a/soc-optimizationtoolkit/packages/core/src/index.test.ts
+++ b/soc-optimizationtoolkit/packages/core/src/index.test.ts
@@ -166,13 +166,14 @@ describe("@soc/core root barrel", () => {
     expect(typeof deriveSectionStatus).toBe("function");
     expect(typeof deriveReadinessPills).toBe("function");
     expect(typeof canDeploy).toBe("function");
-    expect(INTEGRATE_SECTIONS).toHaveLength(8);
+    expect(INTEGRATE_SECTIONS).toHaveLength(9);
     // sample-data joined the built set when Unit 11 shipped (was 3); solution
     // joined it when Unit 14 shipped the lazy solution browser (was 5);
     // gap-analysis joined it when Unit 18 shipped the mapping review (was 6);
     // rule-coverage joined it when Unit 23 shipped the coverage panel;
-    // workbook-coverage split out as its own section - all eight are built now.
-    expect(INTEGRATE_SECTIONS.filter((s) => s.built)).toHaveLength(8);
+    // workbook-coverage split out as its own section; enable-content added
+    // 2026-07-14 (Sentinel content install) - all nine are built now.
+    expect(INTEGRATE_SECTIONS.filter((s) => s.built)).toHaveLength(9);
   });
 
   it("re-exports the sample-parsing domain module and store fake", () => {

--- a/soc-optimizationtoolkit/packages/core/src/index.ts
+++ b/soc-optimizationtoolkit/packages/core/src/index.ts
@@ -43,5 +43,6 @@ export * from "./domain/pack-assembly";
 export * from "./domain/architecture-patterns";
 export * from "./domain/eventhub-discovery";
 export * from "./domain/siem-migration";
+export * from "./domain/content-install";
 export * from "./assets/vendor-schemas";
 export * from "./usecases";

--- a/soc-optimizationtoolkit/packages/core/src/usecases/content-install/available-content.ts
+++ b/soc-optimizationtoolkit/packages/core/src/usecases/content-install/available-content.ts
@@ -1,0 +1,198 @@
+/**
+ * Available-content acquisition for the install flow (2026-07-14): find the
+ * Content Hub package for a solution (its catalog entry - contentId +
+ * packageId + version + installedVersion), and read the solution's SHIPPED
+ * analytics rules and workbooks from the Sentinel repo so they can be
+ * installed. Rules reuse the pinned YAML parser; workbook TEMPLATE bodies
+ * are the serializedData verbatim.
+ *
+ * Pure orchestration over the ports.
+ */
+
+import type { AzureManagement } from "../../ports/azure-management";
+import type { SentinelContent } from "../../ports/sentinel-content";
+import type { Logger } from "../../ports/logger";
+import { listAllPages } from "../azure-discovery/index";
+import {
+  SECURITY_INSIGHTS_API_VERSION,
+  workspaceResourceId,
+} from "./content-install";
+import type { WorkspaceScope } from "./content-install";
+import { ANALYTIC_RULE_DIR_NAMES } from "../../domain/sentinel-content/index";
+import { WORKBOOK_DIR_NAMES } from "../coverage-analysis/index";
+import { parseAnalyticRuleYaml } from "../../domain/coverage-analysis/index";
+import type { ParsedAnalyticRule } from "../../domain/coverage-analysis/index";
+import { parserResourceFromYaml } from "../../domain/content-install/index";
+import type { ParserResource } from "../../domain/content-install/index";
+
+/** A Content Hub catalog entry for a solution. */
+export interface SolutionCatalogEntry {
+  /** contentPackages/-scoped package name (the deploy target). */
+  packageId: string;
+  /** The stable contentId (matches installed contentPackages). */
+  contentId: string;
+  displayName: string;
+  version: string;
+  /** Non-null when already installed (the catalog reports it). */
+  installedVersion: string | null;
+}
+
+/** A solution workbook available to install (its document body). */
+export interface AvailableWorkbook {
+  displayName: string;
+  serializedData: string;
+}
+
+function prop(value: unknown, key: string): unknown {
+  if (typeof value !== "object" || value === null) return undefined;
+  return (value as Record<string, unknown>)[key];
+}
+
+function str(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function normName(s: string): string {
+  return s.toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
+/**
+ * Find the Content Hub catalog entry for `solutionName` (fuzzy display-name
+ * match, the same normalized-containment rule the rest of the app uses).
+ * Returns null when the catalog cannot be read or no entry matches.
+ */
+export async function findSolutionCatalogEntry(
+  azure: AzureManagement,
+  ws: WorkspaceScope,
+  solutionName: string,
+  logger?: Logger,
+): Promise<SolutionCatalogEntry | null> {
+  const scope =
+    `/subscriptions/${ws.subscriptionId}/resourceGroups/${ws.resourceGroup}` +
+    `/providers/Microsoft.OperationalInsights/workspaces/${ws.workspaceName}` +
+    "/providers/Microsoft.SecurityInsights/contentProductPackages";
+  let packages: unknown[];
+  try {
+    packages = await listAllPages(
+      azure,
+      { method: "GET", path: scope, apiVersion: SECURITY_INSIGHTS_API_VERSION },
+      "list content product packages",
+    );
+  } catch (err) {
+    logger?.warn("content-install: catalog listing failed", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
+  const target = normName(solutionName);
+  const match = packages.find((p) => {
+    const dn = normName(str(prop(prop(p, "properties"), "displayName")));
+    return dn === target || dn.includes(target) || target.includes(dn);
+  });
+  if (match === undefined) return null;
+  const props = prop(match, "properties");
+  const installed = prop(props, "installedVersion");
+  return {
+    packageId: str(prop(match, "name")),
+    contentId: str(prop(props, "contentId")),
+    displayName: str(prop(props, "displayName")),
+    version: str(prop(props, "version")),
+    installedVersion:
+      typeof installed === "string" && installed !== "" ? installed : null,
+  };
+}
+
+/**
+ * Read a solution's shipped analytics rules from the Sentinel repo (first
+ * rule-directory variant that yields YAMLs), parsed for install. Capped.
+ */
+export async function availableAnalyticRules(
+  content: SentinelContent,
+  solutionName: string,
+  cap = 60,
+): Promise<ParsedAnalyticRule[]> {
+  for (const dir of ANALYTIC_RULE_DIR_NAMES) {
+    const files = await content.listSolutionFiles(solutionName, dir);
+    const yamls = files
+      .filter((f) => /\.ya?ml$/i.test(f.name))
+      .slice(0, cap);
+    if (yamls.length === 0) continue;
+    const rules: ParsedAnalyticRule[] = [];
+    for (const file of yamls) {
+      const text = await content.readFile(file.path);
+      if (text !== null) rules.push(parseAnalyticRuleYaml(text, file.name));
+    }
+    return rules;
+  }
+  return [];
+}
+
+/**
+ * Read a solution's shipped workbooks from the Sentinel repo (first Workbooks
+ * directory variant that yields .json templates). A template file's body IS
+ * the serializedData. Capped.
+ */
+export async function availableWorkbooks(
+  content: SentinelContent,
+  solutionName: string,
+  cap = 40,
+): Promise<AvailableWorkbook[]> {
+  for (const dir of WORKBOOK_DIR_NAMES) {
+    const files = await content.listSolutionFiles(solutionName, dir);
+    const templates = files
+      .filter(
+        (f) =>
+          /\.json$/i.test(f.name) && !f.name.toLowerCase().includes("metadata"),
+      )
+      .slice(0, cap);
+    if (templates.length === 0) continue;
+    const out: AvailableWorkbook[] = [];
+    for (const file of templates) {
+      const text = await content.readFile(file.path);
+      if (text !== null) {
+        out.push({
+          displayName: file.name.replace(/\.json$/i, ""),
+          serializedData: text,
+        });
+      }
+    }
+    return out;
+  }
+  return [];
+}
+
+/** The Parsers directory-name variants a solution may use. */
+const PARSER_DIR_NAMES: readonly string[] = ["Parsers", "Parser"];
+
+/**
+ * Read a solution's SHIPPED parsers from the Sentinel repo (first Parsers
+ * directory variant that yields installable function files). Parsers are the
+ * DEPENDENCY the solution's rules/workbooks query by alias; the install flow
+ * installs them automatically alongside the content. Capped. Files that are
+ * not installable functions (no alias/query) are skipped.
+ */
+export async function availableParsers(
+  content: SentinelContent,
+  solutionName: string,
+  cap = 60,
+): Promise<ParserResource[]> {
+  for (const dir of PARSER_DIR_NAMES) {
+    const files = await content.listSolutionFiles(solutionName, dir);
+    const candidates = files
+      .filter((f) => /\.(ya?ml|txt|kql)$/i.test(f.name))
+      .slice(0, cap);
+    if (candidates.length === 0) continue;
+    const out: ParserResource[] = [];
+    for (const file of candidates) {
+      const text = await content.readFile(file.path);
+      if (text === null) continue;
+      const parser = parserResourceFromYaml(text);
+      if (parser !== null) out.push(parser);
+    }
+    return out;
+  }
+  return [];
+}
+
+// Re-export so a caller building workbook installs has the sourceId helper.
+export { workspaceResourceId };

--- a/soc-optimizationtoolkit/packages/core/src/usecases/content-install/content-install.test.ts
+++ b/soc-optimizationtoolkit/packages/core/src/usecases/content-install/content-install.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Pins for the content-install usecases (2026-07-14): per-item ARM installs
+ * over the AzureManagement port with success/failure outcomes, installed-
+ * state partitioning (best-effort per dimension), and the solution
+ * fetch-then-deploy flow.
+ */
+
+import { describe, expect, it } from "vitest";
+import { FakeAzureManagement } from "../../testing/index";
+import type { ParsedAnalyticRule } from "../../domain/coverage-analysis/index";
+import {
+  installAnalyticRule,
+  installWorkbook,
+  installSolution,
+  installedContentState,
+} from "./content-install";
+import type { WorkspaceScope } from "./content-install";
+
+const WS: WorkspaceScope = {
+  subscriptionId: "sub",
+  resourceGroup: "rg",
+  workspaceName: "law",
+  location: "eastus",
+};
+
+const mintId = () => "11111111-2222-3333-4444-555555555555";
+
+function rule(over: Partial<ParsedAnalyticRule>): ParsedAnalyticRule {
+  return {
+    id: "id",
+    name: "Rule",
+    severity: "Medium",
+    tactics: [],
+    dataTypes: [],
+    query: "Table | take 1",
+    entityFields: [],
+    fileName: "r.yaml",
+    ...over,
+  };
+}
+
+describe("installAnalyticRule", () => {
+  it("PUTs a scheduled rule and reports success", async () => {
+    const azure = new FakeAzureManagement();
+    azure.respondWith({ status: 200, body: {} });
+    const outcome = await installAnalyticRule(azure, WS, rule({}), mintId);
+    expect(outcome).toEqual({ name: "Rule", ok: true, detail: "installed (Scheduled)" });
+    const call = azure.calls[0];
+    expect(call.method).toBe("PUT");
+    expect(call.path).toContain("/providers/Microsoft.SecurityInsights/alertRules/");
+    expect(call.apiVersion).toBe("2025-09-01");
+  });
+
+  it("uses the preview api-version for NRT", async () => {
+    const azure = new FakeAzureManagement();
+    azure.respondWith({ status: 201, body: {} });
+    await installAnalyticRule(azure, WS, rule({ kind: "NRT" }), mintId);
+    expect(azure.calls[0].apiVersion).toBe("2025-10-01-preview");
+  });
+
+  it("reports the HTTP failure verbatim, never throwing", async () => {
+    const azure = new FakeAzureManagement();
+    azure.respondWith({ status: 400, body: { error: "bad" } });
+    const outcome = await installAnalyticRule(azure, WS, rule({}), mintId);
+    expect(outcome.ok).toBe(false);
+    expect(outcome.detail).toContain("HTTP 400");
+  });
+
+  it("skips unsupported kinds without any ARM call", async () => {
+    const azure = new FakeAzureManagement();
+    const outcome = await installAnalyticRule(azure, WS, rule({ kind: "Fusion" }), mintId);
+    expect(outcome.ok).toBe(false);
+    expect(outcome.detail).toContain("skipped:");
+    expect(azure.calls).toHaveLength(0);
+  });
+});
+
+describe("installWorkbook", () => {
+  it("PUTs a workbook resource linked to the workspace", async () => {
+    const azure = new FakeAzureManagement();
+    azure.respondWith({ status: 200, body: {} });
+    const outcome = await installWorkbook(
+      azure,
+      WS,
+      { displayName: "Overview", serializedData: '{"items":[]}' },
+      mintId,
+    );
+    expect(outcome).toEqual({ name: "Overview", ok: true, detail: "installed" });
+    expect(azure.calls[0].path).toContain("/providers/Microsoft.Insights/workbooks/");
+    expect(azure.calls[0].apiVersion).toBe("2021-08-01");
+  });
+});
+
+describe("installedContentState", () => {
+  it("collects installed rule + workbook names and the solution version", async () => {
+    const azure = new FakeAzureManagement();
+    // contentPackages, then alertRules, then workbooks (FIFO).
+    azure.respondWith(
+      {
+        status: 200,
+        body: { value: [{ properties: { contentId: "cf-id", version: "2.0.1" } }] },
+      },
+      {
+        status: 200,
+        body: { value: [{ properties: { displayName: "Cloudflare - Bad IP" } }] },
+      },
+      {
+        status: 200,
+        body: { value: [{ properties: { displayName: "Cloudflare Overview" } }] },
+      },
+    );
+    const state = await installedContentState(azure, WS, "cf-id");
+    expect(state.solutionInstalled).toBe(true);
+    expect(state.installedSolutionVersion).toBe("2.0.1");
+    expect(state.installedRuleNames.has("cloudflare - bad ip")).toBe(true);
+    expect(state.installedWorkbookNames.has("cloudflare overview")).toBe(true);
+    expect(state.notes).toEqual([]);
+  });
+
+  it("degrades a failed listing to a note, not an error", async () => {
+    const azure = new FakeAzureManagement();
+    azure.respondWith(
+      { status: 200, body: { value: [] } }, // packages: not installed
+      { status: 403, body: "denied" }, // alertRules fails
+      { status: 200, body: { value: [] } }, // workbooks: none
+    );
+    const state = await installedContentState(azure, WS, "cf-id");
+    expect(state.solutionInstalled).toBe(false);
+    expect(state.installedRuleNames.size).toBe(0);
+    expect(state.notes.some((n) => n.includes("analytics rules"))).toBe(true);
+  });
+});
+
+describe("installSolution", () => {
+  it("fetches packagedContent then deploys it, reporting acceptance", async () => {
+    const azure = new FakeAzureManagement();
+    azure.respondWith(
+      { status: 200, body: { properties: { packagedContent: { resources: [] } } } },
+      { status: 200, body: {} },
+    );
+    const outcome = await installSolution(azure, WS, "cloudflare.pkg", "Cloudflare");
+    expect(outcome.ok).toBe(true);
+    const [get, put] = azure.calls;
+    expect(get.path).toContain("/contentProductPackages/cloudflare.pkg");
+    expect(put.method).toBe("PUT");
+    expect(put.path).toContain("/Microsoft.Resources/deployments/");
+    const body = put.body as { properties: { template: unknown } };
+    expect(body.properties.template).toEqual({ resources: [] });
+  });
+
+  it("fails honestly when the package has no deployable template", async () => {
+    const azure = new FakeAzureManagement();
+    azure.respondWith({ status: 200, body: { properties: {} } });
+    const outcome = await installSolution(azure, WS, "pkg", "Sol");
+    expect(outcome.ok).toBe(false);
+    expect(outcome.detail).toContain("no deployable template");
+  });
+});

--- a/soc-optimizationtoolkit/packages/core/src/usecases/content-install/content-install.ts
+++ b/soc-optimizationtoolkit/packages/core/src/usecases/content-install/content-install.ts
@@ -1,0 +1,427 @@
+/**
+ * content-install usecases (user feature 2026-07-14): enable a Sentinel
+ * solution's content in the workspace over the EXISTING AzureManagement port
+ * (management.azure.com - no new external surface). Four capabilities the
+ * Integrate page's "Enable Sentinel Content" section drives:
+ *
+ *   - installedContentState: what the workspace ALREADY has (solution
+ *     installed? which analytics-rule + workbook display names exist?) - so
+ *     the UI shows only what is installable.
+ *   - installSolution: the documented Content Hub flow (GET the product
+ *     package's packagedContent ARM template, deploy it via a
+ *     Microsoft.Resources/deployments PUT).
+ *   - installAnalyticRules: PUT one alertRules resource per rule, each
+ *     yielding a typed {@link ContentInstallOutcome}. Scheduled uses the stable
+ *     api-version; NRT uses the preview one (NRT is not in stable).
+ *   - installWorkbooks: PUT one Microsoft.Insights/workbooks resource per
+ *     workbook, linked to the workspace.
+ *
+ * Every install is per-item and INDEPENDENT: one failure never aborts the
+ * rest, and each returns a success/failure outcome (user requirement). The
+ * shell mints resource GUIDs (core is crypto-free) via mintId.
+ *
+ * Pure orchestration over the ports: no IO of its own.
+ */
+
+import type { AzureManagement } from "../../ports/azure-management";
+import type { PortHttpResponse } from "../../ports/http";
+import type { Logger } from "../../ports/logger";
+import { listAllPages } from "../azure-discovery/index";
+import {
+  alertRuleResourceFromParsed,
+  parserResourceBody,
+  workbookResourceBody,
+} from "../../domain/content-install/index";
+import type {
+  ContentInstallOutcome,
+  ParserResource,
+} from "../../domain/content-install/index";
+import type { ParsedAnalyticRule } from "../../domain/coverage-analysis/index";
+
+/** SecurityInsights stable api-version (solutions, scheduled rules). */
+export const SECURITY_INSIGHTS_API_VERSION = "2025-09-01";
+/** NRT rules are not in any stable version - the preview carries them. */
+export const SECURITY_INSIGHTS_PREVIEW_API_VERSION = "2025-10-01-preview";
+/** Microsoft.Insights/workbooks api-version. */
+export const WORKBOOKS_INSTALL_API_VERSION = "2021-08-01";
+/** Microsoft.OperationalInsights/workspaces/savedSearches (parsers). */
+export const SAVED_SEARCHES_API_VERSION = "2020-08-01";
+/** ARM deployments api-version (solution mainTemplate deploy). */
+export const DEPLOYMENTS_API_VERSION = "2021-04-01";
+
+/** The workspace coordinates every call is scoped to. */
+export interface WorkspaceScope {
+  subscriptionId: string;
+  resourceGroup: string;
+  workspaceName: string;
+  /** Azure region (workbooks are regional; solution deploy needs it). */
+  location: string;
+}
+
+/** The workspace's SecurityInsights ARM scope prefix. */
+function workspaceInsightsScope(ws: WorkspaceScope): string {
+  return (
+    `/subscriptions/${ws.subscriptionId}` +
+    `/resourceGroups/${ws.resourceGroup}` +
+    `/providers/Microsoft.OperationalInsights/workspaces/${ws.workspaceName}` +
+    "/providers/Microsoft.SecurityInsights"
+  );
+}
+
+/** Log Analytics workspace api-version (read the region for regional installs). */
+export const WORKSPACE_READ_API_VERSION = "2023-09-01";
+
+/**
+ * Read the workspace's Azure region (workbooks are regional; the solution
+ * deploy needs a workspace-location parameter). Returns null when the read
+ * fails - the caller then prompts for a region or defaults.
+ */
+export async function fetchWorkspaceLocation(
+  azure: AzureManagement,
+  subscriptionId: string,
+  resourceGroup: string,
+  workspaceName: string,
+): Promise<string | null> {
+  try {
+    const res = await azure.request({
+      method: "GET",
+      path:
+        `/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}` +
+        `/providers/Microsoft.OperationalInsights/workspaces/${workspaceName}`,
+      apiVersion: WORKSPACE_READ_API_VERSION,
+    });
+    if (!is2xx(res.status)) return null;
+    const loc = prop(res.body, "location");
+    return typeof loc === "string" && loc !== "" ? loc : null;
+  } catch {
+    return null;
+  }
+}
+
+/** The full ARM resource id of the Log Analytics workspace (workbook sourceId). */
+export function workspaceResourceId(ws: WorkspaceScope): string {
+  return (
+    `/subscriptions/${ws.subscriptionId}` +
+    `/resourceGroups/${ws.resourceGroup}` +
+    `/providers/Microsoft.OperationalInsights/workspaces/${ws.workspaceName}`
+  );
+}
+
+function prop(value: unknown, key: string): unknown {
+  if (typeof value !== "object" || value === null) return undefined;
+  return (value as Record<string, unknown>)[key];
+}
+
+function errText(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/** Render a failed ARM response as the outcome detail (status + body). */
+function failDetail(res: PortHttpResponse): string {
+  let body: string;
+  try {
+    body = typeof res.body === "string" ? res.body : JSON.stringify(res.body);
+  } catch {
+    body = String(res.body);
+  }
+  return `HTTP ${res.status}${body && body !== "null" ? ` ${body}` : ""}`;
+}
+
+function is2xx(status: number): boolean {
+  return status >= 200 && status < 300;
+}
+
+// ---------------------------------------------------------------------------
+// Installed-state detection
+// ---------------------------------------------------------------------------
+
+/** What the workspace already has (drives the installable partition). */
+export interface InstalledContentState {
+  /** True when this solution's Content Hub package reports an installedVersion. */
+  solutionInstalled: boolean;
+  installedSolutionVersion: string | null;
+  /** LOWERCASED display names of alert rules already in the workspace. */
+  installedRuleNames: ReadonlySet<string>;
+  /** LOWERCASED display names of workbooks already linked to the workspace. */
+  installedWorkbookNames: ReadonlySet<string>;
+  /** Non-fatal notes (a listing that failed degrades to "unknown", not error). */
+  notes: string[];
+}
+
+/**
+ * Probe what the workspace already has. Each listing is best-effort: a
+ * failure degrades that dimension to empty + a note (so the UI offers
+ * install rather than hiding everything). `solutionContentId` is the Content
+ * Hub package contentId (from the catalog); omit to skip the solution probe.
+ */
+export async function installedContentState(
+  azure: AzureManagement,
+  ws: WorkspaceScope,
+  solutionContentId: string | undefined,
+  logger?: Logger,
+): Promise<InstalledContentState> {
+  const scope = workspaceInsightsScope(ws);
+  const notes: string[] = [];
+
+  let solutionInstalled = false;
+  let installedSolutionVersion: string | null = null;
+  if (solutionContentId !== undefined && solutionContentId !== "") {
+    try {
+      const packages = await listAllPages(
+        azure,
+        {
+          method: "GET",
+          path: `${scope}/contentPackages`,
+          apiVersion: SECURITY_INSIGHTS_API_VERSION,
+        },
+        "list installed content packages",
+      );
+      const match = packages.find(
+        (p) => prop(prop(p, "properties"), "contentId") === solutionContentId,
+      );
+      if (match !== undefined) {
+        solutionInstalled = true;
+        const v = prop(prop(match, "properties"), "version");
+        installedSolutionVersion = typeof v === "string" ? v : null;
+      }
+    } catch (err) {
+      notes.push(`Could not read installed solutions: ${errText(err)}`);
+    }
+  }
+
+  const installedRuleNames = new Set<string>();
+  try {
+    const rules = await listAllPages(
+      azure,
+      {
+        method: "GET",
+        path: `${scope}/alertRules`,
+        apiVersion: SECURITY_INSIGHTS_API_VERSION,
+      },
+      "list alert rules",
+    );
+    for (const r of rules) {
+      const name = prop(prop(r, "properties"), "displayName");
+      if (typeof name === "string") installedRuleNames.add(name.toLowerCase());
+    }
+  } catch (err) {
+    notes.push(`Could not read installed analytics rules: ${errText(err)}`);
+  }
+
+  const installedWorkbookNames = new Set<string>();
+  try {
+    const workbooks = await listAllPages(
+      azure,
+      {
+        method: "GET",
+        path:
+          `/subscriptions/${ws.subscriptionId}/resourceGroups/${ws.resourceGroup}` +
+          "/providers/Microsoft.Insights/workbooks",
+        apiVersion: WORKBOOKS_INSTALL_API_VERSION,
+        query: {
+          category: "sentinel",
+          sourceId: workspaceResourceId(ws).toLowerCase(),
+        },
+      },
+      "list workbooks",
+    );
+    for (const w of workbooks) {
+      const name = prop(prop(w, "properties"), "displayName");
+      if (typeof name === "string") installedWorkbookNames.add(name.toLowerCase());
+    }
+  } catch (err) {
+    notes.push(`Could not read installed workbooks: ${errText(err)}`);
+  }
+
+  logger?.info("content-install: installed state probed", {
+    solutionInstalled,
+    rules: installedRuleNames.size,
+    workbooks: installedWorkbookNames.size,
+  });
+
+  return {
+    solutionInstalled,
+    installedSolutionVersion,
+    installedRuleNames,
+    installedWorkbookNames,
+    notes,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Analytics-rule install
+// ---------------------------------------------------------------------------
+
+/** Install one parsed analytics rule; resolves an outcome (never throws). */
+export async function installAnalyticRule(
+  azure: AzureManagement,
+  ws: WorkspaceScope,
+  rule: ParsedAnalyticRule,
+  mintId: () => string,
+): Promise<ContentInstallOutcome> {
+  const resource = alertRuleResourceFromParsed(rule);
+  if (!resource.supported) {
+    return { name: rule.name, ok: false, detail: `skipped: ${resource.reason}` };
+  }
+  const ruleId = /^[0-9a-f-]{36}$/i.test(rule.id) ? rule.id : mintId();
+  const apiVersion =
+    resource.kind === "NRT"
+      ? SECURITY_INSIGHTS_PREVIEW_API_VERSION
+      : SECURITY_INSIGHTS_API_VERSION;
+  try {
+    const res = await azure.request({
+      method: "PUT",
+      path: `${workspaceInsightsScope(ws)}/alertRules/${ruleId}`,
+      apiVersion,
+      body: resource.body,
+    });
+    return is2xx(res.status)
+      ? { name: rule.name, ok: true, detail: `installed (${resource.kind})` }
+      : { name: rule.name, ok: false, detail: failDetail(res) };
+  } catch (err) {
+    return { name: rule.name, ok: false, detail: errText(err) };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Workbook install
+// ---------------------------------------------------------------------------
+
+/** One workbook to install: its display name and serialized document. */
+export interface WorkbookInstallSpec {
+  displayName: string;
+  serializedData: string;
+}
+
+/** Install one workbook linked to the workspace; resolves an outcome. */
+export async function installWorkbook(
+  azure: AzureManagement,
+  ws: WorkspaceScope,
+  spec: WorkbookInstallSpec,
+  mintId: () => string,
+): Promise<ContentInstallOutcome> {
+  const body = workbookResourceBody({
+    displayName: spec.displayName,
+    serializedData: spec.serializedData,
+    workspaceResourceId: workspaceResourceId(ws),
+    location: ws.location,
+  });
+  try {
+    const res = await azure.request({
+      method: "PUT",
+      path:
+        `/subscriptions/${ws.subscriptionId}/resourceGroups/${ws.resourceGroup}` +
+        `/providers/Microsoft.Insights/workbooks/${mintId()}`,
+      apiVersion: WORKBOOKS_INSTALL_API_VERSION,
+      body,
+    });
+    return is2xx(res.status)
+      ? { name: spec.displayName, ok: true, detail: "installed" }
+      : { name: spec.displayName, ok: false, detail: failDetail(res) };
+  } catch (err) {
+    return { name: spec.displayName, ok: false, detail: errText(err) };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Parser install (savedSearches Function) - a DEPENDENCY of rules/workbooks
+// ---------------------------------------------------------------------------
+
+/**
+ * Install one solution parser as a savedSearches Function; resolves an
+ * outcome. Parsers are installed as a DEPENDENCY when rules/workbooks are
+ * installed (they query the function by alias), not as a user choice - so
+ * the UI reports them but never asks. The savedSearch id is derived from the
+ * alias (deterministic + idempotent: a re-install PUTs over the same id).
+ */
+export async function installParser(
+  azure: AzureManagement,
+  ws: WorkspaceScope,
+  parser: ParserResource,
+): Promise<ContentInstallOutcome> {
+  const searchId = `parser-${parser.alias}`.toLowerCase().replace(/[^a-z0-9-]/g, "-");
+  try {
+    const res = await azure.request({
+      method: "PUT",
+      path: `${workspaceResourceId(ws)}/savedSearches/${searchId}`,
+      apiVersion: SAVED_SEARCHES_API_VERSION,
+      body: parserResourceBody(parser),
+    });
+    return is2xx(res.status)
+      ? { name: `${parser.displayName} (parser)`, ok: true, detail: "installed" }
+      : { name: `${parser.displayName} (parser)`, ok: false, detail: failDetail(res) };
+  } catch (err) {
+    return { name: `${parser.displayName} (parser)`, ok: false, detail: errText(err) };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Solution install (Content Hub)
+// ---------------------------------------------------------------------------
+
+/**
+ * Install a Content Hub solution: GET the product package's packagedContent
+ * ARM template, then deploy it via a Microsoft.Resources/deployments PUT
+ * (the documented flow). `packageId` is the contentPackages/-scoped package
+ * name (from the catalog listing's `name`). Resolves an outcome.
+ *
+ * The packagedContent field name has drifted across doc/samples
+ * (packagedContent / mainTemplate / packageContent) - all three are tried.
+ */
+export async function installSolution(
+  azure: AzureManagement,
+  ws: WorkspaceScope,
+  packageId: string,
+  displayName: string,
+  logger?: Logger,
+): Promise<ContentInstallOutcome> {
+  try {
+    const pkg = await azure.request({
+      method: "GET",
+      path: `${workspaceInsightsScope(ws)}/contentProductPackages/${packageId}`,
+      apiVersion: SECURITY_INSIGHTS_API_VERSION,
+    });
+    if (!is2xx(pkg.status)) {
+      return { name: displayName, ok: false, detail: failDetail(pkg) };
+    }
+    const props = prop(pkg.body, "properties");
+    const template =
+      prop(props, "packagedContent") ??
+      prop(props, "mainTemplate") ??
+      prop(props, "packageContent");
+    if (template === undefined || template === null) {
+      return {
+        name: displayName,
+        ok: false,
+        detail: "the product package returned no deployable template (packagedContent)",
+      };
+    }
+    const deploymentName = `sentinel-solution-${packageId}`.slice(0, 64);
+    const res = await azure.request({
+      method: "PUT",
+      path:
+        `/subscriptions/${ws.subscriptionId}/resourceGroups/${ws.resourceGroup}` +
+        `/providers/Microsoft.Resources/deployments/${deploymentName}`,
+      apiVersion: DEPLOYMENTS_API_VERSION,
+      body: {
+        properties: {
+          mode: "Incremental",
+          template,
+          parameters: {
+            workspace: { value: ws.workspaceName },
+            "workspace-location": { value: ws.location },
+          },
+        },
+      },
+    });
+    logger?.info("content-install: solution deploy issued", {
+      packageId,
+      status: res.status,
+    });
+    return is2xx(res.status)
+      ? { name: displayName, ok: true, detail: "solution deployment accepted" }
+      : { name: displayName, ok: false, detail: failDetail(res) };
+  } catch (err) {
+    return { name: displayName, ok: false, detail: errText(err) };
+  }
+}

--- a/soc-optimizationtoolkit/packages/core/src/usecases/content-install/index.ts
+++ b/soc-optimizationtoolkit/packages/core/src/usecases/content-install/index.ts
@@ -1,0 +1,30 @@
+export type {
+  InstalledContentState,
+  WorkbookInstallSpec,
+  WorkspaceScope,
+} from "./content-install";
+export {
+  DEPLOYMENTS_API_VERSION,
+  SAVED_SEARCHES_API_VERSION,
+  SECURITY_INSIGHTS_API_VERSION,
+  SECURITY_INSIGHTS_PREVIEW_API_VERSION,
+  WORKBOOKS_INSTALL_API_VERSION,
+  WORKSPACE_READ_API_VERSION,
+  fetchWorkspaceLocation,
+  installAnalyticRule,
+  installParser,
+  installSolution,
+  installWorkbook,
+  installedContentState,
+  workspaceResourceId,
+} from "./content-install";
+export type {
+  AvailableWorkbook,
+  SolutionCatalogEntry,
+} from "./available-content";
+export {
+  availableAnalyticRules,
+  availableParsers,
+  availableWorkbooks,
+  findSolutionCatalogEntry,
+} from "./available-content";

--- a/soc-optimizationtoolkit/packages/core/src/usecases/index.ts
+++ b/soc-optimizationtoolkit/packages/core/src/usecases/index.ts
@@ -16,3 +16,4 @@ export * from "./install-pack";
 export * from "./dcr-inventory";
 export * from "./update-dcr";
 export * from "./siem-migration";
+export * from "./content-install";

--- a/soc-optimizationtoolkit/packages/ui/src/index.ts
+++ b/soc-optimizationtoolkit/packages/ui/src/index.ts
@@ -462,6 +462,25 @@ export { ArchitectureScreen } from "./screens/architecture/architecture-screen";
 export { MappingCatalogScreen } from "./screens/mapping-catalog/mapping-catalog-screen";
 export { EventHubDiscoveryScreen } from "./screens/eventhub-discovery/eventhub-discovery-screen";
 
+// Enable Sentinel Content (user feature 2026-07-14): install the solution,
+// its analytics rules, and its workbooks (choosing which), with installed-
+// state detection, custom uploads, auto parser dependency, and per-item
+// install outcomes. Rendered as Integrate section 6.
+export { ContentInstallSection } from "./screens/content-install/content-install-section";
+export type { ContentInstallSectionProps } from "./screens/content-install/content-install-section";
+export {
+  partitionOutcomes,
+  selectAll,
+  selectionLabel,
+  splitRules,
+  splitWorkbooks,
+  toggleName,
+} from "./screens/content-install/content-install-state";
+export type {
+  SelectableRule,
+  SelectableWorkbook,
+} from "./screens/content-install/content-install-state";
+
 // SIEM Migration (porting-plan Unit 26, ENG-40 + GUI-22): the rebuilt
 // migration analyzer - upload a Splunk/QRadar export, map its data sources
 // to Sentinel solutions, enrich with the solutions' analytics rules, pivot

--- a/soc-optimizationtoolkit/packages/ui/src/screens/content-install/content-install-section.tsx
+++ b/soc-optimizationtoolkit/packages/ui/src/screens/content-install/content-install-section.tsx
@@ -1,0 +1,576 @@
+/**
+ * ContentInstallSection (user feature 2026-07-14) - the Integrate page's
+ * "Enable Sentinel Content" section: install the Content Hub solution, its
+ * analytics rules, and its workbooks into the workspace, choosing which of
+ * each. It checks what is ALREADY installed (so only installable items are
+ * offered), accepts custom analytics-rule and workbook uploads, and reports
+ * a per-item success/failure outcome for every install (user requirement).
+ *
+ * Parsers the rules/workbooks depend on are installed AUTOMATICALLY as a
+ * dependency (they are queried by alias; a missing function breaks the rule),
+ * indicated but never asked - mirroring Content Hub (user direction).
+ *
+ * INFORMATIONAL and Sentinel-side: it never gates the Cribl deploy. All IO
+ * rides the existing AzureManagement port (management.azure.com) and the
+ * SentinelContent port (repo rules/workbooks/parsers) - no new external
+ * surface. Pure decisions live in content-install-state.
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  availableAnalyticRules,
+  availableParsers,
+  availableWorkbooks,
+  alertRuleResourceFromParsed,
+  fetchWorkspaceLocation,
+  findSolutionCatalogEntry,
+  installAnalyticRule,
+  installParser,
+  installSolution,
+  installWorkbook,
+  installedContentState,
+  parseWorkbookUpload,
+  parseRuleUploadFile,
+  parseAnalyticRuleYaml,
+  summarizeInstallOutcomes,
+} from "@soc/core";
+import type {
+  AvailableWorkbook,
+  ContentInstallOutcome,
+  InstalledContentState,
+  ParsedAnalyticRule,
+  ParserResource,
+  SolutionCatalogEntry,
+  WorkspaceScope,
+} from "@soc/core";
+import { usePorts } from "../../ports-context";
+import { InfoTip } from "../../components/info-tip";
+import {
+  partitionOutcomes,
+  selectAll,
+  splitRules,
+  splitWorkbooks,
+  toggleName,
+} from "./content-install-state";
+
+export interface ContentInstallSectionProps {
+  /** The selected Sentinel solution (scopes the content lookup); "" when none. */
+  solutionName: string;
+  /** Whether a full Azure target scope is committed (needed to install). */
+  scopeCommitted: boolean;
+  /** Diagnostics sink (optional). */
+}
+
+/** Reused across renders; the shell's GUID minter is required to install. */
+export function ContentInstallSection({
+  solutionName,
+  scopeCommitted,
+}: ContentInstallSectionProps) {
+  const { ports, config } = usePorts();
+  const mintId = ports.mintAssignmentName;
+  const content = ports.content;
+
+  const [loading, setLoading] = useState(false);
+  const [loadError, setLoadError] = useState("");
+  const [catalog, setCatalog] = useState<SolutionCatalogEntry | null>(null);
+  const [installed, setInstalled] = useState<InstalledContentState | null>(null);
+  const [rules, setRules] = useState<ParsedAnalyticRule[]>([]);
+  const [workbooks, setWorkbooks] = useState<AvailableWorkbook[]>([]);
+  const [parsers, setParsers] = useState<ParserResource[]>([]);
+  const [location, setLocation] = useState<string | null>(null);
+
+  // Custom uploads merged into the installable pools.
+  const [customRules, setCustomRules] = useState<ParsedAnalyticRule[]>([]);
+  const [customWorkbooks, setCustomWorkbooks] = useState<AvailableWorkbook[]>([]);
+
+  // Selections (by display name) and per-group busy/outcome state.
+  const [ruleSel, setRuleSel] = useState<Set<string>>(new Set());
+  const [wbSel, setWbSel] = useState<Set<string>>(new Set());
+  const [busy, setBusy] = useState<"" | "solution" | "rules" | "workbooks">("");
+  const [outcomes, setOutcomes] = useState<ContentInstallOutcome[]>([]);
+  const [progress, setProgress] = useState("");
+  const ruleFileRef = useRef<HTMLInputElement | null>(null);
+  const wbFileRef = useRef<HTMLInputElement | null>(null);
+
+  const scope = useMemo<WorkspaceScope>(
+    () => ({
+      subscriptionId: config.subscriptionId,
+      resourceGroup: config.resourceGroup,
+      workspaceName: config.workspaceName,
+      location: location ?? "",
+    }),
+    [config, location],
+  );
+
+  const canInstall =
+    scopeCommitted &&
+    mintId !== undefined &&
+    config.subscriptionId !== "" &&
+    config.resourceGroup !== "" &&
+    config.workspaceName !== "";
+
+  // Load the catalog entry, installed state, and available content on demand.
+  const load = useCallback(async () => {
+    if (content === undefined || solutionName.trim() === "") return;
+    setLoading(true);
+    setLoadError("");
+    setOutcomes([]);
+    try {
+      const entry = scopeCommitted
+        ? await findSolutionCatalogEntry(ports.azure, scope, solutionName, ports.logger)
+        : null;
+      setCatalog(entry);
+      const state = scopeCommitted
+        ? await installedContentState(ports.azure, scope, entry?.contentId, ports.logger)
+        : null;
+      setInstalled(state);
+      const [repoRules, repoWorkbooks, repoParsers] = await Promise.all([
+        availableAnalyticRules(content, solutionName),
+        availableWorkbooks(content, solutionName),
+        availableParsers(content, solutionName),
+      ]);
+      setRules(repoRules);
+      setWorkbooks(repoWorkbooks);
+      setParsers(repoParsers);
+      if (scopeCommitted) {
+        setLocation(
+          await fetchWorkspaceLocation(
+            ports.azure,
+            config.subscriptionId,
+            config.resourceGroup,
+            config.workspaceName,
+          ),
+        );
+      }
+    } catch (err) {
+      setLoadError(String(err));
+    } finally {
+      setLoading(false);
+    }
+  }, [content, solutionName, scopeCommitted, ports, scope, config]);
+
+  // Reset when the solution changes (the section is keyed by solution too).
+  useEffect(() => {
+    setCatalog(null);
+    setInstalled(null);
+    setRules([]);
+    setWorkbooks([]);
+    setParsers([]);
+    setCustomRules([]);
+    setCustomWorkbooks([]);
+    setRuleSel(new Set());
+    setWbSel(new Set());
+    setOutcomes([]);
+  }, [solutionName]);
+
+  const allRules = useMemo(() => [...rules, ...customRules], [rules, customRules]);
+  const allWorkbooks = useMemo(
+    () => [...workbooks, ...customWorkbooks],
+    [workbooks, customWorkbooks],
+  );
+  const ruleSplit = useMemo(
+    () =>
+      installed !== null
+        ? splitRules(allRules, installed)
+        : { installed: [], installable: allRules },
+    [allRules, installed],
+  );
+  const wbSplit = useMemo(
+    () =>
+      installed !== null
+        ? splitWorkbooks(allWorkbooks, installed)
+        : { installed: [], installable: allWorkbooks },
+    [allWorkbooks, installed],
+  );
+
+  // Custom rule uploads: parse each file as a Sentinel rule YAML (the full
+  // install-field extraction - scheduling block, entity mappings). Files that
+  // yield no query are dropped. Portal ARM JSON / raw KQL are surfaced via
+  // parseRuleUploadFile only when the YAML parse finds nothing installable,
+  // so a KQL-only upload still installs as a minimal scheduled rule.
+  const onUploadRules = useCallback(async (files: FileList | null) => {
+    const parsed: ParsedAnalyticRule[] = [];
+    for (const file of files ?? []) {
+      const text = await file.text();
+      const lower = file.name.toLowerCase();
+      // YAML: the full install-field extraction (scheduling, entity mappings).
+      // Everything else (portal ARM JSON, raw KQL) rides parseRuleUploadFile,
+      // which also returns ParsedAnalyticRules.
+      if (lower.endsWith(".yaml") || lower.endsWith(".yml")) {
+        const yaml = parseAnalyticRuleYaml(text, file.name);
+        if (yaml.query.trim() !== "") parsed.push(yaml);
+      } else {
+        parsed.push(...parseRuleUploadFile(file.name, text).filter((r) => r.query.trim() !== ""));
+      }
+    }
+    if (parsed.length > 0) setCustomRules((prev) => [...prev, ...parsed]);
+    if (ruleFileRef.current !== null) ruleFileRef.current.value = "";
+  }, []);
+
+  const onUploadWorkbooks = useCallback(async (files: FileList | null) => {
+    const parsed: AvailableWorkbook[] = [];
+    for (const file of files ?? []) {
+      const text = await file.text();
+      const wb = parseWorkbookUpload(file.name, text);
+      if (wb !== null) {
+        parsed.push({ displayName: wb.displayName, serializedData: wb.serializedData });
+      }
+    }
+    if (parsed.length > 0) setCustomWorkbooks((prev) => [...prev, ...parsed]);
+    if (wbFileRef.current !== null) wbFileRef.current.value = "";
+  }, []);
+
+  // Install the referenced parsers as a dependency (best-effort, reported).
+  const installParsers = useCallback(async (): Promise<ContentInstallOutcome[]> => {
+    if (mintId === undefined || parsers.length === 0) return [];
+    const out: ContentInstallOutcome[] = [];
+    for (const parser of parsers) {
+      setProgress(`Installing parser ${parser.displayName}...`);
+      out.push(await installParser(ports.azure, scope, parser));
+    }
+    return out;
+  }, [parsers, ports, scope, mintId]);
+
+  const doInstallSolution = useCallback(async () => {
+    if (catalog === null || !canInstall) return;
+    setBusy("solution");
+    setOutcomes([]);
+    try {
+      setProgress(`Installing solution ${catalog.displayName}...`);
+      const outcome = await installSolution(
+        ports.azure,
+        scope,
+        catalog.packageId,
+        catalog.displayName,
+        ports.logger,
+      );
+      setOutcomes([outcome]);
+    } finally {
+      setBusy("");
+      setProgress("");
+      void load();
+    }
+  }, [catalog, canInstall, ports, scope, load]);
+
+  const doInstallRules = useCallback(async () => {
+    if (mintId === undefined || !canInstall) return;
+    setBusy("rules");
+    setOutcomes([]);
+    try {
+      const selected = ruleSplit.installable.filter((r) => ruleSel.has(r.name));
+      const parserOutcomes = await installParsers();
+      const ruleOutcomes: ContentInstallOutcome[] = [];
+      let done = 0;
+      for (const rule of selected) {
+        setProgress(`Installing rule ${++done}/${selected.length}: ${rule.name}...`);
+        ruleOutcomes.push(await installAnalyticRule(ports.azure, scope, rule, mintId));
+      }
+      setOutcomes([...parserOutcomes, ...ruleOutcomes]);
+    } finally {
+      setBusy("");
+      setProgress("");
+      void load();
+    }
+  }, [mintId, canInstall, ruleSplit, ruleSel, installParsers, ports, scope, load]);
+
+  const doInstallWorkbooks = useCallback(async () => {
+    if (mintId === undefined || !canInstall) return;
+    setBusy("workbooks");
+    setOutcomes([]);
+    try {
+      const selected = wbSplit.installable.filter((w) => wbSel.has(w.displayName));
+      const parserOutcomes = await installParsers();
+      const wbOutcomes: ContentInstallOutcome[] = [];
+      let done = 0;
+      for (const wb of selected) {
+        setProgress(`Installing workbook ${++done}/${selected.length}: ${wb.displayName}...`);
+        wbOutcomes.push(
+          await installWorkbook(
+            ports.azure,
+            scope,
+            { displayName: wb.displayName, serializedData: wb.serializedData },
+            mintId,
+          ),
+        );
+      }
+      setOutcomes([...parserOutcomes, ...wbOutcomes]);
+    } finally {
+      setBusy("");
+      setProgress("");
+      void load();
+    }
+  }, [mintId, canInstall, wbSplit, wbSel, installParsers, ports, scope, load]);
+
+  if (content === undefined) {
+    return (
+      <p className="panel-desc">
+        GitHub content access is not available in this build - the Repositories
+        surface binds it. Solution content cannot be listed here.
+      </p>
+    );
+  }
+
+  if (solutionName.trim() === "") {
+    return (
+      <p className="panel-desc">
+        Select a Sentinel solution in section 1 to enable its content.
+      </p>
+    );
+  }
+
+  const grouped = partitionOutcomes(outcomes);
+
+  return (
+    <div className="content-install">
+      {!scopeCommitted && (
+        <p className="connection-notice">
+          Commit an Azure target scope (Select Azure Resources) to check what is
+          installed and to install content. You can still preview the solution&apos;s
+          rules and workbooks below.
+        </p>
+      )}
+
+      <div className="panel-controls">
+        <button
+          className="run-button"
+          onClick={() => void load()}
+          disabled={loading || busy !== ""}
+        >
+          {loading ? "Loading..." : "Load solution content"}
+        </button>
+        {mintId === undefined && (
+          <span className="field-hint">
+            Installs are unavailable: the shell did not provide an id minter.
+          </span>
+        )}
+      </div>
+      {loadError !== "" && <pre className="result">{loadError}</pre>}
+      {installed !== null &&
+        installed.notes.map((note, i) => (
+          <p key={i} className="field-hint">{note}</p>
+        ))}
+
+      {/* SOLUTION */}
+      <section className="content-install-group">
+        <h3 className="content-install-title">
+          Solution{" "}
+          <InfoTip text="Install the Content Hub solution package itself (its ARM template, deployed to your workspace). This brings in the solution's own rule/workbook/parser definitions the same way the portal Content Hub does." />
+        </h3>
+        {catalog === null ? (
+          <p className="panel-desc">
+            {scopeCommitted
+              ? "Load to look up this solution in Content Hub."
+              : "Commit a target scope, then load to look up the Content Hub package."}
+          </p>
+        ) : catalog.installedVersion !== null ? (
+          <p className="content-install-installed">
+            Installed (version {catalog.installedVersion}). Latest available:{" "}
+            {catalog.version}.
+          </p>
+        ) : (
+          <div className="panel-controls">
+            <span className="panel-desc">
+              {catalog.displayName} {catalog.version} - not installed.
+            </span>
+            <button
+              className="run-button"
+              onClick={() => void doInstallSolution()}
+              disabled={!canInstall || busy !== ""}
+            >
+              {busy === "solution" ? "Installing..." : "Install solution"}
+            </button>
+          </div>
+        )}
+      </section>
+
+      {/* ANALYTICS RULES */}
+      <ContentGroup
+        title="Analytics rules"
+        tip="Install the solution's analytics rules (Scheduled and NRT). Already-installed rules are shown for reference; only installable ones are selectable. Parsers the rules query are installed automatically."
+        installable={ruleSplit.installable.map((r) => ({
+          name: r.name,
+          detail: alertRuleResourceFromParsed(r).supported
+            ? (r.severity || "")
+            : "not installable (managed rule type)",
+          disabled: !alertRuleResourceFromParsed(r).supported,
+        }))}
+        installedNames={ruleSplit.installed.map((r) => r.name)}
+        selection={ruleSel}
+        onToggle={(name) => setRuleSel((s) => toggleName(s, name))}
+        onSelectAll={() =>
+          setRuleSel(
+            selectAll(
+              ruleSplit.installable
+                .filter((r) => alertRuleResourceFromParsed(r).supported)
+                .map((r) => r.name),
+            ),
+          )
+        }
+        onClear={() => setRuleSel(new Set())}
+        onInstall={() => void doInstallRules()}
+        installing={busy === "rules"}
+        canInstall={canInstall}
+        uploadRef={ruleFileRef}
+        uploadAccept=".yaml,.yml,.json,.kql,.txt"
+        onUpload={onUploadRules}
+        uploadLabel="Upload custom rules"
+      />
+
+      {/* WORKBOOKS */}
+      <ContentGroup
+        title="Workbooks"
+        tip="Install the solution's workbooks, linked to your workspace. Upload custom workbooks (gallery-template JSON or a portal ARM export) to install alongside."
+        installable={wbSplit.installable.map((w) => ({ name: w.displayName, detail: "" }))}
+        installedNames={wbSplit.installed.map((w) => w.displayName)}
+        selection={wbSel}
+        onToggle={(name) => setWbSel((s) => toggleName(s, name))}
+        onSelectAll={() =>
+          setWbSel(selectAll(wbSplit.installable.map((w) => w.displayName)))
+        }
+        onClear={() => setWbSel(new Set())}
+        onInstall={() => void doInstallWorkbooks()}
+        installing={busy === "workbooks"}
+        canInstall={canInstall}
+        uploadRef={wbFileRef}
+        uploadAccept=".json"
+        onUpload={onUploadWorkbooks}
+        uploadLabel="Upload custom workbooks"
+      />
+
+      {parsers.length > 0 && (
+        <p className="field-hint">
+          {parsers.length} solution parser(s) will be installed automatically
+          with any rules or workbooks that depend on them.
+        </p>
+      )}
+
+      {progress !== "" && <p className="panel-desc">{progress}</p>}
+      {outcomes.length > 0 && (
+        <div className="content-install-outcomes">
+          <p className="panel-desc">
+            <strong>{summarizeInstallOutcomes(outcomes)}</strong>
+          </p>
+          {grouped.failed.map((o, i) => (
+            <p key={`f-${i}`} className="match-warning match-warning-overflow-loss">
+              {o.name}: {o.detail}
+            </p>
+          ))}
+          {grouped.ok.map((o, i) => (
+            <p key={`o-${i}`} className="content-install-ok">
+              {o.name}: {o.detail}
+            </p>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** One installable content group (rules or workbooks): list + install + upload. */
+function ContentGroup({
+  title,
+  tip,
+  installable,
+  installedNames,
+  selection,
+  onToggle,
+  onSelectAll,
+  onClear,
+  onInstall,
+  installing,
+  canInstall,
+  uploadRef,
+  uploadAccept,
+  onUpload,
+  uploadLabel,
+}: {
+  title: string;
+  tip: string;
+  installable: Array<{ name: string; detail: string; disabled?: boolean }>;
+  installedNames: string[];
+  selection: ReadonlySet<string>;
+  onToggle: (name: string) => void;
+  onSelectAll: () => void;
+  onClear: () => void;
+  onInstall: () => void;
+  installing: boolean;
+  canInstall: boolean;
+  uploadRef: React.RefObject<HTMLInputElement | null>;
+  uploadAccept: string;
+  onUpload: (files: FileList | null) => void | Promise<void>;
+  uploadLabel: string;
+}) {
+  const selectedCount = installable.filter(
+    (i) => selection.has(i.name) && i.disabled !== true,
+  ).length;
+  return (
+    <section className="content-install-group">
+      <h3 className="content-install-title">
+        {title} <InfoTip text={tip} />
+      </h3>
+      {installable.length === 0 && installedNames.length === 0 ? (
+        <p className="panel-desc">None found for this solution.</p>
+      ) : (
+        <>
+          {installable.length > 0 && (
+            <div className="content-install-list">
+              {installable.map((item) => (
+                <label key={item.name} className="content-install-row">
+                  <input
+                    type="checkbox"
+                    checked={selection.has(item.name)}
+                    disabled={item.disabled === true}
+                    onChange={() => onToggle(item.name)}
+                  />
+                  <span>{item.name}</span>
+                  {item.detail !== "" && (
+                    <span className="field-hint">{item.detail}</span>
+                  )}
+                </label>
+              ))}
+            </div>
+          )}
+          {installedNames.length > 0 && (
+            <details className="gap-handles">
+              <summary>{installedNames.length} already installed</summary>
+              <div className="gap-handles-body">
+                {installedNames.map((n) => (
+                  <div key={n}>{n}</div>
+                ))}
+              </div>
+            </details>
+          )}
+          <div className="panel-controls">
+            <button
+              className="run-button"
+              onClick={onInstall}
+              disabled={!canInstall || installing || selectedCount === 0}
+            >
+              {installing
+                ? "Installing..."
+                : `Install selected (${selectedCount})`}
+            </button>
+            {installable.length > 0 && (
+              <>
+                <button className="run-button" onClick={onSelectAll}>
+                  Select all
+                </button>
+                <button className="run-button" onClick={onClear}>
+                  Clear
+                </button>
+              </>
+            )}
+            <input
+              ref={uploadRef}
+              type="file"
+              multiple
+              accept={uploadAccept}
+              onChange={(e) => void onUpload(e.target.files)}
+              aria-label={uploadLabel}
+            />
+          </div>
+        </>
+      )}
+    </section>
+  );
+}

--- a/soc-optimizationtoolkit/packages/ui/src/screens/content-install/content-install-state.test.ts
+++ b/soc-optimizationtoolkit/packages/ui/src/screens/content-install/content-install-state.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Pins for the content-install section's pure state (2026-07-14): the
+ * installed/installable split, the selection toggles, and the outcome
+ * partition.
+ */
+
+import { describe, expect, it } from "vitest";
+import type {
+  AvailableWorkbook,
+  ContentInstallOutcome,
+  InstalledContentState,
+  ParsedAnalyticRule,
+} from "@soc/core";
+import {
+  partitionOutcomes,
+  selectAll,
+  splitRules,
+  splitWorkbooks,
+  toggleName,
+} from "./content-install-state";
+
+function rule(name: string): ParsedAnalyticRule {
+  return {
+    id: name,
+    name,
+    severity: "Medium",
+    tactics: [],
+    dataTypes: [],
+    query: "T | take 1",
+    entityFields: [],
+    fileName: `${name}.yaml`,
+  };
+}
+
+function state(over: Partial<InstalledContentState>): InstalledContentState {
+  return {
+    solutionInstalled: false,
+    installedSolutionVersion: null,
+    installedRuleNames: new Set(),
+    installedWorkbookNames: new Set(),
+    notes: [],
+    ...over,
+  };
+}
+
+describe("splitRules / splitWorkbooks", () => {
+  it("splits available content on case-insensitive installed names", () => {
+    const rules = [rule("Bad IP"), rule("New Rule")];
+    const split = splitRules(rules, state({ installedRuleNames: new Set(["bad ip"]) }));
+    expect(split.installed.map((r) => r.name)).toEqual(["Bad IP"]);
+    expect(split.installable.map((r) => r.name)).toEqual(["New Rule"]);
+  });
+
+  it("splits workbooks the same way", () => {
+    const wbs: AvailableWorkbook[] = [
+      { displayName: "Overview", serializedData: "{}" },
+      { displayName: "Fresh", serializedData: "{}" },
+    ];
+    const split = splitWorkbooks(wbs, state({ installedWorkbookNames: new Set(["overview"]) }));
+    expect(split.installed.map((w) => w.displayName)).toEqual(["Overview"]);
+    expect(split.installable.map((w) => w.displayName)).toEqual(["Fresh"]);
+  });
+});
+
+describe("selection helpers", () => {
+  it("toggles a name in and out immutably", () => {
+    const a = toggleName(new Set<string>(), "X");
+    expect([...a]).toEqual(["X"]);
+    const b = toggleName(a, "X");
+    expect([...b]).toEqual([]);
+    expect([...a]).toEqual(["X"]); // original untouched
+  });
+
+  it("selects all provided names", () => {
+    expect([...selectAll(["A", "B"])].sort()).toEqual(["A", "B"]);
+  });
+});
+
+describe("partitionOutcomes", () => {
+  it("groups by success", () => {
+    const outcomes: ContentInstallOutcome[] = [
+      { name: "a", ok: true, detail: "installed" },
+      { name: "b", ok: false, detail: "HTTP 400" },
+    ];
+    const { ok, failed } = partitionOutcomes(outcomes);
+    expect(ok.map((o) => o.name)).toEqual(["a"]);
+    expect(failed.map((o) => o.name)).toEqual(["b"]);
+  });
+});

--- a/soc-optimizationtoolkit/packages/ui/src/screens/content-install/content-install-state.ts
+++ b/soc-optimizationtoolkit/packages/ui/src/screens/content-install/content-install-state.ts
@@ -1,0 +1,90 @@
+/**
+ * Content-install section state (user feature 2026-07-14) - the PURE
+ * projections behind the "Enable Sentinel Content" section, kept out of the
+ * component so the selection accounting, the installed/installable split, and
+ * the outcome summaries are unit-testable without a DOM.
+ *
+ * Pure: no IO, no fetch, no React.
+ */
+
+import { partitionByInstalled } from "@soc/core";
+import type {
+  AvailableWorkbook,
+  InstalledContentState,
+  ContentInstallOutcome,
+  ParsedAnalyticRule,
+} from "@soc/core";
+
+/** A selectable content item with its checked state. */
+export interface SelectableRule {
+  rule: ParsedAnalyticRule;
+  /** Already in the workspace (rendered disabled + "installed"). */
+  installed: boolean;
+  /** The install-support reason when the rule is not installable at all. */
+  unsupportedReason?: string;
+}
+
+export interface SelectableWorkbook {
+  workbook: AvailableWorkbook;
+  installed: boolean;
+}
+
+/** Split available rules into installed vs installable by display name. */
+export function splitRules(
+  rules: readonly ParsedAnalyticRule[],
+  state: InstalledContentState,
+): { installed: ParsedAnalyticRule[]; installable: ParsedAnalyticRule[] } {
+  return partitionByInstalled(rules, state.installedRuleNames, (r) => r.name);
+}
+
+/** Split available workbooks into installed vs installable by display name. */
+export function splitWorkbooks(
+  workbooks: readonly AvailableWorkbook[],
+  state: InstalledContentState,
+): { installed: AvailableWorkbook[]; installable: AvailableWorkbook[] } {
+  return partitionByInstalled(
+    workbooks,
+    state.installedWorkbookNames,
+    (w) => w.displayName,
+  );
+}
+
+/** How many of `names` are selected (checked and present in the set). */
+export function selectedCount(selection: ReadonlySet<string>): number {
+  return selection.size;
+}
+
+/** A short "N of M selected" label for a group's install button. */
+export function selectionLabel(
+  selectedNames: ReadonlySet<string>,
+  installableCount: number,
+): string {
+  return `${selectedNames.size} of ${installableCount} selected`;
+}
+
+/** Group an outcome list by success for compact rendering. */
+export function partitionOutcomes(outcomes: readonly ContentInstallOutcome[]): {
+  ok: ContentInstallOutcome[];
+  failed: ContentInstallOutcome[];
+} {
+  return {
+    ok: outcomes.filter((o) => o.ok),
+    failed: outcomes.filter((o) => !o.ok),
+  };
+}
+
+/** A stable set with `name` toggled (case-preserving; membership by exact string). */
+export function toggleName(
+  set: ReadonlySet<string>,
+  name: string,
+): Set<string> {
+  const next = new Set(set);
+  if (next.has(name)) next.delete(name);
+  else next.add(name);
+  return next;
+}
+
+/** Select every installable name (the "select all" affordance). */
+export function selectAll(names: readonly string[]): Set<string> {
+  return new Set(names);
+}

--- a/soc-optimizationtoolkit/packages/ui/src/screens/integrate/integrate-screen.tsx
+++ b/soc-optimizationtoolkit/packages/ui/src/screens/integrate/integrate-screen.tsx
@@ -110,6 +110,7 @@ import { derivePipelinePreview } from "../pipeline-preview/pipeline-preview-stat
 import type { EnrichmentField } from "../pipeline-preview/pipeline-preview-state";
 import { SolutionBrowser } from "../solution-browser/solution-browser";
 import { RuleCoverageSection } from "../rule-coverage/rule-coverage-section";
+import { ContentInstallSection } from "../content-install/content-install-section";
 import {
   SearchableMultiSelect,
   SearchableSelect,
@@ -1085,6 +1086,17 @@ export function IntegrateScreen({
     />
   );
 
+  // Enable Sentinel Content (section 6): install the solution, its analytics
+  // rules, and its workbooks - Sentinel-side, informational, never gates the
+  // deploy. Keyed by solution so switching solutions resets its state.
+  const enableContentBody = (
+    <ContentInstallSection
+      key={`content-${solution?.name ?? "none"}`}
+      solutionName={solution?.name ?? ""}
+      scopeCommitted={scopeCommitted}
+    />
+  );
+
   const azureResourcesBody = (
     <>
       <AzureTargetingScreen offline={offline} onCommitScope={onCommitScope} />
@@ -1488,6 +1500,8 @@ export function IntegrateScreen({
         return ruleCoverageBody;
       case "workbook-coverage":
         return workbookCoverageBody;
+      case "enable-content":
+        return enableContentBody;
       case "deploy":
         return deployBody;
       default:

--- a/soc-optimizationtoolkit/packages/ui/src/styles.css
+++ b/soc-optimizationtoolkit/packages/ui/src/styles.css
@@ -2486,6 +2486,46 @@ button.journey-step-main:hover .journey-step-label {
   background: var(--warn-bg);
 }
 
+/* Enable Sentinel Content (content-install section). */
+.content-install-group {
+  border-top: 1px solid var(--border);
+  padding-top: 12px;
+  margin-top: 12px;
+}
+.content-install-title {
+  font-size: 14px;
+  font-weight: 700;
+  margin: 0 0 8px;
+}
+.content-install-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  max-height: 260px;
+  overflow-y: auto;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 8px 10px;
+  margin-bottom: 8px;
+}
+.content-install-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+}
+.content-install-row .field-hint {
+  margin-left: auto;
+}
+.content-install-installed,
+.content-install-ok {
+  font-size: 13px;
+  color: var(--ok-strong);
+}
+.content-install-outcomes {
+  margin-top: 10px;
+}
+
 .mapping-review-stale {
   font-size: 13px;
   line-height: 20px;


### PR DESCRIPTION
## Summary

New Integrate page section 6 "Enable Sentinel Content" (user feature): from Sentinel Integration, install the Content Hub solution, its analytics rules, and its workbooks - choosing which of each.

- **Installed-state detection**: probes the workspace (installed solution version, existing alert-rule + workbook display names) so only *installable* items are offered; already-installed items are shown for reference.
- **Custom uploads**: upload your own analytics rules (YAML / portal ARM JSON / raw KQL) and workbooks (gallery-template JSON or portal ARM export) to install alongside the solution's.
- **Per-item outcomes**: every install reports success or the verbatim failure (HTTP status + body); one failure never aborts the rest (user requirement).
- **Parsers as an automatic dependency**: parsers the rules/workbooks query by alias install automatically (a missing function breaks the rule) - indicated, never asked, mirroring Content Hub.

Verified ARM shapes (SecurityInsights 2025-09-01; NRT on 2025-10-01-preview; workbooks 2021-08-01; savedSearches 2020-08-01; deployments 2021-04-01). All IO rides the existing AzureManagement + SentinelContent ports - no new external surface. Informational and Sentinel-side: it never gates the Cribl deploy (integrate-arc section, unconditionally complete like the coverage sections).

Packaged as 1.2.143. Gates green: typecheck, oxlint, core 2245 / ui 539 (new pins: rule scheduling-field parse, ARM body builders, upload parsing, installed-state probe, solution deploy, section state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)