### PR TITLE
Make Architecture Patterns the journey landing page

### DIFF
--- a/soc-optimizationtoolkit/apps/cribl-app/package.json
+++ b/soc-optimizationtoolkit/apps/cribl-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "soc-optimizationtoolkit",
   "private": true,
-  "version": "1.2.163",
+  "version": "1.2.164",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/soc-optimizationtoolkit/apps/cribl-app/src/App.tsx
+++ b/soc-optimizationtoolkit/apps/cribl-app/src/App.tsx
@@ -1964,6 +1964,10 @@ function App() {
   // parks in the DEVELOPMENT section - still reachable, moved back into
   // journey/tools one item at a time as it passes live testing.
   const routes: AppRoute[] = [
+    // Architecture Patterns is the JOURNEY landing item (user directive
+    // 2026-07-20): users arrive here first to learn how the ingestion works
+    // before setting anything up. requires:'none' so it is always reachable.
+    { id: 'architecture', label: 'Architecture Patterns', requires: 'none', section: 'journey', render: () => architectureView },
     { id: 'home', label: 'Setup', requires: 'none', section: 'journey', render: renderHome },
     { id: 'integrate', label: 'Sentinel Integration', requires: 'both', section: 'journey', render: renderIntegrate },
     { id: 'dcr-automation', label: 'DCR Automation', requires: 'azure', section: 'journey', render: renderDcrAutomation },
@@ -1975,7 +1979,6 @@ function App() {
     { id: 'siem-migration', label: 'SIEM Migration', requires: 'none', section: 'development', render: renderSiemMigration },
     { id: 'preflight', label: 'Permission Verification', requires: 'azure', section: 'development', render: renderPreflight },
     { id: 'eventhub-discovery', label: 'Event Hub Discovery', requires: 'azure', section: 'development', render: () => eventHubDiscoveryView },
-    { id: 'architecture', label: 'Architecture Patterns', requires: 'none', section: 'development', render: () => architectureView },
     { id: 'mapping-catalog', label: 'Mapping Catalog', requires: 'none', section: 'development', render: () => mappingCatalogView },
     { id: 'harness', label: 'Diagnostics', requires: 'none', section: 'diagnostics', render: () => harnessView },
   ];
@@ -1988,7 +1991,7 @@ function App() {
       routes={routes}
       topBar={connectionBar}
       footerNote={`v${window.__APP_VERSION_RUNTIME__ ?? __APP_VERSION__}`}
-      initialRouteId="home"
+      initialRouteId="architecture"
       themeControl={themeControl}
     />
   );

--- a/soc-optimizationtoolkit/apps/local-app/src/web/local-app.tsx
+++ b/soc-optimizationtoolkit/apps/local-app/src/web/local-app.tsx
@@ -1087,6 +1087,10 @@ export function LocalApp() {
   // park in DEVELOPMENT and move out one at a time as they pass live
   // testing.
   const routes: AppRoute[] = [
+    // Architecture Patterns is the JOURNEY landing item (user directive
+    // 2026-07-20): users arrive here first to learn how the ingestion works
+    // before setting anything up. requires:'none' so it is always reachable.
+    { id: 'architecture', label: 'Architecture Patterns', requires: 'none', section: 'journey', render: () => architectureView },
     { id: 'home', label: 'Setup', requires: 'none', section: 'journey', render: renderHome },
     { id: 'integrate', label: 'Sentinel Integration', requires: 'both', section: 'journey', render: renderIntegrate },
     { id: 'dcr-automation', label: 'DCR Automation', requires: 'azure', section: 'journey', render: renderDcrAutomation },
@@ -1098,7 +1102,6 @@ export function LocalApp() {
     { id: 'siem-migration', label: 'SIEM Migration', requires: 'none', section: 'development', render: renderSiemMigration },
     { id: 'preflight', label: 'Permission Verification', requires: 'azure', section: 'development', render: renderPreflight },
     { id: 'eventhub-discovery', label: 'Event Hub Discovery', requires: 'azure', section: 'development', render: () => eventHubDiscoveryView },
-    { id: 'architecture', label: 'Architecture Patterns', requires: 'none', section: 'development', render: () => architectureView },
     { id: 'mapping-catalog', label: 'Mapping Catalog', requires: 'none', section: 'development', render: () => mappingCatalogView },
   ];
 
@@ -1131,7 +1134,7 @@ export function LocalApp() {
       mode={phase.mode}
       routes={routes}
       topBar={topBar}
-      initialRouteId="home"
+      initialRouteId="architecture"
       footerNote={`local host - v${__APP_VERSION__}`}
       themeControl={themeControl}
     />


### PR DESCRIPTION
Move Architecture Patterns from the Development section to the TOP of the Journey section and set it as the initial route in both shells, so users land on the reference-architecture advisor first and learn how ingestion works before setting anything up. requires:none keeps it always reachable. Typecheck + frame tests green. Packaged 1.2.164.

Generated with Claude Code