### PR TITLE
Send required contentSchemaVersion on solution install

### DIFF
--- a/soc-optimizationtoolkit/apps/cribl-app/package.json
+++ b/soc-optimizationtoolkit/apps/cribl-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "soc-optimizationtoolkit",
   "private": true,
-  "version": "1.2.152",
+  "version": "1.2.153",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/soc-optimizationtoolkit/packages/core/src/usecases/content-install/content-install.test.ts
+++ b/soc-optimizationtoolkit/packages/core/src/usecases/content-install/content-install.test.ts
@@ -196,6 +196,7 @@ describe("installSolution", () => {
             contentId: "cloudflare.pkg",
             contentProductId: "cloudflare.pkg-sl-abc123",
             contentKind: "Solution",
+            contentSchemaVersion: "3.0.0",
             displayName: "Cloudflare (Deprecated)",
             version: "2.0.3",
           },
@@ -218,9 +219,31 @@ describe("installSolution", () => {
       contentId: "cloudflare.pkg",
       contentProductId: "cloudflare.pkg-sl-abc123",
       contentKind: "Solution",
+      contentSchemaVersion: "3.0.0",
       displayName: "Cloudflare (Deprecated)",
       version: "2.0.3",
     });
+  });
+
+  it("defaults contentSchemaVersion when the product package omits it", async () => {
+    const azure = new FakeAzureManagement();
+    azure.respondWith(
+      {
+        status: 200,
+        body: {
+          properties: {
+            contentId: "c",
+            contentProductId: "c-sl",
+            contentKind: "Solution",
+            version: "1.0.0",
+          },
+        },
+      },
+      { status: 200, body: {} },
+    );
+    await installSolution(azure, WS, "c", "Sol");
+    const body = azure.calls[1].body as { properties: { contentSchemaVersion: string } };
+    expect(body.properties.contentSchemaVersion).toBe("3.0.0");
   });
 
   it("reports the install PUT failure verbatim, never throwing", async () => {

--- a/soc-optimizationtoolkit/packages/core/src/usecases/content-install/content-install.ts
+++ b/soc-optimizationtoolkit/packages/core/src/usecases/content-install/content-install.ts
@@ -478,6 +478,10 @@ export async function installSolution(
     const contentKind = str(prop(props, "contentKind")) || "Solution";
     const version = str(prop(props, "version"));
     const name = str(prop(props, "displayName")) || displayName;
+    // Required by the live 2025-09-01 install API (the REST reference lists it
+    // as optional, but the RP rejects the PUT without it). Sourced from the
+    // product package; default to the current Content Hub schema version.
+    const contentSchemaVersion = str(prop(props, "contentSchemaVersion")) || "3.0.0";
     if (contentId === "" || contentProductId === "" || version === "") {
       return {
         name: displayName,
@@ -496,6 +500,7 @@ export async function installSolution(
           contentId,
           contentProductId,
           contentKind,
+          contentSchemaVersion,
           displayName: name,
           version,
         },


### PR DESCRIPTION
The live 2025-09-01 contentPackages install API rejects the PUT with "properties.contentSchemaVersion is required" (the REST reference lists it as optional). Source it from the product-package GET and include it in the install body, defaulting to the current Content Hub schema version "3.0.0" when the package omits it. Packaged 1.2.153.

Generated with Claude Code