### PR TITLE
Fix solution-installed detection, rule tactics (CRLF), workbook region

### DIFF
--- a/soc-optimizationtoolkit/apps/cribl-app/package.json
+++ b/soc-optimizationtoolkit/apps/cribl-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "soc-optimizationtoolkit",
   "private": true,
-  "version": "1.2.156",
+  "version": "1.2.157",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/soc-optimizationtoolkit/packages/core/src/domain/coverage-analysis/parse-analytic-rule.test.ts
+++ b/soc-optimizationtoolkit/packages/core/src/domain/coverage-analysis/parse-analytic-rule.test.ts
@@ -90,6 +90,31 @@ describe("parseAnalyticRuleYaml - field extraction", () => {
   });
 });
 
+describe("CRLF line endings (real Azure-Sentinel rules; fixed 2026-07-16)", () => {
+  // JS regex `.` never matches `\r`, so the list pattern `.+\n` matched ZERO
+  // items on a CRLF file - dropping `tactics`. That made the install PUT send
+  // techniques with an empty tactics field, which Azure rejects ("No valid
+  // tactic corresponding to the technique ...").
+  const CRLF = [
+    "id: 11111111-2222-3333-4444-555555555555",
+    "name: CRLF Rule",
+    "severity: Medium",
+    "tactics:",
+    "  - InitialAccess",
+    "relevantTechniques:",
+    "  - T1190",
+    "query: |",
+    "  Table | take 1",
+    "",
+  ].join("\r\n");
+
+  it("extracts tactics (and techniques) despite CRLF", () => {
+    const r = parseAnalyticRuleYaml(CRLF, "crlf.yaml");
+    expect(r.tactics).toEqual(["InitialAccess"]);
+    expect(r.techniques).toEqual(["T1190"]);
+  });
+});
+
 describe("entity columnName builtins filter (verbatim legacy behavior)", () => {
   it("drops a columnName that is a KQL builtin (e.g. Type)", () => {
     const yaml = `name: R

--- a/soc-optimizationtoolkit/packages/core/src/domain/coverage-analysis/parse-analytic-rule.ts
+++ b/soc-optimizationtoolkit/packages/core/src/domain/coverage-analysis/parse-analytic-rule.ts
@@ -51,9 +51,16 @@ import type {
  * Do NOT compromise core purity for the convenience of a runtime YAML library.
  */
 export function parseAnalyticRuleYaml(
-  content: string,
+  contentRaw: string,
   fileName: string,
 ): ParsedAnalyticRule {
+  // Normalize CRLF -> LF up front. JS regex `.` never matches `\r`, so a
+  // list pattern like `(?:\s+-\s+.+\n)*` (tactics, dataTypes) silently matches
+  // ZERO items on a CRLF file - `.+` stops before `\r` and the required `\n`
+  // can't match `\r`. That dropped `tactics` on CRLF rules, so Azure rejected
+  // the install ("No valid tactic corresponding to the technique ..."):
+  // techniques were sent with an empty tactics field.
+  const content = contentRaw.replace(/\r\n?/g, "\n");
   const id = content.match(/^id:\s*(.+)/m)?.[1]?.trim() || "";
   const name =
     content

--- a/soc-optimizationtoolkit/packages/ui/src/screens/content-install/content-install-section.tsx
+++ b/soc-optimizationtoolkit/packages/ui/src/screens/content-install/content-install-section.tsx
@@ -291,6 +291,34 @@ export function ContentInstallSection({
     setOutcomeSource("workbooks");
     setOutcomes([]);
     try {
+      // Workbooks are REGIONAL: the PUT needs a non-empty location or the API
+      // rejects it with "A payload is required." Ensure the workspace region is
+      // known (fetch it on demand if the earlier load did not), and fail with a
+      // clear message rather than sending an empty location.
+      let loc = location ?? "";
+      if (loc === "") {
+        loc =
+          (await fetchWorkspaceLocation(
+            ports.azure,
+            config.subscriptionId,
+            config.resourceGroup,
+            config.workspaceName,
+          )) ?? "";
+        if (loc !== "") setLocation(loc);
+      }
+      if (loc === "") {
+        setOutcomes([
+          {
+            name: "Workbooks",
+            ok: false,
+            detail:
+              "the workspace region could not be determined; regional " +
+              "workbooks cannot be installed without it (reload and retry)",
+          },
+        ]);
+        return;
+      }
+      const wbScope: WorkspaceScope = { ...scope, location: loc };
       const selected = wbSplit.installable.filter((w) => wbSel.has(w.displayName));
       const parserOutcomes = await installParsers();
       const wbOutcomes: ContentInstallOutcome[] = [];
@@ -300,7 +328,7 @@ export function ContentInstallSection({
         wbOutcomes.push(
           await installWorkbook(
             ports.azure,
-            scope,
+            wbScope,
             { displayName: wb.displayName, serializedData: wb.serializedData },
             mintId,
           ),
@@ -312,7 +340,18 @@ export function ContentInstallSection({
       setProgress("");
       void load(true); // keep the install outcome visible through the refresh
     }
-  }, [mintId, canInstall, wbSplit, wbSel, installParsers, ports, scope, load]);
+  }, [
+    mintId,
+    canInstall,
+    wbSplit,
+    wbSel,
+    installParsers,
+    ports,
+    scope,
+    load,
+    location,
+    config,
+  ]);
 
   // Enable Microsoft Sentinel on the workspace (the not-onboarded remedy):
   // the SecurityInsights provider rejects every content call until Sentinel
@@ -360,6 +399,16 @@ export function ContentInstallSection({
   }
 
   const grouped = partitionOutcomes(outcomes);
+
+  // "Is the solution installed?" - the AUTHORITATIVE signal is the installed
+  // contentPackages list (installedContentState.solutionInstalled), NOT the
+  // catalog's installedVersion: installedVersion is an EXPANDABLE property the
+  // contentProductPackages LIST omits, so it reads null even when installed.
+  const solutionInstalledVersion =
+    installed?.installedSolutionVersion ?? catalog?.installedVersion ?? null;
+  const solutionIsInstalled =
+    catalog !== null &&
+    (installed?.solutionInstalled === true || catalog.installedVersion !== null);
 
   // Progress + per-item outcomes for one install control, rendered directly
   // beneath the button that triggered it (never in a distant block).
@@ -453,10 +502,13 @@ export function ContentInstallSection({
               ? "Load to look up this solution in Content Hub."
               : "Commit a target scope, then load to look up the Content Hub package."}
           </p>
-        ) : catalog.installedVersion !== null ? (
+        ) : solutionIsInstalled ? (
           <p className="content-install-installed">
-            Installed (version {catalog.installedVersion}). Latest available:{" "}
-            {catalog.version}.
+            Installed
+            {solutionInstalledVersion !== null
+              ? ` (version ${solutionInstalledVersion})`
+              : ""}
+            . Latest available: {catalog.version}.
           </p>
         ) : (
           <>


### PR DESCRIPTION
Three content-install issues surfaced live on the Cloudflare solution:

1. **Solution showed "not installed" when installed.** The gate read `catalog.installedVersion`, an EXPANDABLE property the contentProductPackages LIST omits (null even when installed). Now uses the authoritative installed `contentPackages` signal (`installedContentState.solutionInstalled` / `installedSolutionVersion`), falling back to the catalog value.

2. **Analytics-rule install failed:** `No valid tactic corresponding to the technique T1190 was provided in the tactics field.` Root cause: the rule YAML uses CRLF and JS regex `.` never matches `\r`, so the `.+\n` list pattern matched ZERO tactics - we sent techniques with an empty tactics field. Fix: normalize CRLF->LF at the top of `parseAnalyticRuleYaml`. Characterization test added.

3. **Workbook install failed:** `A payload is required.` Workbooks are regional; the PUT needs a non-empty `location`. When `fetchWorkspaceLocation` returned null, location was `""` and the API rejected the body. `doInstallWorkbooks` now ensures the region (fetching on demand) and reports a clear error instead of sending an empty location.

Full suites green (core 2273, ui 539). Packaged 1.2.157.

Generated with Claude Code