### PR TITLE
Highlight workbook proxy-limit with Defender-portal install steps

### DIFF
--- a/soc-optimizationtoolkit/apps/cribl-app/package.json
+++ b/soc-optimizationtoolkit/apps/cribl-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "soc-optimizationtoolkit",
   "private": true,
-  "version": "1.2.162",
+  "version": "1.2.163",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/soc-optimizationtoolkit/packages/core/src/domain/content-install/content-install.ts
+++ b/soc-optimizationtoolkit/packages/core/src/domain/content-install/content-install.ts
@@ -35,6 +35,13 @@ export interface ContentInstallOutcome {
   ok: boolean;
   /** Success detail ("created") or the verbatim failure (HTTP status + body). */
   detail: string;
+  /**
+   * Optional machine-readable failure classifier so the UI can render a
+   * tailored remedy instead of string-matching `detail`. Currently:
+   * "workbook-proxy-limit" - the workbook body exceeded the Cribl.Cloud
+   * app-proxy request-body limit; the UI shows Defender-portal install steps.
+   */
+  code?: string;
 }
 
 /** "N installed, M failed" (+ skip note when present). */

--- a/soc-optimizationtoolkit/packages/core/src/usecases/content-install/content-install.test.ts
+++ b/soc-optimizationtoolkit/packages/core/src/usecases/content-install/content-install.test.ts
@@ -160,8 +160,9 @@ describe("installWorkbook", () => {
       mintId,
     );
     expect(outcome.ok).toBe(false);
+    expect(outcome.code).toBe("workbook-proxy-limit");
     expect(outcome.detail).toContain("app-proxy request-body limit");
-    expect(outcome.detail).toContain("Sentinel portal");
+    expect(outcome.detail).toContain("Defender portal");
   });
 });
 

