### PR TITLE
Keep content-install outcomes visible (install did nothing fix)

### DIFF
--- a/soc-optimizationtoolkit/apps/cribl-app/package.json
+++ b/soc-optimizationtoolkit/apps/cribl-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "soc-optimizationtoolkit",
   "private": true,
-  "version": "1.2.147",
+  "version": "1.2.148",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/soc-optimizationtoolkit/packages/core/src/usecases/content-install/content-install.ts
+++ b/soc-optimizationtoolkit/packages/core/src/usecases/content-install/content-install.ts
@@ -496,7 +496,13 @@ export async function installSolution(
       status: res.status,
     });
     return is2xx(res.status)
-      ? { name: displayName, ok: true, detail: "solution deployment accepted" }
+      ? {
+          name: displayName,
+          ok: true,
+          detail:
+            "solution deployment started - it runs asynchronously and can take " +
+            "a minute; reload to see it as installed",
+        }
       : { name: displayName, ok: false, detail: failDetail(res) };
   } catch (err) {
     return { name: displayName, ok: false, detail: errText(err) };

--- a/soc-optimizationtoolkit/packages/ui/src/screens/content-install/content-install-section.tsx
+++ b/soc-optimizationtoolkit/packages/ui/src/screens/content-install/content-install-section.tsx
@@ -112,11 +112,14 @@ export function ContentInstallSection({
     config.workspaceName !== "";
 
   // Load the catalog entry, installed state, and available content on demand.
-  const load = useCallback(async () => {
+  // keepOutcomes preserves the just-set install outcomes when an install
+  // handler refreshes state in its finally (clearing them there was the
+  // "install did nothing" bug: the outcome flashed then the reload wiped it).
+  const load = useCallback(async (keepOutcomes = false) => {
     if (content === undefined || solutionName.trim() === "") return;
     setLoading(true);
     setLoadError("");
-    setOutcomes([]);
+    if (!keepOutcomes) setOutcomes([]);
     try {
       const entry = scopeCommitted
         ? await findSolutionCatalogEntry(ports.azure, scope, solutionName, ports.logger)
@@ -250,7 +253,7 @@ export function ContentInstallSection({
     } finally {
       setBusy("");
       setProgress("");
-      void load();
+      void load(true); // keep the install outcome visible through the refresh
     }
   }, [catalog, canInstall, ports, scope, load]);
 
@@ -271,7 +274,7 @@ export function ContentInstallSection({
     } finally {
       setBusy("");
       setProgress("");
-      void load();
+      void load(true); // keep the install outcome visible through the refresh
     }
   }, [mintId, canInstall, ruleSplit, ruleSel, installParsers, ports, scope, load]);
 
@@ -299,7 +302,7 @@ export function ContentInstallSection({
     } finally {
       setBusy("");
       setProgress("");
-      void load();
+      void load(true); // keep the install outcome visible through the refresh
     }
   }, [mintId, canInstall, wbSplit, wbSel, installParsers, ports, scope, load]);
 


### PR DESCRIPTION
The Install button appeared to do nothing because each install handler refreshed state via load() in its finally, and load() cleared the just-set outcome before it rendered (the reload is the "Loading..." flash). load() now takes a keepOutcomes flag; the three install handlers pass true so success/failure survives the refresh. Solution-install success copy now states the deployment is asynchronous. Packaged 1.2.148.

Generated with Claude Code