### PR TITLE
Tag Content Hub deprecated solutions in the browser

### DIFF
--- a/soc-optimizationtoolkit/apps/cribl-app/package.json
+++ b/soc-optimizationtoolkit/apps/cribl-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "soc-optimizationtoolkit",
   "private": true,
-  "version": "1.2.155",
+  "version": "1.2.156",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/soc-optimizationtoolkit/packages/core/src/usecases/content-install/available-content.test.ts
+++ b/soc-optimizationtoolkit/packages/core/src/usecases/content-install/available-content.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Pins for Content Hub deprecation lookup (2026-07-15): a solution's
+ * authoritative deprecation comes from the Content Hub catalog
+ * (properties.isDeprecated or a "(Deprecated)"/"(Legacy)" displayName), keyed
+ * so a repo folder name ("Cloudflare") matches the Hub package name
+ * ("Cloudflare (Deprecated)").
+ */
+
+import { describe, expect, it } from "vitest";
+import { FakeAzureManagement } from "../../testing/index";
+import {
+  deprecatedSolutionKey,
+  listDeprecatedContentHubSolutions,
+} from "./available-content";
+import type { WorkspaceScope } from "./content-install";
+
+const WS: WorkspaceScope = {
+  subscriptionId: "sub",
+  resourceGroup: "rg",
+  workspaceName: "law",
+  location: "eastus",
+};
+
+describe("deprecatedSolutionKey", () => {
+  it("reduces a Hub '(Deprecated)' name and the repo name to the same key", () => {
+    expect(deprecatedSolutionKey("Cloudflare (Deprecated)")).toBe(
+      deprecatedSolutionKey("Cloudflare"),
+    );
+    expect(deprecatedSolutionKey("Cloudflare (Deprecated)")).toBe("cloudflare");
+  });
+
+  it("strips a '(Legacy)' marker too", () => {
+    expect(deprecatedSolutionKey("Forescout (Legacy)")).toBe("forescout");
+  });
+});
+
+describe("listDeprecatedContentHubSolutions", () => {
+  it("collects keys for isDeprecated and '(Deprecated)'-named packages only", async () => {
+    const azure = new FakeAzureManagement();
+    azure.respondWith({
+      status: 200,
+      body: {
+        value: [
+          { properties: { displayName: "Cloudflare (Deprecated)", isDeprecated: "true" } },
+          { properties: { displayName: "Zscaler Internet Access" } }, // active
+          { properties: { displayName: "Forescout", isDeprecated: true } }, // flag only
+        ],
+      },
+    });
+    const keys = await listDeprecatedContentHubSolutions(azure, WS);
+    expect(keys.has("cloudflare")).toBe(true);
+    expect(keys.has("forescout")).toBe(true);
+    expect(keys.has(deprecatedSolutionKey("Zscaler Internet Access"))).toBe(false);
+    expect(azure.calls[0].path).toContain("/contentProductPackages");
+  });
+
+  it("degrades to an empty set when the listing fails (never throws)", async () => {
+    const azure = new FakeAzureManagement();
+    azure.respondWith({ status: 403, body: "denied" });
+    const keys = await listDeprecatedContentHubSolutions(azure, WS);
+    expect(keys.size).toBe(0);
+  });
+});

