### PR TITLE
Make live-preview version track package.json

### DIFF
--- a/soc-optimizationtoolkit/apps/cribl-app/package.json
+++ b/soc-optimizationtoolkit/apps/cribl-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "soc-optimizationtoolkit",
   "private": true,
-  "version": "1.2.148",
+  "version": "1.2.149",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/soc-optimizationtoolkit/apps/cribl-app/src/App.tsx
+++ b/soc-optimizationtoolkit/apps/cribl-app/src/App.tsx
@@ -1964,7 +1964,7 @@ function App() {
       mode={phase.mode}
       routes={routes}
       topBar={connectionBar}
-      footerNote={`v${__APP_VERSION__}`}
+      footerNote={`v${window.__APP_VERSION_RUNTIME__ ?? __APP_VERSION__}`}
       initialRouteId="home"
       themeControl={themeControl}
     />

--- a/soc-optimizationtoolkit/apps/cribl-app/src/platform.d.ts
+++ b/soc-optimizationtoolkit/apps/cribl-app/src/platform.d.ts
@@ -18,6 +18,13 @@ declare global {
     readonly CRIBL_BASE_PATH: string;
     readonly CRIBL_APP_ID?: string;
     readonly getCriblUser: () => Promise<CriblUser>;
+    /**
+     * Dev-only app version injected fresh into index.html on every load (the
+     * dev server reloads when package.json changes, so live preview tracks the
+     * current version instead of the frozen build-time define). Absent in the
+     * built .tgz, where __APP_VERSION__ is authoritative.
+     */
+    readonly __APP_VERSION_RUNTIME__?: string;
   }
   /** Build-time app version from package.json (Vite define). */
   const __APP_VERSION__: string;

--- a/soc-optimizationtoolkit/apps/cribl-app/vite.config.ts
+++ b/soc-optimizationtoolkit/apps/cribl-app/vite.config.ts
@@ -56,9 +56,11 @@ const injectScriptFromQueryPlugin = () => {
       initScriptUrl = initScriptUrl || url.searchParams.get('init');
       const root = process.cwd();
       let appName;
+      let appVersion;
       try {
-        const pkg = JSON.parse(readFileSync(join(root, 'package.json'), 'utf-8')) as { name?: string };
+        const pkg = JSON.parse(readFileSync(join(root, 'package.json'), 'utf-8')) as { name?: string; version?: string };
         appName = pkg.name;
+        appVersion = pkg.version;
       } catch {
         /* ignore missing or invalid package.json */
       }
@@ -76,6 +78,16 @@ const injectScriptFromQueryPlugin = () => {
           children: CONFIG_CHANGED_BRIDGE,
           injectTo: 'head-prepend' as const,
         });
+        // Inject the version fresh on every dev reload so live preview tracks
+        // package.json (bumped each build) rather than the frozen build-time
+        // define. The package.json watcher above reloads the page on change.
+        if (appVersion) {
+          tags.push({
+            tag: 'script',
+            children: `window.__APP_VERSION_RUNTIME__ = ${JSON.stringify(appVersion)};`,
+            injectTo: 'head-prepend' as const,
+          });
+        }
       }
       if (initScriptUrl) {
         tags.push({


### PR DESCRIPTION
The footer version came from a build-time Vite define, evaluated once when the dev server starts. So live preview stayed frozen at the version from the last restart (145) while packaging kept bumping it. The cribl-app config now injects the version fresh into index.html on every dev load, and the existing package.json watcher reloads on change - so live preview tracks the current version automatically. Falls back to the build-time define, which stays authoritative for the built .tgz. Packaged 1.2.149.

Generated with Claude Code