### PR TITLE
Auto-create a rule's custom tables from CustomTables repo schema

### DIFF
--- a/soc-optimizationtoolkit/apps/cribl-app/package.json
+++ b/soc-optimizationtoolkit/apps/cribl-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "soc-optimizationtoolkit",
   "private": true,
-  "version": "1.2.159",
+  "version": "1.2.160",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/soc-optimizationtoolkit/packages/core/src/usecases/content-install/ensure-tables.test.ts
+++ b/soc-optimizationtoolkit/packages/core/src/usecases/content-install/ensure-tables.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Pins for auto-creating a rule's dependency table (2026-07-16): an existing
+ * (native/standard) table short-circuits; a missing custom table is CREATED
+ * from the CustomTables repo schema (PUT then readback poll); a data type the
+ * repo does not define resolves a clear non-fatal outcome.
+ */
+
+import { describe, expect, it } from "vitest";
+import { FakeAzureManagement, FakeSentinelContent } from "../../testing/index";
+import { ensureRuleDataTable } from "./ensure-tables";
+import type { WorkspaceScope } from "./content-install";
+
+const WS: WorkspaceScope = {
+  subscriptionId: "sub",
+  resourceGroup: "rg",
+  workspaceName: "law",
+  location: "eastus",
+};
+
+const CF_SCHEMA = JSON.stringify({
+  Name: "Cloudflare_CL",
+  Properties: [
+    { Name: "TimeGenerated", Type: "DateTime" },
+    { Name: "ClientIP", Type: "String" },
+    { Name: "EdgeStartTimestamp", Type: "DateTime" },
+  ],
+});
+
+const CUSTOM_TABLES_PATH =
+  ".script/tests/KqlvalidationsTests/CustomTables/Cloudflare_CL.json";
+
+describe("ensureRuleDataTable", () => {
+  it("short-circuits when the table already exists (native or standard)", async () => {
+    const azure = new FakeAzureManagement();
+    azure.respondWith({ status: 200, body: { properties: {} } }); // GET tables/SecurityEvent
+    const content = new FakeSentinelContent({ files: {} });
+    const out = await ensureRuleDataTable(azure, content, WS, "SecurityEvent");
+    expect(out).toEqual({
+      table: "SecurityEvent",
+      ok: true,
+      detail: "already exists",
+      created: false,
+    });
+    expect(azure.calls).toHaveLength(1);
+  });
+
+  it("creates a missing custom table from the CustomTables repo schema", async () => {
+    const azure = new FakeAzureManagement();
+    azure.respondWith(
+      { status: 404, body: { error: "not found" } }, // GET tables/Cloudflare
+      { status: 404, body: { error: "not found" } }, // GET tables/Cloudflare_CL
+      { status: 200, body: {} }, // PUT tables/Cloudflare_CL
+      { status: 200, body: { properties: { provisioningState: "Succeeded" } } }, // poll
+    );
+    const content = new FakeSentinelContent({ files: { [CUSTOM_TABLES_PATH]: CF_SCHEMA } });
+    const out = await ensureRuleDataTable(azure, content, WS, "Cloudflare");
+    expect(out.ok).toBe(true);
+    expect(out.created).toBe(true);
+    expect(out.table).toBe("Cloudflare_CL");
+    const put = azure.calls[2];
+    expect(put.method).toBe("PUT");
+    expect(put.path).toContain("/tables/Cloudflare_CL");
+    // The PUT body carries the repo columns (system-safe; TimeGenerated kept).
+    const body = put.body as { properties: { schema: { columns: { name: string }[] } } };
+    const names = body.properties.schema.columns.map((c) => c.name);
+    expect(names).toContain("ClientIP");
+  });
+
+  it("reports a clear non-fatal outcome when the repo has no schema", async () => {
+    const azure = new FakeAzureManagement();
+    azure.respondWith(
+      { status: 404, body: {} }, // GET tables/Weird
+      { status: 404, body: {} }, // GET tables/Weird_CL
+    );
+    const content = new FakeSentinelContent({ files: {} }); // no schema file
+    const out = await ensureRuleDataTable(azure, content, WS, "Weird");
+    expect(out.ok).toBe(false);
+    expect(out.created).toBe(false);
+    expect(out.detail).toContain("CustomTables repo");
+    // No PUT is attempted when there is no schema to create from.
+    expect(azure.calls.every((c) => c.method === "GET")).toBe(true);
+  });
+});

