### PR TITLE
Dedupe parser functions; guard empty workbook payload

### DIFF
--- a/soc-optimizationtoolkit/apps/cribl-app/package.json
+++ b/soc-optimizationtoolkit/apps/cribl-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "soc-optimizationtoolkit",
   "private": true,
-  "version": "1.2.157",
+  "version": "1.2.158",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/soc-optimizationtoolkit/packages/core/src/usecases/content-install/content-install.test.ts
+++ b/soc-optimizationtoolkit/packages/core/src/usecases/content-install/content-install.test.ts
@@ -10,6 +10,7 @@ import { FakeAzureManagement } from "../../testing/index";
 import type { ParsedAnalyticRule } from "../../domain/coverage-analysis/index";
 import {
   installAnalyticRule,
+  installParser,
   installWorkbook,
   installSolution,
   installedContentState,
@@ -89,6 +90,77 @@ describe("installWorkbook", () => {
     expect(outcome).toEqual({ name: "Overview", ok: true, detail: "installed" });
     expect(azure.calls[0].path).toContain("/providers/Microsoft.Insights/workbooks/");
     expect(azure.calls[0].apiVersion).toBe("2021-08-01");
+  });
+
+  it("fails clearly (no PUT) when the workbook content is empty", async () => {
+    const azure = new FakeAzureManagement();
+    const outcome = await installWorkbook(
+      azure,
+      WS,
+      { displayName: "Empty", serializedData: "   " },
+      mintId,
+    );
+    expect(outcome.ok).toBe(false);
+    expect(outcome.detail).toContain("empty");
+    expect(azure.calls).toHaveLength(0);
+  });
+
+  it("fails clearly (no PUT) when the workspace region is unknown", async () => {
+    const azure = new FakeAzureManagement();
+    const outcome = await installWorkbook(
+      azure,
+      { ...WS, location: "" },
+      { displayName: "WB", serializedData: '{"items":[]}' },
+      mintId,
+    );
+    expect(outcome.ok).toBe(false);
+    expect(outcome.detail).toContain("region");
+    expect(azure.calls).toHaveLength(0);
+  });
+});
+
+describe("installParser (duplicate-alias safety)", () => {
+  const parser = {
+    alias: "Cloudflare",
+    displayName: "Cloudflare",
+    query: "T | take 1",
+    functionParameters: "",
+  };
+
+  it("PUTs the function when no other resource provides the alias", async () => {
+    const azure = new FakeAzureManagement();
+    azure.respondWith(
+      { status: 200, body: { value: [] } }, // list savedSearches: none
+      { status: 200, body: {} }, // PUT ours
+    );
+    const outcome = await installParser(azure, WS, parser);
+    expect(outcome).toEqual({ name: "Cloudflare (parser)", ok: true, detail: "installed" });
+    expect(azure.calls[1].method).toBe("PUT");
+    expect(azure.calls[1].path).toContain("/savedSearches/parser-cloudflare");
+  });
+
+  it("defers to another provider and deletes our duplicate copy", async () => {
+    const azure = new FakeAzureManagement();
+    azure.respondWith(
+      {
+        status: 200,
+        body: {
+          value: [
+            // The solution's own parser under a DIFFERENT resource name.
+            { name: "cloudflare.sol.func", properties: { functionAlias: "Cloudflare" } },
+            // Our earlier deterministic copy - the duplicate to remove.
+            { name: "parser-cloudflare", properties: { functionAlias: "Cloudflare" } },
+          ],
+        },
+      },
+      { status: 200, body: {} }, // DELETE ours
+    );
+    const outcome = await installParser(azure, WS, parser);
+    expect(outcome.ok).toBe(true);
+    expect(outcome.detail).toContain("already provided");
+    expect(azure.calls[0].method).toBe("GET");
+    expect(azure.calls[1].method).toBe("DELETE");
+    expect(azure.calls[1].path).toContain("/savedSearches/parser-cloudflare");
   });
 });
 

