### PR TITLE
Surface async solution-deployment failures

### DIFF
--- a/soc-optimizationtoolkit/apps/cribl-app/package.json
+++ b/soc-optimizationtoolkit/apps/cribl-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "soc-optimizationtoolkit",
   "private": true,
-  "version": "1.2.150",
+  "version": "1.2.151",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/soc-optimizationtoolkit/packages/core/src/usecases/content-install/content-install.test.ts
+++ b/soc-optimizationtoolkit/packages/core/src/usecases/content-install/content-install.test.ts
@@ -9,6 +9,7 @@ import { describe, expect, it } from "vitest";
 import { FakeAzureManagement } from "../../testing/index";
 import type { ParsedAnalyticRule } from "../../domain/coverage-analysis/index";
 import {
+  fetchSolutionDeploymentStatus,
   installAnalyticRule,
   installWorkbook,
   installSolution,
@@ -208,5 +209,74 @@ describe("installSolution", () => {
     const outcome = await installSolution(azure, WS, "pkg", "Sol");
     expect(outcome.ok).toBe(false);
     expect(outcome.detail).toContain("no deployable template");
+  });
+});
+
+describe("fetchSolutionDeploymentStatus", () => {
+  it("returns a null state when no deployment record exists (404)", async () => {
+    const azure = new FakeAzureManagement();
+    azure.respondWith({ status: 404, body: { error: "not found" } });
+    const status = await fetchSolutionDeploymentStatus(azure, WS, "cloudflare.pkg");
+    expect(status).toEqual({ state: null, error: null });
+  });
+
+  it("reports a Succeeded deployment with no error", async () => {
+    const azure = new FakeAzureManagement();
+    azure.respondWith({
+      status: 200,
+      body: { properties: { provisioningState: "Succeeded" } },
+    });
+    const status = await fetchSolutionDeploymentStatus(azure, WS, "cloudflare.pkg");
+    expect(status).toEqual({ state: "Succeeded", error: null });
+  });
+
+  it("drills into deployment operations for the specific failure", async () => {
+    const azure = new FakeAzureManagement();
+    azure.respondWith(
+      {
+        status: 200,
+        body: {
+          properties: {
+            provisioningState: "Failed",
+            // The deployment-level message is the generic pointer; the real
+            // cause lives in the operations list.
+            error: {
+              code: "DeploymentFailed",
+              message:
+                "At least one resource deployment operation failed. Please " +
+                "list deployment operations for details.",
+            },
+          },
+        },
+      },
+      {
+        status: 200,
+        body: {
+          value: [
+            {
+              properties: {
+                provisioningState: "Failed",
+                targetResource: {
+                  resourceType: "Microsoft.OperationalInsights/workspaces/savedSearches",
+                },
+                statusMessage: {
+                  error: {
+                    code: "BadRequest",
+                    message: "The parser function alias already exists.",
+                  },
+                },
+              },
+            },
+          ],
+        },
+      },
+    );
+    const status = await fetchSolutionDeploymentStatus(azure, WS, "cloudflare.pkg");
+    expect(status.state).toBe("Failed");
+    expect(status.error).toContain("The parser function alias already exists.");
+    expect(status.error).toContain("savedSearches");
+    // GET the deployment, then GET its operations.
+    expect(azure.calls).toHaveLength(2);
+    expect(azure.calls[1].path).toContain("/operations");
   });
 });

--- a/soc-optimizationtoolkit/packages/core/src/usecases/content-install/content-install.ts
+++ b/soc-optimizationtoolkit/packages/core/src/usecases/content-install/content-install.ts
@@ -473,12 +473,9 @@ export async function installSolution(
         detail: "the product package returned no deployable template (packagedContent)",
       };
     }
