### PR TITLE
Broaden not-onboarded detection for the double-encoded ARM body

### DIFF
--- a/soc-optimizationtoolkit/apps/cribl-app/package.json
+++ b/soc-optimizationtoolkit/apps/cribl-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "soc-optimizationtoolkit",
   "private": true,
-  "version": "1.2.144",
+  "version": "1.2.145",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/soc-optimizationtoolkit/packages/core/src/usecases/content-install/content-install.test.ts
+++ b/soc-optimizationtoolkit/packages/core/src/usecases/content-install/content-install.test.ts
@@ -133,11 +133,19 @@ describe("installedContentState", () => {
 
   it("flags a not-onboarded workspace instead of a raw ARM note", async () => {
     const azure = new FakeAzureManagement();
+    // The EXACT double-encoded shape ARM returns live (2026-07-15): the outer
+    // message is itself a JSON string containing the not-onboarded error.
     const notOnboarded = {
       error: {
         code: "BadRequest",
-        message:
-          "Workspace 'law' is not onboarded to Microsoft Sentinel. Please onboard through the portal.",
+        message: JSON.stringify({
+          error: {
+            code: "BadRequest",
+            message:
+              "Workspace 'law-jpederson-eastus' is not onboarded to Microsoft Sentinel. " +
+              "Please onboard through the portal or use the OnboardingStates ARM api to onboard to Sentinel.",
+          },
+        }),
       },
     };
     azure.respondWith(

--- a/soc-optimizationtoolkit/packages/core/src/usecases/content-install/content-install.ts
+++ b/soc-optimizationtoolkit/packages/core/src/usecases/content-install/content-install.ts
@@ -155,7 +155,13 @@ export interface InstalledContentState {
   notOnboarded: boolean;
 }
 
-/** Detect the ARM "not onboarded to Microsoft Sentinel" rejection. */
+/**
+ * Detect the ARM "not onboarded to Microsoft Sentinel" rejection across its
+ * phrasings: the SecurityInsights provider returns a 400 whose (sometimes
+ * double-encoded) body says the workspace is not onboarded and points at the
+ * OnboardingStates API / quickstart. Match any of those signals so a wording
+ * change or nested-JSON escaping never drops it back to a raw note.
+ */
 export function isNotOnboardedError(body: unknown): boolean {
   let text: string;
   try {
@@ -163,7 +169,12 @@ export function isNotOnboardedError(body: unknown): boolean {
   } catch {
     return false;
   }
-  return /not onboarded to Microsoft Sentinel/i.test(text);
+  return (
+    /not onboarded to Microsoft Sentinel/i.test(text) ||
+    /onboard(?:ed|ing)?[^.]{0,40}(?:to )?(?:Microsoft )?Sentinel/i.test(text) ||
+    /sentinel-onboarding-states/i.test(text) ||
+    /OnboardingStates/i.test(text)
+  );
 }
 
 /**


### PR DESCRIPTION
The live "not onboarded to Microsoft Sentinel" 400 nests the error as a JSON string inside the outer message. isNotOnboardedError now matches the double-encoded body and the OnboardingStates/quickstart phrasings, so the content section always shows the Enable Microsoft Sentinel action instead of the raw ARM note. Pinned with the exact double-encoded shape. Packaged 1.2.145.

Generated with Claude Code