--- a/soc-optimizationtoolkit/packages/core/src/usecases/content-install/ensure-tables.ts
+++ b/soc-optimizationtoolkit/packages/core/src/usecases/content-install/ensure-tables.ts
@@ -1,0 +1,212 @@
+/**
+ * Auto-create a rule's dependency tables (user direction 2026-07-16). Azure
+ * validates an analytics rule's query at install time and rejects it when a
+ * table it reads does not exist ("One of the tables does not exist."). When
+ * that table is a custom (_CL) table the Azure-Sentinel CustomTables repo
+ * defines, the toolkit can CREATE it from that authoritative schema first, so
+ * the rule installs - instead of forcing the user to set up ingestion before
+ * any content lands.
+ *
+ * Schema source: `.script/tests/KqlvalidationsTests/CustomTables/<Table>.json`
+ * (the schemas Microsoft's own CI validates every solution's KQL against),
+ * read through the SentinelContent port and parsed by parseKqlValidationTable.
+ *
+ * Pure orchestration over the AzureManagement + SentinelContent ports; never
+ * throws (every path resolves an outcome).
+ */
+
+import type { AzureManagement } from "../../ports/azure-management";
+import type { SentinelContent } from "../../ports/sentinel-content";
+import type { Logger } from "../../ports/logger";
+import {
+  buildTablePutRequest,
+  LOG_ANALYTICS_TABLES_API_VERSION,
+} from "../../domain/custom-table/index";
+import {
+  KQL_VALIDATION_TABLES_DIR,
+  parseKqlValidationTable,
+} from "../../domain/field-matcher/index";
+import type { WorkspaceScope } from "./content-install";
+
+/** The result of ensuring one dependency table. */
+export interface EnsureTableOutcome {
+  table: string;
+  ok: boolean;
+  /** created | already exists | a failure reason. */
+  detail: string;
+  /** True only when this call CREATED the table (vs it already existing). */
+  created: boolean;
+}
+
+/** Attempt-bounded poll for the created table to read back terminal. */
+const DEFAULT_TABLE_POLL_ATTEMPTS = 12;
+
+function workspacePath(ws: WorkspaceScope): string {
+  return (
+    `/subscriptions/${ws.subscriptionId}/resourceGroups/${ws.resourceGroup}` +
+    `/providers/Microsoft.OperationalInsights/workspaces/${ws.workspaceName}`
+  );
+}
+
+function prop(value: unknown, key: string): unknown {
+  if (typeof value !== "object" || value === null) return undefined;
+  return (value as Record<string, unknown>)[key];
+}
+
+function is2xx(status: number): boolean {
+  return status >= 200 && status < 300;
+}
+
+/**
+ * Fetch a custom table's schema from the CustomTables repo (keyed by the
+ * exact _CL table name). Returns null when the repo does not define it (a
+ * native table, or one only ingestion creates). Never throws.
+ */
+export async function resolveCustomTableSchema(
+  content: SentinelContent,
+  tableName: string,
+): Promise<{ name: string; type: string }[] | null> {
+  try {
+    const text = await content.readFile(
+      `${KQL_VALIDATION_TABLES_DIR}/${tableName}.json`,
+    );
+    if (text === null) return null;
+    return parseKqlValidationTable(text);
+  } catch {
+    return null;
+  }
+}
+
+/** Does a Log Analytics table (native or custom) already exist? */
+export async function customTableExists(
+  azure: AzureManagement,
+  ws: WorkspaceScope,
+  tableName: string,
+): Promise<boolean> {
+  try {
+    const res = await azure.request({
+      method: "GET",
+      path: `${workspacePath(ws)}/tables/${tableName}`,
+      apiVersion: LOG_ANALYTICS_TABLES_API_VERSION,
+    });
+    return is2xx(res.status);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Ensure the table a rule's `dataType` reads exists, creating the custom (_CL)
+ * table from the CustomTables repo schema when it does not. `dataType` is the
+ * rule's declared data type (e.g. "Cloudflare"); the table is that name with
+ * "_CL" appended unless already suffixed. A native/existing table short-
+ * circuits to "already exists"; a data type the repo does not define resolves
+ * a clear non-fatal outcome (the caller still tries the rule).
+ */
+export async function ensureRuleDataTable(
+  azure: AzureManagement,
+  content: SentinelContent,
+  ws: WorkspaceScope,
+  dataType: string,
+  logger?: Logger,
+): Promise<EnsureTableOutcome> {
+  const suffixed = /_CL$/i.test(dataType) ? dataType : `${dataType}_CL`;
+  try {
+    // Already present as the raw name (native/standard) or the _CL name.
+    if (await customTableExists(azure, ws, dataType)) {
+      return { table: dataType, ok: true, detail: "already exists", created: false };
+    }
+    if (suffixed !== dataType && (await customTableExists(azure, ws, suffixed))) {
+      return { table: suffixed, ok: true, detail: "already exists", created: false };
+    }
+    // Missing: resolve the custom-table schema (repo keys by the _CL name).
+    let columns = await resolveCustomTableSchema(content, suffixed);
+    if (columns === null && suffixed !== dataType) {
+      columns = await resolveCustomTableSchema(content, dataType);
+    }
+    if (columns === null || columns.length === 0) {
+      return {
+        table: suffixed,
+        ok: false,
+        created: false,
+        detail:
+          "not defined in the CustomTables repo (a native table, or one only " +
+          "ingestion creates - set up ingestion first)",
+      };
+    }
+    const req = buildTablePutRequest({
+      subscriptionId: ws.subscriptionId,
+      resourceGroup: ws.resourceGroup,
+      workspaceName: ws.workspaceName,
+      table: suffixed,
+      columns: columns.map((c) => ({ name: c.name, type: c.type })),
+    });
+    const res = await azure.request({
+      method: "PUT",
+      path: req.path,
+      apiVersion: req.apiVersion,
+      body: req.body,
+    });
+    if (!is2xx(res.status)) {
+      let body: string;
+      try {
+        body = typeof res.body === "string" ? res.body : JSON.stringify(res.body);
+      } catch {
+        body = String(res.body);
+      }
+      return {
+        table: req.tableName,
+        ok: false,
+        created: false,
+        detail: `create failed: HTTP ${res.status}${body && body !== "null" ? ` ${body}` : ""}`,
+      };
+    }
+    logger?.info("content-install: created dependency table", {
+      table: req.tableName,
+      columns: columns.length,
+    });
+    // Attempt-bounded readback until the table provisions (no timers - the
+    // adapter enforces per-request timeouts; table creation is fast).
+    for (let attempt = 0; attempt < DEFAULT_TABLE_POLL_ATTEMPTS; attempt++) {
+      const poll = await azure.request({
+        method: "GET",
+        path: `${workspacePath(ws)}/tables/${req.tableName}`,
+        apiVersion: LOG_ANALYTICS_TABLES_API_VERSION,
+      });
+      if (!is2xx(poll.status)) continue;
+      const state = prop(prop(poll.body, "properties"), "provisioningState");
+      const stateText = typeof state === "string" ? state : "";
+      if (/^succeeded$/i.test(stateText)) {
+        return {
+          table: req.tableName,
+          ok: true,
+          created: true,
+          detail: `created (${columns.length} columns)`,
+        };
+      }
+      if (/^(failed|canceled)$/i.test(stateText)) {
+        return {
+          table: req.tableName,
+          ok: false,
+          created: false,
+          detail: `create ${stateText.toLowerCase()}`,
+        };
+      }
+    }
+    // Accepted but still provisioning after the bound - treat as created; the
+    // rule install a moment later will find it (or report the table cleanly).
+    return {
+      table: req.tableName,
+      ok: true,
+      created: true,
+      detail: `created (${columns.length} columns; still provisioning)`,
+    };
+  } catch (err) {
+    return {
+      table: suffixed,
+      ok: false,
+      created: false,
+      detail: err instanceof Error ? err.message : String(err),
+    };
+  }
+}

--- a/soc-optimizationtoolkit/packages/core/src/usecases/content-install/index.ts
+++ b/soc-optimizationtoolkit/packages/core/src/usecases/content-install/index.ts
@@ -21,6 +21,12 @@ export {
   onboardSentinelWorkspace,
   workspaceResourceId,
 } from "./content-install";
+export type { EnsureTableOutcome } from "./ensure-tables";
+export {
+  customTableExists,
+  ensureRuleDataTable,
+  resolveCustomTableSchema,
+} from "./ensure-tables";
 export type {
   AvailableWorkbook,
   SolutionCatalogEntry,

--- a/soc-optimizationtoolkit/packages/ui/src/screens/content-install/content-install-section.tsx
+++ b/soc-optimizationtoolkit/packages/ui/src/screens/content-install/content-install-section.tsx
@@ -22,6 +22,7 @@ import {
   availableParsers,
   availableWorkbooks,
   alertRuleResourceFromParsed,
+  ensureRuleDataTable,
   onboardSentinelWorkspace,
   fetchWorkspaceLocation,
   findSolutionCatalogEntry,
@@ -270,6 +271,22 @@ export function ContentInstallSection({
     setOutcomes([]);
     try {
       const selected = ruleSplit.installable.filter((r) => ruleSel.has(r.name));
+      // Auto-create the custom (_CL) tables the selected rules read, from the
+      // CustomTables repo schema, so rule-query validation ("One of the tables
+      // does not exist") passes instead of forcing ingestion setup first.
+      // Only creations/failures are surfaced (an existing table is silent).
+      const tableOutcomes: ContentInstallOutcome[] = [];
+      if (content !== undefined) {
+        const dataTypes = [...new Set(selected.flatMap((r) => r.dataTypes ?? []))];
+        let ti = 0;
+        for (const dt of dataTypes) {
+          setProgress(`Ensuring table ${++ti}/${dataTypes.length}: ${dt}...`);
+          const t = await ensureRuleDataTable(ports.azure, content, scope, dt, ports.logger);
+          if (t.created || !t.ok) {
+            tableOutcomes.push({ name: `Table ${t.table}`, ok: t.ok, detail: t.detail });
+          }
+        }
+      }
       const parserOutcomes = await installParsers();
       const ruleOutcomes: ContentInstallOutcome[] = [];
       let done = 0;
@@ -277,13 +294,13 @@ export function ContentInstallSection({
         setProgress(`Installing rule ${++done}/${selected.length}: ${rule.name}...`);
         ruleOutcomes.push(await installAnalyticRule(ports.azure, scope, rule, mintId));
       }
-      setOutcomes([...parserOutcomes, ...ruleOutcomes]);
+      setOutcomes([...tableOutcomes, ...parserOutcomes, ...ruleOutcomes]);
     } finally {
       setBusy("");
       setProgress("");
       void load(true); // keep the install outcome visible through the refresh
     }
-  }, [mintId, canInstall, ruleSplit, ruleSel, installParsers, ports, scope, load]);
+  }, [mintId, canInstall, ruleSplit, ruleSel, installParsers, ports, scope, load, content]);
 
   const doInstallWorkbooks = useCallback(async () => {
     if (mintId === undefined || !canInstall) return;
@@ -532,7 +549,7 @@ export function ContentInstallSection({
       {/* ANALYTICS RULES */}
       <ContentGroup
         title="Analytics rules"
-        tip="Install the solution's analytics rules (Scheduled and NRT). Already-installed rules are shown for reference; only installable ones are selectable. Parsers the rules query are installed automatically."
+        tip="Install the solution's analytics rules (Scheduled and NRT). Already-installed rules are shown for reference; only installable ones are selectable. Parsers the rules query are installed automatically, and any custom (_CL) table a rule reads is created from the CustomTables repo schema if it does not exist yet."
         installable={ruleSplit.installable.map((r) => ({
           name: r.name,
           detail: alertRuleResourceFromParsed(r).supported


### PR DESCRIPTION
Installing an analytics rule validates its query and fails when a table it reads does not exist ("One of the tables does not exist"). When that is a custom (_CL) table the Azure-Sentinel CustomTables repo defines, the toolkit now CREATES it from that authoritative schema before installing the rule - so content lands without forcing ingestion setup first.

- **core `ensureRuleDataTable`**: for a rule dataType, short-circuit if the table (native or _CL) already exists; else read `.script/tests/KqlvalidationsTests/CustomTables/<Table>_CL.json` via the SentinelContent port, build the custom-table PUT (`buildTablePutRequest`) and readback-poll to Succeeded. A data type the repo does not define resolves a clear non-fatal outcome.
- **ui**: `doInstallRules` ensures the selected rules dataType tables first (surfacing creations/failures; existing tables stay silent), then installs parsers and rules.

Core content-install tests: 42 passing. Packaged 1.2.160.

Generated with Claude Code