--- a/soc-optimizationtoolkit/packages/core/src/usecases/content-install/available-content.ts
+++ b/soc-optimizationtoolkit/packages/core/src/usecases/content-install/available-content.ts
@@ -103,6 +103,65 @@ export async function findSolutionCatalogEntry(
 }
 
 /**
+ * Normalize a solution name to a deprecation-match key: strip a "(Deprecated)"
+ * / "(Legacy)" marker, then normalize. The Content Hub package displayName
+ * ("Cloudflare (Deprecated)") and the repo folder name ("Cloudflare") both
+ * reduce to the same key, so a repo-listed solution can be matched against the
+ * authoritative Content Hub deprecation flag.
+ */
+export function deprecatedSolutionKey(name: string): string {
+  return normName(name.replace(/\(?\s*(?:deprecated|legacy)\s*\)?/gi, ""));
+}
+
+/**
+ * The AUTHORITATIVE set of deprecated solutions from the workspace's Content
+ * Hub catalog (contentProductPackages) - a package is deprecated when its
+ * properties.isDeprecated is set or its displayName carries a Deprecated /
+ * Legacy marker. Returned as {@link deprecatedSolutionKey} keys so the solution
+ * browser (which lists REPO folder names) can tag rows the repo heuristics
+ * miss - e.g. Cloudflare, deprecated in the Hub but current in the repo.
+ * Best-effort: a failed listing yields an empty set (no tags), never throws.
+ */
+export async function listDeprecatedContentHubSolutions(
+  azure: AzureManagement,
+  ws: WorkspaceScope,
+  logger?: Logger,
+): Promise<Set<string>> {
+  const scope =
+    `/subscriptions/${ws.subscriptionId}/resourceGroups/${ws.resourceGroup}` +
+    `/providers/Microsoft.OperationalInsights/workspaces/${ws.workspaceName}` +
+    "/providers/Microsoft.SecurityInsights/contentProductPackages";
+  const keys = new Set<string>();
+  let packages: unknown[];
+  try {
+    packages = await listAllPages(
+      azure,
+      { method: "GET", path: scope, apiVersion: SECURITY_INSIGHTS_API_VERSION },
+      "list content product packages",
+    );
+  } catch (err) {
+    logger?.warn("content-install: deprecated-solutions listing failed", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return keys;
+  }
+  for (const p of packages) {
+    const props = prop(p, "properties");
+    const displayName = str(prop(props, "displayName"));
+    const isDep = prop(props, "isDeprecated");
+    const deprecated =
+      isDep === true ||
+      (typeof isDep === "string" && isDep.toLowerCase() === "true") ||
+      /\b(?:deprecated|legacy)\b/i.test(displayName);
+    if (deprecated && displayName !== "") keys.add(deprecatedSolutionKey(displayName));
+  }
+  logger?.info("content-install: content hub deprecated solutions", {
+    count: keys.size,
+  });
+  return keys;
+}
+
+/**
  * Read a solution's shipped analytics rules from the Sentinel repo (first
  * rule-directory variant that yields YAMLs), parsed for install. Capped.
  */

--- a/soc-optimizationtoolkit/packages/core/src/usecases/content-install/index.ts
+++ b/soc-optimizationtoolkit/packages/core/src/usecases/content-install/index.ts
@@ -29,5 +29,7 @@ export {
   availableAnalyticRules,
   availableParsers,
   availableWorkbooks,
+  deprecatedSolutionKey,
   findSolutionCatalogEntry,
+  listDeprecatedContentHubSolutions,
 } from "./available-content";

--- a/soc-optimizationtoolkit/packages/ui/src/screens/integrate/integrate-screen.tsx
+++ b/soc-optimizationtoolkit/packages/ui/src/screens/integrate/integrate-screen.tsx
@@ -996,7 +996,12 @@ export function IntegrateScreen({
 
   // ---- Section bodies (built sections only) -----------------------------
 
-  const solutionBody = <SolutionBrowser onSelect={handleSolutionChange} />;
+  const solutionBody = (
+    <SolutionBrowser
+      onSelect={handleSolutionChange}
+      scopeCommitted={scopeCommitted}
+    />
+  );
 
   const sampleDataBody = (
     <>

--- a/soc-optimizationtoolkit/packages/ui/src/screens/solution-browser/solution-browser.tsx
+++ b/soc-optimizationtoolkit/packages/ui/src/screens/solution-browser/solution-browser.tsx
@@ -25,13 +25,15 @@ import {
   classifySolutionIngestion,
   connectorsCacheKey,
   decodeConnector,
+  deprecatedSolutionKey,
   ingestionTierLabel,
   ingestionTierReason,
+  listDeprecatedContentHubSolutions,
   lookupSolutionIngestion,
   solutionIndexCacheKey,
   toVendorLogTypes,
 } from "@soc/core";
-import type { IngestionClass, SolutionRef } from "@soc/core";
+import type { IngestionClass, SolutionRef, WorkspaceScope } from "@soc/core";
 import { usePorts } from "../../ports-context";
 import {
   buildSolutionDeepLink,
@@ -49,6 +51,13 @@ export interface SolutionBrowserProps {
    * readiness pill. Called on every selection change.
    */
   onSelect?: (solution: SolutionRef | null) => void;
+  /**
+   * When true (an Azure target scope is committed), the browser cross-
+   * references the Content Hub catalog for AUTHORITATIVE deprecation - the
+   * repo folder heuristics miss solutions the Hub deprecated (e.g. Cloudflare,
+   * current in the repo but deprecated as a Content Hub package).
+   */
+  scopeCommitted?: boolean;
 }
 
 // The cap on how many connector files a selected solution decodes for the
@@ -75,12 +84,15 @@ type DetailState =
   | { phase: "loaded"; detail: SolutionDetail }
   | { phase: "error"; message: string };
 
-export function SolutionBrowser({ onSelect }: SolutionBrowserProps) {
-  const { ports } = usePorts();
+export function SolutionBrowser({ onSelect, scopeCommitted }: SolutionBrowserProps) {
+  const { ports, config } = usePorts();
   const content = ports.content;
   const cache = ports.contentCache;
 
   const [solutions, setSolutions] = useState<SolutionRef[] | null>(null);
+  // Authoritative Content Hub deprecation keys (populated when a scope is
+  // committed); merged into the repo deprecation signal below.
+  const [hubDeprecated, setHubDeprecated] = useState<Set<string>>(new Set());
   const [commitSha, setCommitSha] = useState<string | null>(null);
   const [loadError, setLoadError] = useState("");
   const [query, setQuery] = useState("");
@@ -132,6 +144,55 @@ export function SolutionBrowser({ onSelect }: SolutionBrowserProps) {
   useEffect(() => {
     void loadIndex();
   }, [loadIndex]);
+
+  // Cross-reference the Content Hub catalog for authoritative deprecation once
+  // a scope is committed (the repo folder heuristics miss Hub-deprecated
+  // solutions like Cloudflare). Best-effort: a failure leaves the set empty.
+  useEffect(() => {
+    if (
+      scopeCommitted !== true ||
+      config.subscriptionId === "" ||
+      config.resourceGroup === "" ||
+      config.workspaceName === ""
+    ) {
+      setHubDeprecated(new Set());
+      return;
+    }
+    let cancelled = false;
+    const scope: WorkspaceScope = {
+      subscriptionId: config.subscriptionId,
+      resourceGroup: config.resourceGroup,
+      workspaceName: config.workspaceName,
+      location: "",
+    };
+    void listDeprecatedContentHubSolutions(ports.azure, scope, ports.logger).then(
+      (set) => {
+        if (!cancelled) setHubDeprecated(set);
+      },
+    );
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    scopeCommitted,
+    config.subscriptionId,
+    config.resourceGroup,
+    config.workspaceName,
+    ports.azure,
+    ports.logger,
+  ]);
+
+  // Repo index + the authoritative Content Hub deprecation, merged: a solution
+  // the Hub flags is marked deprecated even when the repo folder is not.
+  const mergedSolutions = useMemo<SolutionRef[] | null>(() => {
+    if (solutions === null) return null;
+    if (hubDeprecated.size === 0) return solutions;
+    return solutions.map((s) =>
+      s.deprecated !== true && hubDeprecated.has(deprecatedSolutionKey(s.name))
+        ? { ...s, deprecated: true, deprecationReason: "Deprecated in the Microsoft Content Hub" }
+        : s,
+    );
+  }, [solutions, hubDeprecated]);
 
   // Fetch (and cache) one solution's connector detail on demand.
   const loadDetail = useCallback(
@@ -240,19 +301,19 @@ export function SolutionBrowser({ onSelect }: SolutionBrowserProps) {
   }, [solutions, deepLinkName, selectedName, select]);
 
   const counts = useMemo(
-    () => (solutions === null ? null : solutionCounts(solutions)),
-    [solutions],
+    () => (mergedSolutions === null ? null : solutionCounts(mergedSolutions)),
+    [mergedSolutions],
   );
   const visible = useMemo(
     () =>
-      solutions === null
+      mergedSolutions === null
         ? []
-        : filterSolutions(solutions, { query, hideDeprecated }),
-    [solutions, query, hideDeprecated],
+        : filterSolutions(mergedSolutions, { query, hideDeprecated }),
+    [mergedSolutions, query, hideDeprecated],
   );
   const selected = useMemo(
-    () => resolveSelectedSolution(solutions ?? [], selectedName),
-    [solutions, selectedName],
+    () => resolveSelectedSolution(mergedSolutions ?? [], selectedName),
+    [mergedSolutions, selectedName],
   );
 
   if (content === undefined) {


### PR DESCRIPTION
The browser lists GitHub repo folders, so its deprecation heuristics miss solutions Microsoft deprecated at the CONTENT HUB level - e.g. Cloudflare, whose repo folder is current (ships a modern CCF connector) but whose Content Hub package is "Cloudflare (Deprecated)".

When an Azure scope is committed, the browser now cross-references the Content Hub catalog (contentProductPackages) for the authoritative deprecation signal (properties.isDeprecated or a "(Deprecated)"/"(Legacy)" displayName) and merges it into the repo deprecation flag. A shared key normalizer maps the Hub package name to the repo folder name, so the merged signal flows through the existing DEPRECATED badge, counts, and hide-deprecated toggle uniformly. Falls back to repo heuristics when no scope is committed.

Full suites green (core 2272, ui 539). Packaged 1.2.156.

Generated with Claude Code