### PR TITLE
Retry GitHub 429s; handle not-onboarded Sentinel workspace

### DIFF
--- a/soc-optimizationtoolkit/apps/cribl-app/package.json
+++ b/soc-optimizationtoolkit/apps/cribl-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "soc-optimizationtoolkit",
   "private": true,
-  "version": "1.2.143",
+  "version": "1.2.144",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/soc-optimizationtoolkit/apps/cribl-app/src/platform/adapters.ts
+++ b/soc-optimizationtoolkit/apps/cribl-app/src/platform/adapters.ts
@@ -919,9 +919,46 @@ const GITHUB_JSON_ACCEPT = 'application/vnd.github+json';
 // sample_data listing degraded the whole Sentinel browse tier).
 const GITHUB_RETRY_STATUSES = new Set([500, 502, 503, 504]);
 const GITHUB_RETRY_DELAYS_MS = [500, 1500];
+// RATE LIMITING (live report 2026-07-15: coverage + content-install fire many
+// parallel reads per solution and trip GitHub's rate/secondary limits ->
+// HTTP 429 "Too many requests", and 403 for the primary limit). These need a
+// LONGER, header-driven backoff than the 5xx blips, so they get their own
+// retry budget honoring Retry-After / x-ratelimit-reset.
+const GITHUB_RATE_LIMIT_ATTEMPTS = 4;
+const GITHUB_RATE_LIMIT_CAP_MS = 20000;
+
+/** Whether a response is a GitHub rate-limit rejection (429, or 403 with a limit header). */
+function isRateLimited(res: Response): boolean {
+  if (res.status === 429) return true;
+  if (res.status !== 403) return false;
+  return (
+    res.headers.get('retry-after') !== null ||
+    res.headers.get('x-ratelimit-remaining') === '0'
+  );
+}
+
+/** How long to wait for a rate-limited response: Retry-After, else reset delta, else exponential. */
+function rateLimitWaitMs(res: Response, attempt: number): number {
+  const retryAfter = Number(res.headers.get('retry-after'));
+  if (Number.isFinite(retryAfter) && retryAfter > 0) {
+    return Math.min(retryAfter * 1000, GITHUB_RATE_LIMIT_CAP_MS);
+  }
+  const reset = Number(res.headers.get('x-ratelimit-reset'));
+  if (Number.isFinite(reset) && reset > 0) {
+    const deltaMs = reset * 1000 - Date.now();
+    if (deltaMs > 0) return Math.min(deltaMs, GITHUB_RATE_LIMIT_CAP_MS);
+  }
+  return Math.min(1000 * 2 ** attempt, GITHUB_RATE_LIMIT_CAP_MS);
+}
 
 async function githubFetchWithRetry(url: string, init: RequestInit): Promise<Response> {
   let res = await fetchWithTimeout(url, init, GITHUB_TIMEOUT_MS);
+  // First: the header-driven rate-limit backoff (429 / limited 403).
+  for (let attempt = 0; attempt < GITHUB_RATE_LIMIT_ATTEMPTS && isRateLimited(res); attempt++) {
+    await new Promise((resolve) => setTimeout(resolve, rateLimitWaitMs(res, attempt)));
+    res = await fetchWithTimeout(url, init, GITHUB_TIMEOUT_MS);
+  }
+  // Then: the short 5xx-blip retries.
   for (const delay of GITHUB_RETRY_DELAYS_MS) {
     if (!GITHUB_RETRY_STATUSES.has(res.status)) {
       return res;

--- a/soc-optimizationtoolkit/apps/local-app/src/host/github.mjs
+++ b/soc-optimizationtoolkit/apps/local-app/src/host/github.mjs
@@ -213,9 +213,27 @@ export function createGithubProxy(dataDir, logger) {
       if (token !== '') {
         headers.Authorization = `Bearer ${token}`;
       }
+      let res = await fetchTextWithTimeout(url, { method: 'GET', headers });
+      // RATE LIMITING (live report 2026-07-15: parallel per-solution reads
+      // trip GitHub's 429/limited-403) - honor Retry-After / x-ratelimit-reset
+      // with a capped backoff before the short 5xx-blip retries.
+      for (let attempt = 0; attempt < 4; attempt++) {
+        const limited =
+          res.status === 429 || (res.status === 403 && res.retryAfter !== null);
+        if (!limited) break;
+        let waitMs;
+        if (res.retryAfter !== null) {
+          waitMs = Math.min(res.retryAfter * 1000, 20000);
+        } else if (res.rateLimitReset !== null) {
+          waitMs = Math.min(Math.max(res.rateLimitReset * 1000 - Date.now(), 0), 20000);
+        } else {
+          waitMs = Math.min(1000 * 2 ** attempt, 20000);
+        }
+        await new Promise((resolve) => setTimeout(resolve, waitMs));
+        res = await fetchTextWithTimeout(url, { method: 'GET', headers });
+      }
       // Transient GitHub 5xx blips (502 Bad Gateway pages) are routine -
       // retry a couple of times before answering (mirrors the cloud shell).
-      let res = await fetchTextWithTimeout(url, { method: 'GET', headers });
       for (const delay of [500, 1500]) {
         if (![500, 502, 503, 504].includes(res.status)) break;
         await new Promise((resolve) => setTimeout(resolve, delay));

--- a/soc-optimizationtoolkit/apps/local-app/src/host/http-util.mjs
+++ b/soc-optimizationtoolkit/apps/local-app/src/host/http-util.mjs
@@ -119,15 +119,25 @@ export function readJsonBody(req, maxBytes = MAX_BODY_BYTES) {
  * @param {string} url
  * @param {RequestInit} [init]
  * @param {number} [timeoutMs]
- * @returns {Promise<{ status: number, ok: boolean, text: string }>}
+ * @returns {Promise<{ status: number, ok: boolean, text: string, retryAfter: number|null, rateLimitReset: number|null }>}
  */
 export async function fetchTextWithTimeout(url, init = {}, timeoutMs = DEFAULT_UPSTREAM_TIMEOUT_MS) {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
     const res = await fetch(url, { ...init, signal: controller.signal });
+    // Surface the rate-limit headers so callers can honor Retry-After /
+    // x-ratelimit-reset on GitHub 429s (live report 2026-07-15).
+    const retryAfterRaw = Number(res.headers.get('retry-after'));
+    const resetRaw = Number(res.headers.get('x-ratelimit-reset'));
     // res.text() shares the abort signal: aborting mid-body rejects it too.
-    return { status: res.status, ok: res.ok, text: await res.text() };
+    return {
+      status: res.status,
+      ok: res.ok,
+      text: await res.text(),
+      retryAfter: Number.isFinite(retryAfterRaw) && retryAfterRaw > 0 ? retryAfterRaw : null,
+      rateLimitReset: Number.isFinite(resetRaw) && resetRaw > 0 ? resetRaw : null,
+    };
   } catch (err) {
     if (controller.signal.aborted) {
       throw new Error(`request to ${new URL(url).host} timed out after ${timeoutMs / 1000}s`);

--- a/soc-optimizationtoolkit/packages/core/src/usecases/content-install/content-install.test.ts
+++ b/soc-optimizationtoolkit/packages/core/src/usecases/content-install/content-install.test.ts
@@ -128,6 +128,27 @@ describe("installedContentState", () => {
     expect(state.solutionInstalled).toBe(false);
     expect(state.installedRuleNames.size).toBe(0);
     expect(state.notes.some((n) => n.includes("analytics rules"))).toBe(true);
+    expect(state.notOnboarded).toBe(false);
+  });
+
+  it("flags a not-onboarded workspace instead of a raw ARM note", async () => {
+    const azure = new FakeAzureManagement();
+    const notOnboarded = {
+      error: {
+        code: "BadRequest",
+        message:
+          "Workspace 'law' is not onboarded to Microsoft Sentinel. Please onboard through the portal.",
+      },
+    };
+    azure.respondWith(
+      { status: 400, body: notOnboarded }, // packages
+      { status: 400, body: notOnboarded }, // alertRules
+      { status: 200, body: { value: [] } }, // workbooks (Insights, unaffected)
+    );
+    const state = await installedContentState(azure, WS, "cf-id");
+    expect(state.notOnboarded).toBe(true);
+    // The raw ARM error is NOT pushed as a note - the UI shows an Enable action.
+    expect(state.notes.some((n) => n.includes("not onboarded"))).toBe(false);
   });
 });
 

--- a/soc-optimizationtoolkit/packages/core/src/usecases/content-install/content-install.ts
+++ b/soc-optimizationtoolkit/packages/core/src/usecases/content-install/content-install.ts
@@ -146,6 +146,24 @@ export interface InstalledContentState {
   installedWorkbookNames: ReadonlySet<string>;
   /** Non-fatal notes (a listing that failed degrades to "unknown", not error). */
   notes: string[];
+  /**
+   * True when a probe returned the "workspace is not onboarded to Microsoft
+   * Sentinel" error - the SecurityInsights provider rejects every content
+   * call until Sentinel is enabled on the workspace. The UI turns this into
+   * an actionable Enable action instead of a raw ARM error.
+   */
+  notOnboarded: boolean;
+}
+
+/** Detect the ARM "not onboarded to Microsoft Sentinel" rejection. */
+export function isNotOnboardedError(body: unknown): boolean {
+  let text: string;
+  try {
+    text = typeof body === "string" ? body : JSON.stringify(body);
+  } catch {
+    return false;
+  }
+  return /not onboarded to Microsoft Sentinel/i.test(text);
 }
 
 /**
@@ -162,6 +180,7 @@ export async function installedContentState(
 ): Promise<InstalledContentState> {
   const scope = workspaceInsightsScope(ws);
   const notes: string[] = [];
+  let notOnboarded = false;
 
   let solutionInstalled = false;
   let installedSolutionVersion: string | null = null;
@@ -185,7 +204,8 @@ export async function installedContentState(
         installedSolutionVersion = typeof v === "string" ? v : null;
       }
     } catch (err) {
-      notes.push(`Could not read installed solutions: ${errText(err)}`);
+      if (isNotOnboardedError(errText(err))) notOnboarded = true;
+      else notes.push(`Could not read installed solutions: ${errText(err)}`);
     }
   }
 
@@ -205,7 +225,8 @@ export async function installedContentState(
       if (typeof name === "string") installedRuleNames.add(name.toLowerCase());
     }
   } catch (err) {
-    notes.push(`Could not read installed analytics rules: ${errText(err)}`);
+    if (isNotOnboardedError(errText(err))) notOnboarded = true;
+    else notes.push(`Could not read installed analytics rules: ${errText(err)}`);
   }
 
   const installedWorkbookNames = new Set<string>();
@@ -230,6 +251,8 @@ export async function installedContentState(
       if (typeof name === "string") installedWorkbookNames.add(name.toLowerCase());
     }
   } catch (err) {
+    // Workbooks live under Microsoft.Insights, not SecurityInsights, so this
+    // path never raises the not-onboarded error; a failure is a plain note.
     notes.push(`Could not read installed workbooks: ${errText(err)}`);
   }
 
@@ -237,6 +260,7 @@ export async function installedContentState(
     solutionInstalled,
     rules: installedRuleNames.size,
     workbooks: installedWorkbookNames.size,
+    notOnboarded,
   });
 
   return {
@@ -245,6 +269,7 @@ export async function installedContentState(
     installedRuleNames,
     installedWorkbookNames,
     notes,
+    notOnboarded,
   };
 }
 

--- a/soc-optimizationtoolkit/packages/core/src/usecases/content-install/index.ts
+++ b/soc-optimizationtoolkit/packages/core/src/usecases/content-install/index.ts
@@ -11,6 +11,7 @@ export {
   WORKBOOKS_INSTALL_API_VERSION,
   WORKSPACE_READ_API_VERSION,
   fetchWorkspaceLocation,
+  isNotOnboardedError,
   installAnalyticRule,
   installParser,
   installSolution,

--- a/soc-optimizationtoolkit/packages/ui/src/screens/content-install/content-install-section.tsx
+++ b/soc-optimizationtoolkit/packages/ui/src/screens/content-install/content-install-section.tsx
@@ -22,6 +22,7 @@ import {
   availableParsers,
   availableWorkbooks,
   alertRuleResourceFromParsed,
+  enableSentinel,
   fetchWorkspaceLocation,
   findSolutionCatalogEntry,
   installAnalyticRule,
@@ -86,9 +87,10 @@ export function ContentInstallSection({
   // Selections (by display name) and per-group busy/outcome state.
   const [ruleSel, setRuleSel] = useState<Set<string>>(new Set());
   const [wbSel, setWbSel] = useState<Set<string>>(new Set());
-  const [busy, setBusy] = useState<"" | "solution" | "rules" | "workbooks">("");
+  const [busy, setBusy] = useState<"" | "solution" | "rules" | "workbooks" | "onboard">("");
   const [outcomes, setOutcomes] = useState<ContentInstallOutcome[]>([]);
   const [progress, setProgress] = useState("");
+  const [onboardError, setOnboardError] = useState("");
   const ruleFileRef = useRef<HTMLInputElement | null>(null);
   const wbFileRef = useRef<HTMLInputElement | null>(null);
 
@@ -301,6 +303,34 @@ export function ContentInstallSection({
     }
   }, [mintId, canInstall, wbSplit, wbSel, installParsers, ports, scope, load]);
 
+  // Enable Microsoft Sentinel on the workspace (the not-onboarded remedy):
+  // the SecurityInsights provider rejects every content call until Sentinel
+  // is enabled. Reuses the same idempotent enableSentinel the Azure Targeting
+  // screen offers, then reloads.
+  const doEnableSentinel = useCallback(async () => {
+    if (!canInstall) return;
+    setBusy("onboard");
+    setOnboardError("");
+    setProgress("Enabling Microsoft Sentinel on the workspace...");
+    try {
+      await enableSentinel(
+        ports.azure,
+        {
+          subscriptionId: config.subscriptionId,
+          resourceGroup: config.resourceGroup,
+          workspaceName: config.workspaceName,
+        },
+        ports.logger,
+      );
+      await load();
+    } catch (err) {
+      setOnboardError(String(err));
+    } finally {
+      setBusy("");
+      setProgress("");
+    }
+  }, [canInstall, ports, config, load]);
+
   if (content === undefined) {
     return (
       <p className="panel-desc">
@@ -345,6 +375,26 @@ export function ContentInstallSection({
         )}
       </div>
       {loadError !== "" && <pre className="result">{loadError}</pre>}
+      {installed !== null && installed.notOnboarded && (
+        <div className="connection-notice">
+          <p>
+            This workspace is not onboarded to Microsoft Sentinel, so its
+            content cannot be read or installed yet. Enable Sentinel (a
+            one-time, idempotent step) to continue - or do it in Select Azure
+            Resources.
+          </p>
+          <div className="panel-controls">
+            <button
+              className="run-button"
+              onClick={() => void doEnableSentinel()}
+              disabled={!canInstall || busy !== ""}
+            >
+              {busy === "onboard" ? "Enabling..." : "Enable Microsoft Sentinel"}
+            </button>
+          </div>
+          {onboardError !== "" && <pre className="result">{onboardError}</pre>}
+        </div>
+      )}
       {installed !== null &&
         installed.notes.map((note, i) => (
           <p key={i} className="field-hint">{note}</p>

--- a/soc-optimizationtoolkit/packages/ui/src/screens/content-install/content-install-state.test.ts
+++ b/soc-optimizationtoolkit/packages/ui/src/screens/content-install/content-install-state.test.ts
@@ -39,6 +39,7 @@ function state(over: Partial<InstalledContentState>): InstalledContentState {
     installedRuleNames: new Set(),
     installedWorkbookNames: new Set(),
     notes: [],
+    notOnboarded: false,
     ...over,
   };
 }


### PR DESCRIPTION
Two live-bug fixes on 1.2.143:

1. **GitHub 429 "Too many requests"** on rule/workbook coverage (and content-install) - the parallel per-solution reads trip GitHub's rate/secondary limits. Both shells' GitHub adapters now retry rate-limited responses (429, limited 403) with a header-driven backoff honoring `Retry-After` / `x-ratelimit-reset` (capped 20s, 4 attempts) before the existing short 5xx-blip retries. The local host's fetch helper surfaces the two rate-limit headers.

2. **"Workspace is not onboarded to Microsoft Sentinel" (HTTP 400)** in the new content-install section - `installedContentState` now detects the not-onboarded rejection and flags it (`notOnboarded`) instead of surfacing the raw ARM error; the section shows an actionable "Enable Microsoft Sentinel" button that runs the existing idempotent `enableSentinel`, then reloads.

Packaged 1.2.144. Gates green: typecheck, oxlint, core 2246 / ui 539 (new pins: not-onboarded detection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)