### PR TITLE
Recover from orphaned contentPackages association on solution install

### DIFF
--- a/soc-optimizationtoolkit/apps/cribl-app/package.json
+++ b/soc-optimizationtoolkit/apps/cribl-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "soc-optimizationtoolkit",
   "private": true,
-  "version": "1.2.153",
+  "version": "1.2.154",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/soc-optimizationtoolkit/packages/core/src/usecases/content-install/content-install.test.ts
+++ b/soc-optimizationtoolkit/packages/core/src/usecases/content-install/content-install.test.ts
@@ -246,6 +246,75 @@ describe("installSolution", () => {
     expect(body.properties.contentSchemaVersion).toBe("3.0.0");
   });
 
+  it("short-circuits when the product package already reports installedVersion", async () => {
+    const azure = new FakeAzureManagement();
+    azure.respondWith({
+      status: 200,
+      body: {
+        properties: {
+          contentId: "c",
+          contentProductId: "c-sl",
+          contentKind: "Solution",
+          version: "2.0.3",
+          installedVersion: "2.0.3",
+        },
+      },
+    });
+    const outcome = await installSolution(azure, WS, "c", "Cloudflare");
+    expect(outcome.ok).toBe(true);
+    expect(outcome.detail).toContain("already installed (version 2.0.3)");
+    // Only the product-package GET - no install PUT is attempted.
+    expect(azure.calls).toHaveLength(1);
+  });
+
+  it("clears an orphaned association then retries the install on conflict", async () => {
+    const azure = new FakeAzureManagement();
+    azure.respondWith(
+      {
+        status: 200,
+        body: {
+          properties: {
+            contentId: "azuresentinel.azure-sentinel-solution-cloudflare",
+            contentProductId: "azuresentinel.azure-sentinel-solution-cloudflare-sl-xyz",
+            contentKind: "Solution",
+            contentSchemaVersion: "3.0.0",
+            displayName: "Cloudflare (Deprecated)",
+            version: "2.0.3",
+          },
+        },
+      },
+      // First install PUT: the RP refuses - contentId owned by another package.
+      {
+        status: 400,
+        body: {
+          error: {
+            code: "BadRequestException",
+            message:
+              "contentId azuresentinel.azure-sentinel-solution-cloudflare is " +
+              "already associated with another package",
+          },
+        },
+      },
+      { status: 200, body: {} }, // DELETE the versioned-name orphan
+      { status: 204, body: {} }, // DELETE the contentId-name (idempotent)
+      { status: 200, body: { properties: { installedVersion: "2.0.3" } } }, // retry PUT
+    );
+    const outcome = await installSolution(
+      azure,
+      WS,
+      "azuresentinel.azure-sentinel-solution-cloudflare",
+      "Cloudflare (Deprecated)",
+    );
+    expect(outcome.ok).toBe(true);
+    expect(outcome.detail).toContain("installed (version 2.0.3)");
+    const methods = azure.calls.map((c) => c.method);
+    expect(methods).toEqual(["GET", "PUT", "DELETE", "DELETE", "PUT"]);
+    // The orphan under the versioned contentProductId name is deleted.
+    expect(azure.calls[2].path).toContain(
+      "/contentPackages/azuresentinel.azure-sentinel-solution-cloudflare-sl-xyz",
+    );
+  });
+
   it("reports the install PUT failure verbatim, never throwing", async () => {
     const azure = new FakeAzureManagement();
     azure.respondWith(

--- a/soc-optimizationtoolkit/packages/core/src/usecases/content-install/content-install.ts
+++ b/soc-optimizationtoolkit/packages/core/src/usecases/content-install/content-install.ts
@@ -159,14 +159,18 @@ function errText(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
 }
 
+/** The response body as a string (for error-message matching). */
+function bodyText(res: PortHttpResponse): string {
+  try {
+    return typeof res.body === "string" ? res.body : JSON.stringify(res.body);
+  } catch {
+    return String(res.body);
+  }
+}
+
 /** Render a failed ARM response as the outcome detail (status + body). */
 function failDetail(res: PortHttpResponse): string {
-  let body: string;
-  try {
-    body = typeof res.body === "string" ? res.body : JSON.stringify(res.body);
-  } catch {
-    body = String(res.body);
-  }
+  const body = bodyText(res);
   return `HTTP ${res.status}${body && body !== "null" ? ` ${body}` : ""}`;
 }
 
@@ -491,21 +495,48 @@ export async function installSolution(
           "(contentId / contentProductId / version)",
       };
     }
-    const res = await azure.request({
-      method: "PUT",
-      path: `${workspaceInsightsScope(ws)}/contentPackages/${packageId}`,
-      apiVersion: SECURITY_INSIGHTS_API_VERSION,
-      body: {
-        properties: {
-          contentId,
-          contentProductId,
-          contentKind,
-          contentSchemaVersion,
-          displayName: name,
-          version,
-        },
+    // Short-circuit: the product package already reports an installed version.
+    const installedVersion = str(prop(props, "installedVersion"));
+    if (installedVersion !== "") {
+      return {
+        name: displayName,
+        ok: true,
+        detail: `already installed (version ${installedVersion})`,
+      };
+    }
+    // The install resource name is the short contentId (== the product
+    // package name); the RP enforces one contentPackages resource per
+    // contentId. Ref: learn.microsoft.com Content Package - Install.
+    const body = {
+      properties: {
+        contentId,
+        contentProductId,
+        contentKind,
+        contentSchemaVersion,
+        displayName: name,
+        version,
       },
-    });
+    };
+    const put = () =>
+      azure.request({
+        method: "PUT",
+        path: `${workspaceInsightsScope(ws)}/contentPackages/${contentId}`,
+        apiVersion: SECURITY_INSIGHTS_API_VERSION,
+        body,
+      });
+    let res = await put();
+    // A prior partial/failed attempt can leave an ORPHAN contentPackages
+    // resource that already owns this contentId under a different name (the
+    // versioned contentProductId), so the RP refuses a second association with
+    // "contentId ... is already associated with another package". Delete the
+    // orphan(s) - two Solutions never share a contentId, so it can only be a
+    // stale copy of THIS solution - then retry the install once.
+    if (res.status === 400 && /already associated with another package/i.test(bodyText(res))) {
+      logger?.info("content-install: clearing orphaned package association", { contentId });
+      await deleteContentPackage(azure, ws, contentProductId);
+      await deleteContentPackage(azure, ws, contentId);
+      res = await put();
+    }
     logger?.info("content-install: solution install PUT", {
       packageId,
       status: res.status,
@@ -515,5 +546,23 @@ export async function installSolution(
       : { name: displayName, ok: false, detail: failDetail(res) };
   } catch (err) {
     return { name: displayName, ok: false, detail: errText(err) };
+  }
+}
+
+/** Uninstall (DELETE) a contentPackages resource by name; best-effort, never throws. */
+async function deleteContentPackage(
+  azure: AzureManagement,
+  ws: WorkspaceScope,
+  name: string,
+): Promise<void> {
+  if (name === "") return;
+  try {
+    await azure.request({
+      method: "DELETE",
+      path: `${workspaceInsightsScope(ws)}/contentPackages/${name}`,
+      apiVersion: SECURITY_INSIGHTS_API_VERSION,
+    });
+  } catch {
+    /* best-effort - a retry PUT still surfaces any real failure */
   }
 }


### PR DESCRIPTION
A prior partial/failed install (the earlier hung Microsoft.Resources/deployments attempts) can leave an orphan contentPackages resource that already owns the solution contentId under a different resource name (the versioned contentProductId). The RP then rejects the clean install with "contentId ... is already associated with another package".

installSolution now:
- short-circuits to success when the product package already reports installedVersion;
- on that specific 400, DELETEs the orphan package(s) - safe because two Solutions never share a contentId, so it can only be a stale copy of this solution - then retries the install once;
- PUTs/DELETEs under the canonical short contentId name.

Verified against the Content Package Install/Uninstall/List REST docs and the contentId-uniqueness semantics in azure-rest-api-specs PR #23151. Core content-install tests: 30 passing. Packaged 1.2.154.

Generated with Claude Code