### PR TITLE
Explain the missing-table rule failure clearly

### DIFF
--- a/soc-optimizationtoolkit/apps/cribl-app/package.json
+++ b/soc-optimizationtoolkit/apps/cribl-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "soc-optimizationtoolkit",
   "private": true,
-  "version": "1.2.158",
+  "version": "1.2.159",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/soc-optimizationtoolkit/packages/core/src/usecases/content-install/content-install.test.ts
+++ b/soc-optimizationtoolkit/packages/core/src/usecases/content-install/content-install.test.ts
@@ -68,6 +68,24 @@ describe("installAnalyticRule", () => {
     expect(outcome.detail).toContain("HTTP 400");
   });
 
+  it("gives actionable guidance when the rule's data table does not exist", async () => {
+    const azure = new FakeAzureManagement();
+    azure.respondWith({
+      status: 400,
+      body: {
+        error: {
+          code: "BadRequest",
+          message:
+            "Failed to run the analytics rule query. One of the tables does not exist.",
+        },
+      },
+    });
+    const outcome = await installAnalyticRule(azure, WS, rule({}), mintId);
+    expect(outcome.ok).toBe(false);
+    expect(outcome.detail).toContain("does not exist in the workspace yet");
+    expect(outcome.detail).toContain("Raw error");
+  });
+
   it("skips unsupported kinds without any ARM call", async () => {
     const azure = new FakeAzureManagement();
     const outcome = await installAnalyticRule(azure, WS, rule({ kind: "Fusion" }), mintId);

--- a/soc-optimizationtoolkit/packages/core/src/usecases/content-install/content-install.ts
+++ b/soc-optimizationtoolkit/packages/core/src/usecases/content-install/content-install.ts
@@ -174,6 +174,27 @@ function failDetail(res: PortHttpResponse): string {
   return `HTTP ${res.status}${body && body !== "null" ? ` ${body}` : ""}`;
 }
 
+/**
+ * A rule PUT is validated against the workspace: Azure compiles the query and
+ * rejects it when a table it reads does not exist yet ("Failed to run the
+ * analytics rule query. One of the tables does not exist."). That is a
+ * workflow dependency, not a tooling bug - the source's data table is created
+ * when ingestion is set up (its DCR / custom table) and data arrives. Turn the
+ * opaque message into actionable guidance, keeping the raw error for reference.
+ */
+function ruleFailureDetail(res: PortHttpResponse): string {
+  const text = bodyText(res);
+  if (/does not exist|Failed to run the analytics rule query/i.test(text)) {
+    return (
+      "the rule's data table does not exist in the workspace yet - set up " +
+      "ingestion for this source first (create its DCR / custom table and let " +
+      "data arrive), then install the rule. Raw error: " +
+      failDetail(res)
+    );
+  }
+  return failDetail(res);
+}
+
 function is2xx(status: number): boolean {
   return status >= 200 && status < 300;
 }
@@ -360,7 +381,7 @@ export async function installAnalyticRule(
     });
     return is2xx(res.status)
       ? { name: rule.name, ok: true, detail: `installed (${resource.kind})` }
-      : { name: rule.name, ok: false, detail: failDetail(res) };
+      : { name: rule.name, ok: false, detail: ruleFailureDetail(res) };
   } catch (err) {
     return { name: rule.name, ok: false, detail: errText(err) };
   }


### PR DESCRIPTION
Installing a rule validates its query against the workspace; Azure rejects it when a table it reads does not exist yet ("Failed to run the analytics rule query. One of the tables does not exist."). That is a workflow dependency, not a bug. Turn the opaque message into actionable guidance, keeping the raw error. Follow-up will auto-create the table from the CustomTables repo schema. Packaged 1.2.159.

Generated with Claude Code