--- a/soc-optimizationtoolkit/packages/core/src/usecases/content-install/content-install.ts
+++ b/soc-optimizationtoolkit/packages/core/src/usecases/content-install/content-install.ts
@@ -191,20 +191,23 @@ function compactJson(text: string): string {
  * Turn that into an actionable message (with the minified size) pointing at
  * the manual-install workaround; other failures render verbatim.
  */
-function workbookFailureDetail(res: PortHttpResponse, minifiedBytes: number): string {
+function workbookFailureDetail(
+  res: PortHttpResponse,
+  minifiedBytes: number,
+): { detail: string; code?: string } {
   const text = bodyText(res);
   if (/a payload is required|request body must not be empty/i.test(text)) {
     const kb = Math.max(1, Math.round(minifiedBytes / 1024));
-    return (
-      `the workbook (~${kb} KB minified) exceeds the Cribl.Cloud app-proxy ` +
-      "request-body limit, so Azure received an empty body (\"A payload is " +
-      "required\"). Large workbooks cannot be installed through the app - add " +
-      "this one manually in the Sentinel portal (Workbooks > Add workbook > " +
-      "Advanced Editor > paste the template), or ask Cribl to raise the " +
-      "app-proxy body limit."
-    );
+    return {
+      code: "workbook-proxy-limit",
+      detail:
+        `the workbook (~${kb} KB minified) exceeds the Cribl.Cloud app-proxy ` +
+        "request-body limit, so Azure received an empty body. Install it from " +
+        "the Defender portal instead (steps below), or ask Cribl to raise the " +
+        "app-proxy body limit.",
+    };
   }
-  return failDetail(res);
+  return { detail: failDetail(res) };
 }
 
 /**
@@ -476,13 +479,16 @@ export async function installWorkbook(
       apiVersion: WORKBOOKS_INSTALL_API_VERSION,
       body,
     });
-    return is2xx(res.status)
-      ? { name: spec.displayName, ok: true, detail: "installed" }
-      : {
-          name: spec.displayName,
-          ok: false,
-          detail: workbookFailureDetail(res, serializedData.length),
-        };
+    if (is2xx(res.status)) {
+      return { name: spec.displayName, ok: true, detail: "installed" };
+    }
+    const failure = workbookFailureDetail(res, serializedData.length);
+    return {
+      name: spec.displayName,
+      ok: false,
+      detail: failure.detail,
+      ...(failure.code !== undefined ? { code: failure.code } : {}),
+    };
   } catch (err) {
     return { name: spec.displayName, ok: false, detail: errText(err) };
   }

--- a/soc-optimizationtoolkit/packages/ui/src/screens/content-install/content-install-section.tsx
+++ b/soc-optimizationtoolkit/packages/ui/src/screens/content-install/content-install-section.tsx
@@ -439,11 +439,22 @@ export function ContentInstallSection({
           <p className="panel-desc">
             <strong>{summarizeInstallOutcomes(outcomes)}</strong>
           </p>
-          {grouped.failed.map((o, i) => (
-            <p key={`f-${i}`} className="match-warning match-warning-overflow-loss">
-              {o.name}: {o.detail}
-            </p>
-          ))}
+          {grouped.failed.map((o, i) =>
+            o.code === "workbook-proxy-limit" ? (
+              <WorkbookPortalInstall
+                key={`f-${i}`}
+                name={o.name}
+                detail={o.detail}
+                serializedData={
+                  allWorkbooks.find((w) => w.displayName === o.name)?.serializedData ?? ""
+                }
+              />
+            ) : (
+              <p key={`f-${i}`} className="match-warning match-warning-overflow-loss">
+                {o.name}: {o.detail}
+              </p>
+            ),
+          )}
           {grouped.ok.map((o, i) => (
             <p key={`o-${i}`} className="content-install-ok">
               {o.name}: {o.detail}
@@ -722,5 +733,72 @@ function ContentGroup({
         </>
       )}
     </section>
+  );
+}
+
+/**
+ * A highlighted remedy for a workbook the app proxy can't carry (its body
+ * exceeds the Cribl.Cloud app-proxy request-body limit). Gives the Defender-
+ * portal install steps and a one-click copy of the workbook template to paste
+ * there - so a too-large workbook is a clear "do this instead", not a dead end.
+ */
+function WorkbookPortalInstall({
+  name,
+  detail,
+  serializedData,
+}: {
+  name: string;
+  detail: string;
+  serializedData: string;
+}) {
+  const [copied, setCopied] = useState(false);
+  const copy = useCallback(() => {
+    void navigator.clipboard
+      .writeText(serializedData)
+      .then(() => {
+        setCopied(true);
+        window.setTimeout(() => setCopied(false), 2000);
+      })
+      .catch(() => setCopied(false));
+  }, [serializedData]);
+
+  return (
+    <div className="workbook-portal-install">
+      <p className="workbook-portal-install-head">
+        <strong>{name}</strong> - too large for the app; install from the Defender portal
+      </p>
+      <p className="field-hint">{detail}</p>
+      <ol className="workbook-portal-steps">
+        <li>
+          Copy the workbook template (button below), then open the{" "}
+          <a href="https://security.microsoft.com" target="_blank" rel="noreferrer">
+            Microsoft Defender portal
+          </a>{" "}
+          and go to <strong>Microsoft Sentinel &gt; Threat management &gt; Workbooks</strong>.
+        </li>
+        <li>
+          Select <strong>+ Add workbook</strong>, then <strong>Edit</strong>, then open the
+          Advanced Editor (the <code className="code-chip">&lt;/&gt;</code> icon).
+        </li>
+        <li>
+          Set <strong>Template Type</strong> to <strong>Gallery Template</strong>, replace the
+          contents with the copied template, and select <strong>Apply</strong>.
+        </li>
+        <li>
+          Select <strong>Done Editing</strong>, then <strong>Save</strong>; name it and choose
+          the resource group and location.
+        </li>
+      </ol>
+      <div className="panel-controls">
+        <button className="run-button" onClick={copy} disabled={serializedData === ""}>
+          {copied ? "Copied!" : "Copy workbook template"}
+        </button>
+        {serializedData === "" && (
+          <span className="field-hint">
+            Template unavailable here - reload solution content, then retry.
+          </span>
+        )}
+      </div>
+    </div>
   );
 }

--- a/soc-optimizationtoolkit/packages/ui/src/styles.css
+++ b/soc-optimizationtoolkit/packages/ui/src/styles.css
@@ -2564,6 +2564,33 @@ button.journey-step-main:hover .journey-step-label {
 .content-install-outcomes {
   margin-top: 10px;
 }
+/* Highlighted remedy when a workbook exceeds the app-proxy body limit. */
+.workbook-portal-install {
+  margin: 8px 0;
+  padding: 12px 14px;
+  border-radius: 6px;
+  border: 1px solid var(--accent-border);
+  border-left: 3px solid var(--accent);
+  background: var(--accent-bg);
+}
+.workbook-portal-install-head {
+  margin: 0 0 4px;
+  font-size: 13px;
+  color: var(--accent-strong);
+}
+.workbook-portal-steps {
+  margin: 8px 0 10px;
+  padding-left: 20px;
+  font-size: 12px;
+  line-height: 19px;
+  color: var(--text-muted);
+}
+.workbook-portal-steps li {
+  margin-bottom: 4px;
+}
+.workbook-portal-steps strong {
+  color: var(--text);
+}
 
 .mapping-review-stale {
   font-size: 13px;


### PR DESCRIPTION
When a workbook exceeds the Cribl.Cloud app-proxy request-body limit, the install now surfaces a distinct, highlighted callout instead of a generic red error - with step-by-step Microsoft Defender portal install instructions and a one-click "Copy workbook template" button so the user can paste it into the portal Advanced Editor.

- **core**: classify the failure with a machine-readable `outcome.code` ("workbook-proxy-limit") so the UI detects it cleanly (not by string-matching the message).
- **ui**: `WorkbookPortalInstall` accent-styled callout rendered for that code; looks up the workbook serializedData by name for the copy button.

Core content-install 45 + UI 565 tests green. Packaged 1.2.163.

Generated with Claude Code