### PR TITLE
Install solutions via the first-class contentPackages PUT

### DIFF
--- a/soc-optimizationtoolkit/apps/cribl-app/package.json
+++ b/soc-optimizationtoolkit/apps/cribl-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "soc-optimizationtoolkit",
   "private": true,
-  "version": "1.2.151",
+  "version": "1.2.152",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/soc-optimizationtoolkit/packages/core/src/usecases/content-install/content-install.test.ts
+++ b/soc-optimizationtoolkit/packages/core/src/usecases/content-install/content-install.test.ts
@@ -9,7 +9,6 @@ import { describe, expect, it } from "vitest";
 import { FakeAzureManagement } from "../../testing/index";
 import type { ParsedAnalyticRule } from "../../domain/coverage-analysis/index";
 import {
-  fetchSolutionDeploymentStatus,
   installAnalyticRule,
   installWorkbook,
   installSolution,
@@ -187,96 +186,71 @@ describe("onboardSentinelWorkspace", () => {
 });
 
 describe("installSolution", () => {
-  it("fetches packagedContent then deploys it, reporting acceptance", async () => {
-    const azure = new FakeAzureManagement();
-    azure.respondWith(
-      { status: 200, body: { properties: { packagedContent: { resources: [] } } } },
-      { status: 200, body: {} },
-    );
-    const outcome = await installSolution(azure, WS, "cloudflare.pkg", "Cloudflare");
-    expect(outcome.ok).toBe(true);
-    const [get, put] = azure.calls;
-    expect(get.path).toContain("/contentProductPackages/cloudflare.pkg");
-    expect(put.method).toBe("PUT");
-    expect(put.path).toContain("/Microsoft.Resources/deployments/");
-    const body = put.body as { properties: { template: unknown } };
-    expect(body.properties.template).toEqual({ resources: [] });
-  });
-
-  it("fails honestly when the package has no deployable template", async () => {
-    const azure = new FakeAzureManagement();
-    azure.respondWith({ status: 200, body: { properties: {} } });
-    const outcome = await installSolution(azure, WS, "pkg", "Sol");
-    expect(outcome.ok).toBe(false);
-    expect(outcome.detail).toContain("no deployable template");
-  });
-});
-
-describe("fetchSolutionDeploymentStatus", () => {
-  it("returns a null state when no deployment record exists (404)", async () => {
-    const azure = new FakeAzureManagement();
-    azure.respondWith({ status: 404, body: { error: "not found" } });
-    const status = await fetchSolutionDeploymentStatus(azure, WS, "cloudflare.pkg");
-    expect(status).toEqual({ state: null, error: null });
-  });
-
-  it("reports a Succeeded deployment with no error", async () => {
-    const azure = new FakeAzureManagement();
-    azure.respondWith({
-      status: 200,
-      body: { properties: { provisioningState: "Succeeded" } },
-    });
-    const status = await fetchSolutionDeploymentStatus(azure, WS, "cloudflare.pkg");
-    expect(status).toEqual({ state: "Succeeded", error: null });
-  });
-
-  it("drills into deployment operations for the specific failure", async () => {
+  it("installs via the contentPackages PUT, sourcing fields from the product package", async () => {
     const azure = new FakeAzureManagement();
     azure.respondWith(
       {
         status: 200,
         body: {
           properties: {
-            provisioningState: "Failed",
-            // The deployment-level message is the generic pointer; the real
-            // cause lives in the operations list.
-            error: {
-              code: "DeploymentFailed",
-              message:
-                "At least one resource deployment operation failed. Please " +
-                "list deployment operations for details.",
-            },
+            contentId: "cloudflare.pkg",
+            contentProductId: "cloudflare.pkg-sl-abc123",
+            contentKind: "Solution",
+            displayName: "Cloudflare (Deprecated)",
+            version: "2.0.3",
           },
         },
       },
+      { status: 200, body: { properties: { installedVersion: "2.0.3" } } },
+    );
+    const outcome = await installSolution(azure, WS, "cloudflare.pkg", "Cloudflare");
+    expect(outcome.ok).toBe(true);
+    expect(outcome.detail).toContain("installed (version 2.0.3)");
+    const [get, put] = azure.calls;
+    expect(get.path).toContain("/contentProductPackages/cloudflare.pkg");
+    expect(put.method).toBe("PUT");
+    // The first-class install operation - NOT a Microsoft.Resources/deployments.
+    expect(put.path).toContain("/contentPackages/cloudflare.pkg");
+    expect(put.path).not.toContain("/Microsoft.Resources/deployments/");
+    expect(put.apiVersion).toBe("2025-09-01");
+    const body = put.body as { properties: Record<string, unknown> };
+    expect(body.properties).toEqual({
+      contentId: "cloudflare.pkg",
+      contentProductId: "cloudflare.pkg-sl-abc123",
+      contentKind: "Solution",
+      displayName: "Cloudflare (Deprecated)",
+      version: "2.0.3",
+    });
+  });
+
+  it("reports the install PUT failure verbatim, never throwing", async () => {
+    const azure = new FakeAzureManagement();
+    azure.respondWith(
       {
         status: 200,
         body: {
-          value: [
-            {
-              properties: {
-                provisioningState: "Failed",
-                targetResource: {
-                  resourceType: "Microsoft.OperationalInsights/workspaces/savedSearches",
-                },
-                statusMessage: {
-                  error: {
-                    code: "BadRequest",
-                    message: "The parser function alias already exists.",
-                  },
-                },
-              },
-            },
-          ],
+          properties: {
+            contentId: "c",
+            contentProductId: "c-sl",
+            contentKind: "Solution",
+            version: "1.0.0",
+          },
         },
       },
+      { status: 400, body: { error: "bad" } },
     );
-    const status = await fetchSolutionDeploymentStatus(azure, WS, "cloudflare.pkg");
-    expect(status.state).toBe("Failed");
-    expect(status.error).toContain("The parser function alias already exists.");
-    expect(status.error).toContain("savedSearches");
-    // GET the deployment, then GET its operations.
-    expect(azure.calls).toHaveLength(2);
-    expect(azure.calls[1].path).toContain("/operations");
+    const outcome = await installSolution(azure, WS, "c", "Sol");
+    expect(outcome.ok).toBe(false);
+    expect(outcome.detail).toContain("HTTP 400");
+  });
+
+  it("fails honestly when the product package lacks required install fields", async () => {
+    const azure = new FakeAzureManagement();
+    azure.respondWith({ status: 200, body: { properties: {} } });
+    const outcome = await installSolution(azure, WS, "pkg", "Sol");
+    expect(outcome.ok).toBe(false);
+    expect(outcome.detail).toContain("missing required install fields");
+    // No install PUT is attempted when the package is unusable.
+    expect(azure.calls).toHaveLength(1);
   });
 });

--- a/soc-optimizationtoolkit/packages/core/src/usecases/content-install/content-install.ts
+++ b/soc-optimizationtoolkit/packages/core/src/usecases/content-install/content-install.ts
@@ -46,8 +46,6 @@ export const SECURITY_INSIGHTS_PREVIEW_API_VERSION = "2025-10-01-preview";
 export const WORKBOOKS_INSTALL_API_VERSION = "2021-08-01";
 /** Microsoft.OperationalInsights/workspaces/savedSearches (parsers). */
 export const SAVED_SEARCHES_API_VERSION = "2020-08-01";
-/** ARM deployments api-version (solution mainTemplate deploy). */
-export const DEPLOYMENTS_API_VERSION = "2021-04-01";
 
 /** The workspace coordinates every call is scoped to. */
 export interface WorkspaceScope {
@@ -151,6 +149,10 @@ export function workspaceResourceId(ws: WorkspaceScope): string {
 function prop(value: unknown, key: string): unknown {
   if (typeof value !== "object" || value === null) return undefined;
   return (value as Record<string, unknown>)[key];
+}
+
+function str(value: unknown): string {
+  return typeof value === "string" ? value : "";
 }
 
 function errText(err: unknown): string {
@@ -437,13 +439,22 @@ export async function installParser(
 // ---------------------------------------------------------------------------
 
 /**
- * Install a Content Hub solution: GET the product package's packagedContent
- * ARM template, then deploy it via a Microsoft.Resources/deployments PUT
- * (the documented flow). `packageId` is the contentPackages/-scoped package
- * name (from the catalog listing's `name`). Resolves an outcome.
+ * Install a Content Hub solution via the first-class "Content Package -
+ * Install" operation: a direct PUT of the contentPackages/{packageId}
+ * resource. This is the documented, SYNCHRONOUS install (the portal's
+ * "Install" button) - the response IS the installed package (its
+ * installedVersion is set), so there is no async deployment to poll.
  *
- * The packagedContent field name has drifted across doc/samples
- * (packagedContent / mainTemplate / packageContent) - all three are tried.
+ * We deliberately do NOT deploy the package's packagedContent ARM template
+ * ourselves (the legacy path) - that outer deployment can sit in
+ * provisioningState "Running" indefinitely while its nested deployments
+ * resolve, so an install would report "started" yet never install. The
+ * install PUT lets the SecurityInsights RP materialize the content
+ * server-side. Ref: learn.microsoft.com Content Package - Install.
+ *
+ * The five install fields all come from the contentProductPackages GET we
+ * already make (contentId, contentProductId, contentKind, displayName,
+ * version). `packageId` is the product package's `name` (== its contentId).
  */
 export async function installSolution(
   azure: AzureManagement,
@@ -462,166 +473,42 @@ export async function installSolution(
       return { name: displayName, ok: false, detail: failDetail(pkg) };
     }
     const props = prop(pkg.body, "properties");
-    const template =
-      prop(props, "packagedContent") ??
-      prop(props, "mainTemplate") ??
-      prop(props, "packageContent");
-    if (template === undefined || template === null) {
+    const contentId = str(prop(props, "contentId"));
+    const contentProductId = str(prop(props, "contentProductId"));
+    const contentKind = str(prop(props, "contentKind")) || "Solution";
+    const version = str(prop(props, "version"));
+    const name = str(prop(props, "displayName")) || displayName;
+    if (contentId === "" || contentProductId === "" || version === "") {
       return {
         name: displayName,
         ok: false,
-        detail: "the product package returned no deployable template (packagedContent)",
+        detail:
+          "the product package is missing required install fields " +
+          "(contentId / contentProductId / version)",
       };
     }
     const res = await azure.request({
       method: "PUT",
-      path: solutionDeploymentPath(ws, packageId),
-      apiVersion: DEPLOYMENTS_API_VERSION,
+      path: `${workspaceInsightsScope(ws)}/contentPackages/${packageId}`,
+      apiVersion: SECURITY_INSIGHTS_API_VERSION,
       body: {
         properties: {
-          mode: "Incremental",
-          template,
-          parameters: {
-            workspace: { value: ws.workspaceName },
-            "workspace-location": { value: ws.location },
-          },
+          contentId,
+          contentProductId,
+          contentKind,
+          displayName: name,
+          version,
         },
       },
     });
-    logger?.info("content-install: solution deploy issued", {
+    logger?.info("content-install: solution install PUT", {
       packageId,
       status: res.status,
     });
     return is2xx(res.status)
-      ? {
-          name: displayName,
-          ok: true,
-          detail:
-            "solution deployment started - it runs asynchronously and can take " +
-            "a minute; reload to see it as installed",
-        }
+      ? { name: displayName, ok: true, detail: `installed (version ${version})` }
       : { name: displayName, ok: false, detail: failDetail(res) };
   } catch (err) {
     return { name: displayName, ok: false, detail: errText(err) };
-  }
-}
-
-/** The deployment resource name for a solution install (bounded to 64 chars). */
-function solutionDeploymentName(packageId: string): string {
-  return `sentinel-solution-${packageId}`.slice(0, 64);
-}
-
-/** Full ARM id of the Microsoft.Resources/deployments used for a solution. */
-function solutionDeploymentPath(ws: WorkspaceScope, packageId: string): string {
-  return (
-    `/subscriptions/${ws.subscriptionId}/resourceGroups/${ws.resourceGroup}` +
-    `/providers/Microsoft.Resources/deployments/${solutionDeploymentName(packageId)}`
-  );
-}
-
-/** Flatten an ARM error object ({code, message, details[]}) to one line. */
-function renderArmError(err: unknown): string {
-  const parts: string[] = [];
-  const code = prop(err, "code");
-  const message = prop(err, "message");
-  if (typeof code === "string" && code !== "") parts.push(code);
-  if (typeof message === "string" && message !== "") parts.push(message);
-  const details = prop(err, "details");
-  if (Array.isArray(details)) {
-    for (const d of details) {
-      const dm = prop(d, "message");
-      if (typeof dm === "string" && dm !== "") parts.push(dm);
-    }
-  }
-  return parts.join(" - ");
-}
-
-/** The terminal (or in-flight) state of a solution's install deployment. */
-export interface SolutionDeploymentStatus {
-  /**
-   * The deployment's provisioningState (Succeeded | Failed | Canceled |
-   * Running | Accepted | ...); null when NO deployment record exists (the
-   * solution was never install-attempted, or ARM aged the record out).
-   */
-  state: string | null;
-  /** Specific failure detail when the deployment Failed/Canceled; else null. */
-  error: string | null;
-}
-
-/**
- * Read the result of a solution install's async ARM deployment. The install
- * PUT only returns "Accepted" - the deployment then provisions in the
- * background and CAN FAIL after acceptance (a failed deployment looks
- * identical to a pending one at PUT time, which is why an install can report
- * "started" yet never install). This reads the deployment's terminal state
- * and, when it failed, drills into the deployment OPERATIONS to surface the
- * specific resource error (the deployment-level message is usually the
- * generic "list deployment operations for details"). Never throws.
- */
-export async function fetchSolutionDeploymentStatus(
-  azure: AzureManagement,
-  ws: WorkspaceScope,
-  packageId: string,
-  logger?: Logger,
-): Promise<SolutionDeploymentStatus> {
-  try {
-    const res = await azure.request({
-      method: "GET",
-      path: solutionDeploymentPath(ws, packageId),
-      apiVersion: DEPLOYMENTS_API_VERSION,
-    });
-    if (res.status === 404) return { state: null, error: null };
-    if (!is2xx(res.status)) return { state: null, error: failDetail(res) };
-    const props = prop(res.body, "properties");
-    const stateRaw = prop(props, "provisioningState");
-    const state = typeof stateRaw === "string" ? stateRaw : null;
-    if (state !== null && /^(failed|canceled)$/i.test(state)) {
-      let error = renderArmError(prop(props, "error"));
-      if (error === "" || /list deployment operations/i.test(error)) {
-        const opError = await fetchFailedOperationError(azure, ws, packageId);
-        if (opError !== "") error = opError;
-      }
-      logger?.info("content-install: solution deployment failed", { packageId, state });
-      return {
-        state,
-        error: error !== "" ? error : "deployment failed (no error detail returned)",
-      };
-    }
-    return { state, error: null };
-  } catch (err) {
-    return { state: null, error: errText(err) };
-  }
-}
-
-/** Pull the first failed deployment operations' resource errors (best-effort). */
-async function fetchFailedOperationError(
-  azure: AzureManagement,
-  ws: WorkspaceScope,
-  packageId: string,
-): Promise<string> {
-  try {
-    const res = await azure.request({
-      method: "GET",
-      path: `${solutionDeploymentPath(ws, packageId)}/operations`,
-      apiVersion: DEPLOYMENTS_API_VERSION,
-    });
-    if (!is2xx(res.status)) return "";
-    const value = prop(res.body, "value");
-    if (!Array.isArray(value)) return "";
-    const messages: string[] = [];
-    for (const op of value) {
-      const opProps = prop(op, "properties");
-      const opState = prop(opProps, "provisioningState");
-      if (typeof opState !== "string" || !/^failed$/i.test(opState)) continue;
-      const statusMessage = prop(opProps, "statusMessage");
-      const errObj = prop(statusMessage, "error") ?? statusMessage;
-      const rendered = renderArmError(errObj);
-      const resType = prop(prop(opProps, "targetResource"), "resourceType");
-      const label = typeof resType === "string" && resType !== "" ? `${resType}: ` : "";
-      if (rendered !== "") messages.push(`${label}${rendered}`);
-    }
-    return messages.slice(0, 3).join(" | ");
-  } catch {
-    return "";
   }
 }

--- a/soc-optimizationtoolkit/packages/core/src/usecases/content-install/index.ts
+++ b/soc-optimizationtoolkit/packages/core/src/usecases/content-install/index.ts
@@ -1,19 +1,16 @@
 export type {
   InstalledContentState,
   OnboardOutcome,
-  SolutionDeploymentStatus,
   WorkbookInstallSpec,
   WorkspaceScope,
 } from "./content-install";
 export {
-  DEPLOYMENTS_API_VERSION,
   SAVED_SEARCHES_API_VERSION,
   SECURITY_INSIGHTS_API_VERSION,
   SECURITY_INSIGHTS_PREVIEW_API_VERSION,
   SENTINEL_ONBOARDING_API_VERSION,
   WORKBOOKS_INSTALL_API_VERSION,
   WORKSPACE_READ_API_VERSION,
-  fetchSolutionDeploymentStatus,
   fetchWorkspaceLocation,
   isNotOnboardedError,
   installAnalyticRule,

--- a/soc-optimizationtoolkit/packages/ui/src/screens/content-install/content-install-section.tsx
+++ b/soc-optimizationtoolkit/packages/ui/src/screens/content-install/content-install-section.tsx
@@ -23,7 +23,6 @@ import {
   availableWorkbooks,
   alertRuleResourceFromParsed,
   onboardSentinelWorkspace,
-  fetchSolutionDeploymentStatus,
   fetchWorkspaceLocation,
   findSolutionCatalogEntry,
   installAnalyticRule,
@@ -43,7 +42,6 @@ import type {
   ParsedAnalyticRule,
   ParserResource,
   SolutionCatalogEntry,
-  SolutionDeploymentStatus,
   WorkspaceScope,
 } from "@soc/core";
 import { usePorts } from "../../ports-context";
@@ -77,9 +75,6 @@ export function ContentInstallSection({
   const [loadError, setLoadError] = useState("");
   const [catalog, setCatalog] = useState<SolutionCatalogEntry | null>(null);
   const [installed, setInstalled] = useState<InstalledContentState | null>(null);
-  // Result of the LAST solution-install deployment (async ARM): a Failed
-  // state here explains why "install started" never became "installed".
-  const [deployStatus, setDeployStatus] = useState<SolutionDeploymentStatus | null>(null);
   const [rules, setRules] = useState<ParsedAnalyticRule[]>([]);
   const [workbooks, setWorkbooks] = useState<AvailableWorkbook[]>([]);
   const [parsers, setParsers] = useState<ParserResource[]>([]);
@@ -138,13 +133,6 @@ export function ContentInstallSection({
         ? await installedContentState(ports.azure, scope, entry?.contentId, ports.logger)
         : null;
       setInstalled(state);
-      // When the solution is NOT installed, read the last install deployment's
-      // terminal state so a background failure is surfaced (not silent).
-      const deploy =
-        scopeCommitted && entry !== null && entry.installedVersion === null
-          ? await fetchSolutionDeploymentStatus(ports.azure, scope, entry.packageId, ports.logger)
-          : null;
-      setDeployStatus(deploy);
       const [repoRules, repoWorkbooks, repoParsers] = await Promise.all([
         availableAnalyticRules(content, solutionName),
         availableWorkbooks(content, solutionName),
@@ -174,7 +162,6 @@ export function ContentInstallSection({
   useEffect(() => {
     setCatalog(null);
     setInstalled(null);
-    setDeployStatus(null);
     setRules([]);
     setWorkbooks([]);
     setParsers([]);
@@ -486,24 +473,6 @@ export function ContentInstallSection({
               </button>
             </div>
             {renderFeedback("solution")}
-            {busy !== "solution" &&
-              deployStatus !== null &&
-              deployStatus.state !== null &&
-              /^(failed|canceled)$/i.test(deployStatus.state) && (
-                <p className="match-warning match-warning-overflow-loss">
-                  The last install deployment {deployStatus.state.toLowerCase()}:{" "}
-                  {deployStatus.error ?? "no error detail returned"}
-                </p>
-              )}
-            {busy !== "solution" &&
-              deployStatus !== null &&
-              deployStatus.state !== null &&
-              /^(running|accepted)$/i.test(deployStatus.state) && (
-                <p className="field-hint">
-                  A previous install deployment is still {deployStatus.state.toLowerCase()};
-                  reload in a moment to see the result.
-                </p>
-              )}
           </>
         )}
       </section>


### PR DESCRIPTION
Root cause of "Install did nothing / stuck Running": we used the legacy path - deploying the package's packagedContent ARM template through a Microsoft.Resources/deployments PUT. That outer deployment stays in provisioningState "Running" indefinitely while its nested deployments resolve, so the install reported "started" and never completed.

Fix: switch to the documented, SYNCHRONOUS "Content Package - Install" operation - a direct PUT of Microsoft.SecurityInsights/contentPackages/{packageId} with the five install fields (contentId, contentProductId, contentKind, displayName, version) taken from the contentProductPackages GET we already make. The response is the installed package; nothing to poll. Verified against learn.microsoft.com (Content Package - Install) and the contentPackages ARM/Bicep/Terraform schema.

Removes the now-dead async deployment-status code added while diagnosing the wrong approach. Full suites green (core 2249, ui 539). Packaged 1.2.152.

Generated with Claude Code