--- a/soc-optimizationtoolkit/packages/core/src/usecases/content-install/content-install.ts
+++ b/soc-optimizationtoolkit/packages/core/src/usecases/content-install/content-install.ts
@@ -383,6 +383,23 @@ export async function installWorkbook(
   spec: WorkbookInstallSpec,
   mintId: () => string,
 ): Promise<ContentInstallOutcome> {
+  // The workbooks API rejects an empty body with "A payload is required." Fail
+  // with a precise reason rather than that opaque message if the content or
+  // region is missing (both are required: serializedData and a regional location).
+  if (spec.serializedData.trim() === "") {
+    return {
+      name: spec.displayName,
+      ok: false,
+      detail: "the workbook content was empty (nothing to install)",
+    };
+  }
+  if (ws.location.trim() === "") {
+    return {
+      name: spec.displayName,
+      ok: false,
+      detail: "the workspace region is unknown; regional workbooks need it",
+    };
+  }
   const body = workbookResourceBody({
     displayName: spec.displayName,
     serializedData: spec.serializedData,
@@ -416,6 +433,14 @@ export async function installWorkbook(
  * installed (they query the function by alias), not as a user choice - so
  * the UI reports them but never asks. The savedSearch id is derived from the
  * alias (deterministic + idempotent: a re-install PUTs over the same id).
+ *
+ * DUPLICATE-ALIAS SAFETY: the SecurityInsights RP lets two savedSearches
+ * carry the SAME functionAlias under different resource names (the solution's
+ * own parser + ours), and a query that references the alias then fails to
+ * compile ("Detected multiple functions with the same name"). So before
+ * creating ours, look for an EXISTING function with this alias from another
+ * source; if one exists, delete our deterministic copy (if any) and defer to
+ * it - leaving exactly one provider.
  */
 export async function installParser(
   azure: AzureManagement,
@@ -423,18 +448,56 @@ export async function installParser(
   parser: ParserResource,
 ): Promise<ContentInstallOutcome> {
   const searchId = `parser-${parser.alias}`.toLowerCase().replace(/[^a-z0-9-]/g, "-");
+  const searchPath = `${workspaceResourceId(ws)}/savedSearches/${searchId}`;
+  const label = `${parser.displayName} (parser)`;
   try {
+    // Which resources already provide this alias? (Best-effort: if the listing
+    // fails, fall through to a plain idempotent PUT.)
+    const aliasLc = parser.alias.toLowerCase();
+    let othersProvideAlias = false;
+    try {
+      const all = await listAllPages(
+        azure,
+        {
+          method: "GET",
+          path: `${workspaceResourceId(ws)}/savedSearches`,
+          apiVersion: SAVED_SEARCHES_API_VERSION,
+        },
+        "list saved searches",
+      );
+      othersProvideAlias = all.some((s) => {
+        const name = str(prop(s, "name")).toLowerCase();
+        const alias = str(prop(prop(s, "properties"), "functionAlias")).toLowerCase();
+        return alias === aliasLc && name !== searchId;
+      });
+    } catch {
+      /* listing unavailable - fall through to the plain PUT below */
+    }
+    if (othersProvideAlias) {
+      // Another resource already provides this function. Remove OUR own copy
+      // (deterministic id) if it exists so exactly one remains, and defer.
+      try {
+        await azure.request({
+          method: "DELETE",
+          path: searchPath,
+          apiVersion: SAVED_SEARCHES_API_VERSION,
+        });
+      } catch {
+        /* best-effort cleanup */
+      }
+      return { name: label, ok: true, detail: "already provided by the solution" };
+    }
     const res = await azure.request({
       method: "PUT",
-      path: `${workspaceResourceId(ws)}/savedSearches/${searchId}`,
+      path: searchPath,
       apiVersion: SAVED_SEARCHES_API_VERSION,
       body: parserResourceBody(parser),
     });
     return is2xx(res.status)
-      ? { name: `${parser.displayName} (parser)`, ok: true, detail: "installed" }
-      : { name: `${parser.displayName} (parser)`, ok: false, detail: failDetail(res) };
+      ? { name: label, ok: true, detail: "installed" }
+      : { name: label, ok: false, detail: failDetail(res) };
   } catch (err) {
-    return { name: `${parser.displayName} (parser)`, ok: false, detail: errText(err) };
+    return { name: label, ok: false, detail: errText(err) };
   }
 }
 


### PR DESCRIPTION
Two more content-install fixes, live on the Cloudflare solution:

1. **Analytics-rule compile failure:** `Detected multiple functions with the same name: Cloudflare`. The RP allows two savedSearches with the same functionAlias under different resource names (the solution installs its own parser; we also install one as a rule/workbook dependency), and a rule referencing the alias then fails to compile. `installParser` now checks for an existing provider of the alias and, if found, deletes our deterministic `parser-<alias>` copy and defers - leaving exactly one function. Idempotent PUT when none exists.

2. **Workbook opaque error** `A payload is required.` `installWorkbook` now fails with a precise reason when `serializedData` is empty or the workspace region is unknown (both required) instead of surfacing that message - making the real precondition visible for diagnosis.

Full suites green (core 2277, ui 539). Packaged 1.2.158.

Generated with Claude Code