-    const deploymentName = `sentinel-solution-${packageId}`.slice(0, 64);
     const res = await azure.request({
       method: "PUT",
-      path:
-        `/subscriptions/${ws.subscriptionId}/resourceGroups/${ws.resourceGroup}` +
-        `/providers/Microsoft.Resources/deployments/${deploymentName}`,
+      path: solutionDeploymentPath(ws, packageId),
       apiVersion: DEPLOYMENTS_API_VERSION,
       body: {
         properties: {
@@ -506,5 +503,125 @@ export async function installSolution(
       : { name: displayName, ok: false, detail: failDetail(res) };
   } catch (err) {
     return { name: displayName, ok: false, detail: errText(err) };
+  }
+}
+
+/** The deployment resource name for a solution install (bounded to 64 chars). */
+function solutionDeploymentName(packageId: string): string {
+  return `sentinel-solution-${packageId}`.slice(0, 64);
+}
+
+/** Full ARM id of the Microsoft.Resources/deployments used for a solution. */
+function solutionDeploymentPath(ws: WorkspaceScope, packageId: string): string {
+  return (
+    `/subscriptions/${ws.subscriptionId}/resourceGroups/${ws.resourceGroup}` +
+    `/providers/Microsoft.Resources/deployments/${solutionDeploymentName(packageId)}`
+  );
+}
+
+/** Flatten an ARM error object ({code, message, details[]}) to one line. */
+function renderArmError(err: unknown): string {
+  const parts: string[] = [];
+  const code = prop(err, "code");
+  const message = prop(err, "message");
+  if (typeof code === "string" && code !== "") parts.push(code);
+  if (typeof message === "string" && message !== "") parts.push(message);
+  const details = prop(err, "details");
+  if (Array.isArray(details)) {
+    for (const d of details) {
+      const dm = prop(d, "message");
+      if (typeof dm === "string" && dm !== "") parts.push(dm);
+    }
+  }
+  return parts.join(" - ");
+}
+
+/** The terminal (or in-flight) state of a solution's install deployment. */
+export interface SolutionDeploymentStatus {
+  /**
+   * The deployment's provisioningState (Succeeded | Failed | Canceled |
+   * Running | Accepted | ...); null when NO deployment record exists (the
+   * solution was never install-attempted, or ARM aged the record out).
+   */
+  state: string | null;
+  /** Specific failure detail when the deployment Failed/Canceled; else null. */
+  error: string | null;
+}
+
+/**
+ * Read the result of a solution install's async ARM deployment. The install
+ * PUT only returns "Accepted" - the deployment then provisions in the
+ * background and CAN FAIL after acceptance (a failed deployment looks
+ * identical to a pending one at PUT time, which is why an install can report
+ * "started" yet never install). This reads the deployment's terminal state
+ * and, when it failed, drills into the deployment OPERATIONS to surface the
+ * specific resource error (the deployment-level message is usually the
+ * generic "list deployment operations for details"). Never throws.
+ */
+export async function fetchSolutionDeploymentStatus(
+  azure: AzureManagement,
+  ws: WorkspaceScope,
+  packageId: string,
+  logger?: Logger,
+): Promise<SolutionDeploymentStatus> {
+  try {
+    const res = await azure.request({
+      method: "GET",
+      path: solutionDeploymentPath(ws, packageId),
+      apiVersion: DEPLOYMENTS_API_VERSION,
+    });
+    if (res.status === 404) return { state: null, error: null };
+    if (!is2xx(res.status)) return { state: null, error: failDetail(res) };
+    const props = prop(res.body, "properties");
+    const stateRaw = prop(props, "provisioningState");
+    const state = typeof stateRaw === "string" ? stateRaw : null;
+    if (state !== null && /^(failed|canceled)$/i.test(state)) {
+      let error = renderArmError(prop(props, "error"));
+      if (error === "" || /list deployment operations/i.test(error)) {
+        const opError = await fetchFailedOperationError(azure, ws, packageId);
+        if (opError !== "") error = opError;
+      }
+      logger?.info("content-install: solution deployment failed", { packageId, state });
+      return {
+        state,
+        error: error !== "" ? error : "deployment failed (no error detail returned)",
+      };
+    }
+    return { state, error: null };
+  } catch (err) {
+    return { state: null, error: errText(err) };
+  }
+}
+
+/** Pull the first failed deployment operations' resource errors (best-effort). */
+async function fetchFailedOperationError(
+  azure: AzureManagement,
+  ws: WorkspaceScope,
+  packageId: string,
+): Promise<string> {
+  try {
+    const res = await azure.request({
+      method: "GET",
+      path: `${solutionDeploymentPath(ws, packageId)}/operations`,
+      apiVersion: DEPLOYMENTS_API_VERSION,
+    });
+    if (!is2xx(res.status)) return "";
+    const value = prop(res.body, "value");
+    if (!Array.isArray(value)) return "";
+    const messages: string[] = [];
+    for (const op of value) {
+      const opProps = prop(op, "properties");
+      const opState = prop(opProps, "provisioningState");
+      if (typeof opState !== "string" || !/^failed$/i.test(opState)) continue;
+      const statusMessage = prop(opProps, "statusMessage");
+      const errObj = prop(statusMessage, "error") ?? statusMessage;
+      const rendered = renderArmError(errObj);
+      const resType = prop(prop(opProps, "targetResource"), "resourceType");
+      const label = typeof resType === "string" && resType !== "" ? `${resType}: ` : "";
+      if (rendered !== "") messages.push(`${label}${rendered}`);
+    }
+    return messages.slice(0, 3).join(" | ");
+  } catch {
+    return "";
   }
 }

--- a/soc-optimizationtoolkit/packages/core/src/usecases/content-install/index.ts
+++ b/soc-optimizationtoolkit/packages/core/src/usecases/content-install/index.ts
@@ -1,6 +1,7 @@
 export type {
   InstalledContentState,
   OnboardOutcome,
+  SolutionDeploymentStatus,
   WorkbookInstallSpec,
   WorkspaceScope,
 } from "./content-install";
@@ -12,6 +13,7 @@ export {
   SENTINEL_ONBOARDING_API_VERSION,
   WORKBOOKS_INSTALL_API_VERSION,
   WORKSPACE_READ_API_VERSION,
+  fetchSolutionDeploymentStatus,
   fetchWorkspaceLocation,
   isNotOnboardedError,
   installAnalyticRule,

--- a/soc-optimizationtoolkit/packages/ui/src/screens/content-install/content-install-section.tsx
+++ b/soc-optimizationtoolkit/packages/ui/src/screens/content-install/content-install-section.tsx
@@ -23,6 +23,7 @@ import {
   availableWorkbooks,
   alertRuleResourceFromParsed,
   onboardSentinelWorkspace,
+  fetchSolutionDeploymentStatus,
   fetchWorkspaceLocation,
   findSolutionCatalogEntry,
   installAnalyticRule,
@@ -42,6 +43,7 @@ import type {
   ParsedAnalyticRule,
   ParserResource,
   SolutionCatalogEntry,
+  SolutionDeploymentStatus,
   WorkspaceScope,
 } from "@soc/core";
 import { usePorts } from "../../ports-context";
@@ -75,6 +77,9 @@ export function ContentInstallSection({
   const [loadError, setLoadError] = useState("");
   const [catalog, setCatalog] = useState<SolutionCatalogEntry | null>(null);
   const [installed, setInstalled] = useState<InstalledContentState | null>(null);
+  // Result of the LAST solution-install deployment (async ARM): a Failed
+  // state here explains why "install started" never became "installed".
+  const [deployStatus, setDeployStatus] = useState<SolutionDeploymentStatus | null>(null);
   const [rules, setRules] = useState<ParsedAnalyticRule[]>([]);
   const [workbooks, setWorkbooks] = useState<AvailableWorkbook[]>([]);
   const [parsers, setParsers] = useState<ParserResource[]>([]);
@@ -133,6 +138,13 @@ export function ContentInstallSection({
         ? await installedContentState(ports.azure, scope, entry?.contentId, ports.logger)
         : null;
       setInstalled(state);
+      // When the solution is NOT installed, read the last install deployment's
+      // terminal state so a background failure is surfaced (not silent).
+      const deploy =
+        scopeCommitted && entry !== null && entry.installedVersion === null
+          ? await fetchSolutionDeploymentStatus(ports.azure, scope, entry.packageId, ports.logger)
+          : null;
+      setDeployStatus(deploy);
       const [repoRules, repoWorkbooks, repoParsers] = await Promise.all([
         availableAnalyticRules(content, solutionName),
         availableWorkbooks(content, solutionName),
@@ -162,6 +174,7 @@ export function ContentInstallSection({
   useEffect(() => {
     setCatalog(null);
     setInstalled(null);
+    setDeployStatus(null);
     setRules([]);
     setWorkbooks([]);
     setParsers([]);
@@ -473,6 +486,24 @@ export function ContentInstallSection({
               </button>
             </div>
             {renderFeedback("solution")}
+            {busy !== "solution" &&
+              deployStatus !== null &&
+              deployStatus.state !== null &&
+              /^(failed|canceled)$/i.test(deployStatus.state) && (
+                <p className="match-warning match-warning-overflow-loss">
+                  The last install deployment {deployStatus.state.toLowerCase()}:{" "}
+                  {deployStatus.error ?? "no error detail returned"}
+                </p>
+              )}
+            {busy !== "solution" &&
+              deployStatus !== null &&
+              deployStatus.state !== null &&
+              /^(running|accepted)$/i.test(deployStatus.state) && (
+                <p className="field-hint">
+                  A previous install deployment is still {deployStatus.state.toLowerCase()};
+                  reload in a moment to see the result.
+                </p>
+              )}
           </>
         )}
       </section>


### PR DESCRIPTION
Installing a Content Hub solution is an async ARM deployment: the PUT returns Accepted while provisioning continues in the background, and the deployment can fail AFTER acceptance. That failure looked identical to success, so the install reported "started" and then silently never installed (matching the 20-minutes-later "still not installed" report).

On reload, when the solution is not installed, the section now reads the last deployment resource state via fetchSolutionDeploymentStatus and shows the specific failure - drilling into the deployment OPERATIONS to extract the real resource error, since the deployment-level message is usually the generic "list deployment operations for details". A Running/Accepted deployment shows a still-provisioning hint instead. Core tests added; packaged 1.2.151.

Generated with Claude Code