### PR TITLE
Interactive architecture data-flow diagram (React Flow)

### DIFF
--- a/soc-optimizationtoolkit/apps/cribl-app/package.json
+++ b/soc-optimizationtoolkit/apps/cribl-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "soc-optimizationtoolkit",
   "private": true,
-  "version": "1.2.164",
+  "version": "1.2.165",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/soc-optimizationtoolkit/apps/cribl-app/src/main.tsx
+++ b/soc-optimizationtoolkit/apps/cribl-app/src/main.tsx
@@ -1,7 +1,10 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import App from './App'
-// Shared @soc/ui class conventions first, then the shell-specific chrome.
+// React Flow base styles (architecture data-flow canvas) first, then the
+// shared @soc/ui class conventions (which override .arch-flow-*), then the
+// shell-specific chrome.
+import '@xyflow/react/dist/style.css'
 import '@soc/ui/styles.css'
 import './App.css'
 

--- a/soc-optimizationtoolkit/apps/local-app/src/web/main.tsx
+++ b/soc-optimizationtoolkit/apps/local-app/src/web/main.tsx
@@ -5,6 +5,7 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { LocalApp } from './local-app';
+import '@xyflow/react/dist/style.css';
 import '@soc/ui/styles.css';
 import './local.css';
 

--- a/soc-optimizationtoolkit/package-lock.json
+++ b/soc-optimizationtoolkit/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "soc-optimization-toolkit",
       "version": "0.0.0",
+      "license": "Apache-2.0",
       "workspaces": [
         "packages/*",
         "apps/*"
@@ -14,7 +15,8 @@
     },
     "apps/cribl-app": {
       "name": "soc-optimizationtoolkit",
-      "version": "1.2.25",
+      "version": "1.2.164",
+      "license": "Apache-2.0",
       "dependencies": {
         "@soc/core": "*",
         "@soc/ui": "*",
@@ -35,6 +37,7 @@
     "apps/local-app": {
       "name": "@soc/local-app",
       "version": "0.0.0",
+      "license": "Apache-2.0",
       "dependencies": {
         "@soc/core": "*",
         "@soc/ui": "*"
@@ -93,6 +96,21 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@dagrejs/dagre": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@dagrejs/dagre/-/dagre-3.0.0.tgz",
+      "integrity": "sha512-ZzhnTy1rfuoew9Ez3EIw4L2znPGnYYhfn8vc9c4oB8iw6QAsszbiU0vRhlxWPFnmmNSFAkrYeF1PhM5m4lAN0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@dagrejs/graphlib": "4.0.1"
+      }
+    },
+    "node_modules/@dagrejs/graphlib": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@dagrejs/graphlib/-/graphlib-4.0.1.tgz",
+      "integrity": "sha512-IvcV6FduIIAmLwnH+yun+QtV36SC7mERqa86aClNqmMN09WhmPPYU8ckHrZBozErf+UvHPWOTJYaGYiIcs0DgA==",
+      "license": "MIT"
     },
     "node_modules/@emnapi/core": {
       "version": "1.11.1",
@@ -1660,6 +1678,55 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -1688,7 +1755,7 @@
       "version": "19.2.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -1698,7 +1765,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -1835,6 +1902,48 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@xyflow/react": {
+      "version": "12.11.2",
+      "resolved": "https://registry.npmjs.org/@xyflow/react/-/react-12.11.2.tgz",
+      "integrity": "sha512-eLAlDWJfWnQEhJwGMjlWdAXO9eYllKpliUmPQlAmOLxz6mExXuzMVDUKLMquixgkrtmMFFtug3jGKmYYld12cA==",
+      "license": "MIT",
+      "dependencies": {
+        "@xyflow/system": "0.0.79",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=17",
+        "@types/react-dom": ">=17",
+        "react": ">=17",
+        "react-dom": ">=17"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@xyflow/system": {
+      "version": "0.0.79",
+      "resolved": "https://registry.npmjs.org/@xyflow/system/-/system-0.0.79.tgz",
+      "integrity": "sha512-czLyOh91NF0hIzbNzwi8I6GlqG23BHh2435OddfI6uiaLH3xdrdygO93gqgH1Bv9mhy8XPFQJOBn1FTq4LvEWA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-drag": "^3.0.7",
+        "@types/d3-interpolate": "^3.0.4",
+        "@types/d3-selection": "^3.0.10",
+        "@types/d3-transition": "^3.0.8",
+        "@types/d3-zoom": "^3.0.8",
+        "d3-drag": "^3.0.0",
+        "d3-interpolate": "^3.0.1",
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -1931,6 +2040,12 @@
         "node": ">= 16"
       }
     },
+    "node_modules/classcat": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/classcat/-/classcat-5.0.5.tgz",
+      "integrity": "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==",
+      "license": "MIT"
+    },
     "node_modules/cookie": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
@@ -1948,8 +2063,113 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -2891,6 +3111,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/vite": {
       "version": "8.1.2",
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.2.tgz",
@@ -3291,9 +3520,38 @@
         }
       }
     },
+    "node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
     "packages/core": {
       "name": "@soc/core",
       "version": "0.0.0",
+      "license": "Apache-2.0",
       "devDependencies": {
         "typescript": "~6.0.2",
         "vitest": "^3.2.4"
@@ -3302,8 +3560,11 @@
     "packages/ui": {
       "name": "@soc/ui",
       "version": "0.0.0",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@soc/core": "*"
+        "@dagrejs/dagre": "^3.0.0",
+        "@soc/core": "*",
+        "@xyflow/react": "^12.11.2"
       },
       "devDependencies": {
         "@testing-library/react": "^16.3.2",

--- a/soc-optimizationtoolkit/packages/core/src/domain/architecture-patterns/architecture-patterns.test.ts
+++ b/soc-optimizationtoolkit/packages/core/src/domain/architecture-patterns/architecture-patterns.test.ts
@@ -14,6 +14,7 @@ import {
   catalogLabel,
   expandResources,
   recommendPatterns,
+  unifyPatternDiagrams,
 } from "./architecture-patterns";
 
 const PRODUCT_IDS = new Set(CRIBL_PRODUCTS.map((p) => p.id));
@@ -133,5 +134,38 @@ describe("catalogLabel", () => {
     expect(catalogLabel("stream")).toBe("Cribl Stream");
     expect(catalogLabel("event-hub")).toBe("Azure Event Hub");
     expect(catalogLabel("mystery")).toBe("mystery");
+  });
+});
+
+describe("unifyPatternDiagrams", () => {
+  it("returns an empty graph for no patterns", () => {
+    expect(unifyPatternDiagrams([])).toEqual({ nodes: [], edges: [] });
+  });
+
+  it("merges shared-label nodes across patterns and dedupes edges", () => {
+    const directDcr = ARCHITECTURE_PATTERNS.find((p) => p.id === "direct-dcr");
+    const eventHub = ARCHITECTURE_PATTERNS.find((p) => p.id === "event-hub-fanin");
+    expect(directDcr && eventHub).toBeTruthy();
+    const unified = unifyPatternDiagrams([directDcr!, eventHub!]);
+
+    // "Cribl Stream" and "Sentinel / LA" appear in both -> one node each.
+    const labels = unified.nodes.map((n) => n.label);
+    expect(labels.filter((l) => l === "Cribl Stream")).toHaveLength(1);
+    expect(labels.filter((l) => l === "Sentinel / LA")).toHaveLength(1);
+
+    // Node ids are canonical keys and edges reference them.
+    const streamKey = unified.nodes.find((n) => n.label === "Cribl Stream")?.id;
+    expect(streamKey).toBe("criblstream");
+    expect(unified.edges.every((e) => e.from !== e.to)).toBe(true);
+    // Every edge endpoint resolves to a node in the unified set.
+    const ids = new Set(unified.nodes.map((n) => n.id));
+    expect(unified.edges.every((e) => ids.has(e.from) && ids.has(e.to))).toBe(true);
+  });
+
+  it("carries a single canonical graph for one pattern (idempotent shape)", () => {
+    const p = ARCHITECTURE_PATTERNS.find((x) => x.id === "direct-dcr")!;
+    const unified = unifyPatternDiagrams([p]);
+    expect(unified.nodes).toHaveLength(p.diagram.nodes.length);
+    expect(unified.edges).toHaveLength(p.diagram.edges.length);
   });
 });

--- a/soc-optimizationtoolkit/packages/core/src/domain/architecture-patterns/architecture-patterns.ts
+++ b/soc-optimizationtoolkit/packages/core/src/domain/architecture-patterns/architecture-patterns.ts
@@ -477,3 +477,49 @@ export function catalogLabel(id: string): string {
   const resource = AZURE_RESOURCES.find((r) => r.id === id);
   return resource !== undefined ? resource.label : id;
 }
+
+/** A node's canonical merge key: its label reduced to lowercase alphanumerics. */
+function canonicalNodeKey(label: string): string {
+  return label.toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
+/**
+ * Merge several patterns' tiered diagrams into ONE canonical graph for the
+ * interactive dataflow view: nodes with the same label collapse (so shared
+ * endpoints - Log sources, Cribl Stream, Sentinel - appear once and the
+ * distinct middle paths fan through them), and edges dedupe by endpoint pair.
+ * Node ids in the result are the canonical keys (stable across patterns), so
+ * edges reference them directly. Pure - order of `patterns` sets first-wins
+ * label/tier and edge-label.
+ */
+export function unifyPatternDiagrams(
+  patterns: readonly ArchitecturePattern[],
+): PatternDiagram {
+  const nodes = new Map<string, DiagramNode>();
+  const edges = new Map<string, DiagramEdge>();
+  for (const pattern of patterns) {
+    // Local node id -> canonical key, for remapping this pattern's edges.
+    const localToKey = new Map<string, string>();
+    for (const node of pattern.diagram.nodes) {
+      const key = canonicalNodeKey(node.label);
+      localToKey.set(node.id, key);
+      if (!nodes.has(key)) {
+        nodes.set(key, { id: key, label: node.label, tier: node.tier });
+      }
+    }
+    for (const edge of pattern.diagram.edges) {
+      const from = localToKey.get(edge.from);
+      const to = localToKey.get(edge.to);
+      if (from === undefined || to === undefined || from === to) continue;
+      const key = `${from} ${to}`;
+      if (!edges.has(key)) {
+        edges.set(key, {
+          from,
+          to,
+          ...(edge.label !== undefined ? { label: edge.label } : {}),
+        });
+      }
+    }
+  }
+  return { nodes: [...nodes.values()], edges: [...edges.values()] };
+}

--- a/soc-optimizationtoolkit/packages/core/src/domain/architecture-patterns/index.ts
+++ b/soc-optimizationtoolkit/packages/core/src/domain/architecture-patterns/index.ts
@@ -24,4 +24,5 @@ export {
   expandResources,
   recommendPatterns,
   catalogLabel,
+  unifyPatternDiagrams,
 } from "./architecture-patterns";

--- a/soc-optimizationtoolkit/packages/ui/package.json
+++ b/soc-optimizationtoolkit/packages/ui/package.json
@@ -15,7 +15,9 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@soc/core": "*"
+    "@dagrejs/dagre": "^3.0.0",
+    "@soc/core": "*",
+    "@xyflow/react": "^12.11.2"
   },
   "peerDependencies": {
     "react": "^19.0.0"

--- a/soc-optimizationtoolkit/packages/ui/src/screens/architecture/architecture-flow.tsx
+++ b/soc-optimizationtoolkit/packages/ui/src/screens/architecture/architecture-flow.tsx
@@ -1,0 +1,200 @@
+/**
+ * ArchitectureFlow - the interactive data-flow canvas (user direction
+ * 2026-07-20). Replaces the per-pattern static SVGs with ONE React Flow canvas
+ * that lays out the unified diagram (unifyPatternDiagrams) into left->right
+ * tiers with @dagrejs/dagre, renders draggable tier-colored node cards, and
+ * animates "data flowing" through each edge (a CSS stroke-dashoffset pipe plus
+ * SVG <animateMotion> packets). As the selected components change, the diagram
+ * recomputes and re-lays-out.
+ *
+ * STRICT-CSP SAFE: React Flow ships a STATIC bundled stylesheet (no runtime
+ * <style> injection) and uses no eval; dagre is pure JS (no WASM/eval); the
+ * flow animation is declarative SMIL + a bundled CSS @keyframes. No external
+ * assets, no unsafe-eval, no unsafe-inline. (See reference_interactive_diagram.)
+ */
+
+import { useEffect, useMemo } from "react";
+import {
+  Background,
+  BackgroundVariant,
+  BaseEdge,
+  Controls,
+  EdgeLabelRenderer,
+  Handle,
+  Position,
+  ReactFlow,
+  getSmoothStepPath,
+  useEdgesState,
+  useNodesState,
+  type Edge,
+  type EdgeProps,
+  type Node,
+  type NodeProps,
+} from "@xyflow/react";
+import Dagre from "@dagrejs/dagre";
+import type { DiagramTier, PatternDiagram } from "@soc/core";
+// React Flow's stylesheet is imported by the SHELL entry points (cribl-app
+// main.tsx / local-app), matching how @soc/ui/styles.css is loaded - a library
+// component must not side-effect-import CSS (no *.css module in the lib tsc).
+
+type ArchNodeData = { label: string; tier: DiagramTier };
+type ArchNode = Node<ArchNodeData, "arch">;
+type FlowEdgeData = { label?: string };
+type FlowEdge = Edge<FlowEdgeData, "flowing">;
+
+const NODE_W = 190;
+const NODE_H = 62;
+
+/** The short tier badge shown above a node's label. */
+const TIER_BADGE: Record<DiagramTier, string> = {
+  source: "Source",
+  cribl: "Cribl",
+  azure: "Azure",
+  destination: "Sentinel",
+};
+
+/** A tier-colored, draggable node card (React Flow custom node). */
+function ArchNodeCard({ data }: NodeProps<ArchNode>) {
+  return (
+    <div className={`arch-flow-node arch-flow-node-${data.tier}`}>
+      <Handle type="target" position={Position.Left} className="arch-flow-handle" />
+      <span className="arch-flow-node-tier">{TIER_BADGE[data.tier]}</span>
+      <span className="arch-flow-node-label">{data.label}</span>
+      <Handle type="source" position={Position.Right} className="arch-flow-handle" />
+    </div>
+  );
+}
+
+/**
+ * A custom edge that looks like data flowing through a pipe: a dashed pipe
+ * animated in CSS (Firefox-safe - not SMIL) plus <animateMotion> packets that
+ * ride the exact edge path, so they track the geometry on drag/relayout.
+ */
+function FlowingEdge({
+  id,
+  sourceX,
+  sourceY,
+  targetX,
+  targetY,
+  sourcePosition,
+  targetPosition,
+  data,
+}: EdgeProps<FlowEdge>) {
+  const [edgePath, labelX, labelY] = getSmoothStepPath({
+    sourceX,
+    sourceY,
+    sourcePosition,
+    targetX,
+    targetY,
+    targetPosition,
+    borderRadius: 14,
+  });
+  return (
+    <>
+      <BaseEdge id={id} path={edgePath} className="arch-flow-pipe" />
+      {[0, 0.9, 1.8].map((delay, i) => (
+        <circle key={i} r={3} className="arch-flow-dot">
+          <animateMotion
+            dur="2.7s"
+            begin={`${delay}s`}
+            repeatCount="indefinite"
+            path={edgePath}
+            calcMode="paced"
+          />
+        </circle>
+      ))}
+      {data?.label !== undefined && data.label !== "" && (
+        <EdgeLabelRenderer>
+          <div
+            className="arch-flow-edge-label nodrag nopan"
+            style={{
+              transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)`,
+            }}
+          >
+            {data.label}
+          </div>
+        </EdgeLabelRenderer>
+      )}
+    </>
+  );
+}
+
+// Defined at module scope: React Flow warns if these objects are recreated per
+// render (it treats them as new type maps).
+const NODE_TYPES = { arch: ArchNodeCard };
+const EDGE_TYPES = { flowing: FlowingEdge };
+
+/** Lay the unified diagram out into left->right tiers with dagre. */
+function layoutGraph(diagram: PatternDiagram): { nodes: ArchNode[]; edges: FlowEdge[] } {
+  const g = new Dagre.graphlib.Graph().setDefaultEdgeLabel(() => ({}));
+  g.setGraph({ rankdir: "LR", nodesep: 34, ranksep: 96, marginx: 12, marginy: 12 });
+  for (const node of diagram.nodes) g.setNode(node.id, { width: NODE_W, height: NODE_H });
+  for (const edge of diagram.edges) g.setEdge(edge.from, edge.to);
+  Dagre.layout(g);
+
+  const nodes: ArchNode[] = diagram.nodes.map((n) => {
+    const p = g.node(n.id);
+    return {
+      id: n.id,
+      type: "arch",
+      position: { x: p.x - NODE_W / 2, y: p.y - NODE_H / 2 },
+      data: { label: n.label, tier: n.tier },
+    };
+  });
+  const edges: FlowEdge[] = diagram.edges.map((e, i) => ({
+    id: `edge-${e.from}-${e.to}-${i}`,
+    source: e.from,
+    target: e.to,
+    type: "flowing",
+    data: { label: e.label },
+  }));
+  return { nodes, edges };
+}
+
+export interface ArchitectureFlowProps {
+  diagram: PatternDiagram;
+}
+
+/** The interactive canvas. Empty diagrams render nothing (caller shows a hint). */
+export function ArchitectureFlow({ diagram }: ArchitectureFlowProps) {
+  const layouted = useMemo(() => layoutGraph(diagram), [diagram]);
+  const [nodes, setNodes, onNodesChange] = useNodesState<ArchNode>(layouted.nodes);
+  const [edges, setEdges, onEdgesChange] = useEdgesState<FlowEdge>(layouted.edges);
+
+  // Re-seed nodes/edges when the selection (and thus the diagram) changes.
+  useEffect(() => {
+    setNodes(layouted.nodes);
+    setEdges(layouted.edges);
+  }, [layouted, setNodes, setEdges]);
+
+  if (diagram.nodes.length === 0) return null;
+
+  return (
+    <div className="arch-flow-canvas">
+      <ReactFlow
+        nodes={nodes}
+        edges={edges}
+        onNodesChange={onNodesChange}
+        onEdgesChange={onEdgesChange}
+        nodeTypes={NODE_TYPES}
+        edgeTypes={EDGE_TYPES}
+        fitView
+        fitViewOptions={{ padding: 0.15 }}
+        minZoom={0.3}
+        maxZoom={1.6}
+        nodesConnectable={false}
+        edgesFocusable={false}
+        deleteKeyCode={null}
+        proOptions={{ hideAttribution: true }}
+      >
+        <Background
+          variant={BackgroundVariant.Dots}
+          gap={18}
+          size={1}
+          color="var(--border)"
+        />
+        <Controls showInteractive={false} />
+      </ReactFlow>
+    </div>
+  );
+}

--- a/soc-optimizationtoolkit/packages/ui/src/screens/architecture/architecture-screen.tsx
+++ b/soc-optimizationtoolkit/packages/ui/src/screens/architecture/architecture-screen.tsx
@@ -1,10 +1,12 @@
 /**
- * ArchitectureScreen - the reference-architecture advisor (roadmap Phase 4
- * QUEUED item). Select the Cribl products and Azure resources in use; the
- * pure @soc/core architecture-patterns recommender returns the matching
- * patterns (and the one-addition-away near-misses), each rendered as a card
- * with rationale, considerations, and a tiered flow diagram drawn as
- * SELF-CONTAINED inline SVG (strict-CSP safe - no external assets).
+ * ArchitectureScreen - the reference-architecture advisor and the JOURNEY
+ * landing page (user directives 2026-07-20): users arrive here to learn how
+ * the ingestion works. Select the Cribl products and Azure resources in use;
+ * the pure @soc/core recommender returns the matching patterns (and the
+ * one-addition-away near-misses). The matched patterns' tiered diagrams are
+ * MERGED (unifyPatternDiagrams) into ONE interactive data-flow canvas
+ * (ArchitectureFlow) that recomputes and animates as the selection changes;
+ * each pattern's rationale and considerations render as text below.
  *
  * ADVISORY ONLY: this screen recommends and visualizes; it deploys nothing,
  * calls nothing external, and needs no ports (requires: 'none' in both
@@ -18,215 +20,18 @@ import {
   CRIBL_PRODUCTS,
   catalogLabel,
   recommendPatterns,
+  unifyPatternDiagrams,
 } from "@soc/core";
 import type {
   ArchitecturePattern,
   AzureResource,
   CriblProduct,
-  DiagramNode,
-  PatternDiagram,
   PatternRecommendation,
 } from "@soc/core";
 import { SearchableMultiSelect } from "../../components/searchable-select";
+import { ArchitectureFlow } from "./architecture-flow";
 
-// ---------------------------------------------------------------------------
-// Diagram renderer: tiered columns, forward/back/same-column edges, pure SVG.
-// ---------------------------------------------------------------------------
-
-const TIER_ORDER = ["source", "cribl", "azure", "destination"] as const;
-const NODE_W = 150;
-const NODE_H = 44;
-const NODE_GAP = 18;
-const COL_W = 190;
-const PAD = 12;
-
-interface PlacedNode extends DiagramNode {
-  x: number;
-  y: number;
-}
-
-/** Split a long label into at most two lines at the space nearest the middle. */
-function wrapLabel(label: string): string[] {
-  if (label.length <= 17) {
-    return [label];
-  }
-  const mid = Math.floor(label.length / 2);
-  let split = -1;
-  for (let offset = 0; offset < label.length; offset += 1) {
-    if (label[mid - offset] === " ") {
-      split = mid - offset;
-      break;
-    }
-    if (label[mid + offset] === " ") {
-      split = mid + offset;
-      break;
-    }
-  }
-  return split === -1
-    ? [label]
-    : [label.slice(0, split), label.slice(split + 1)];
-}
-
-/** Compute tiered positions for a diagram's nodes. */
-function placeNodes(diagram: PatternDiagram): {
-  placed: Map<string, PlacedNode>;
-  width: number;
-  height: number;
-} {
-  const tiersPresent = TIER_ORDER.filter((tier) =>
-    diagram.nodes.some((n) => n.tier === tier),
-  );
-  const columns = tiersPresent.map((tier) =>
-    diagram.nodes.filter((n) => n.tier === tier),
-  );
-  const maxRows = Math.max(...columns.map((c) => c.length));
-  const height = PAD * 2 + maxRows * NODE_H + (maxRows - 1) * NODE_GAP;
-  const width = PAD * 2 + tiersPresent.length * COL_W - (COL_W - NODE_W);
-
-  const placed = new Map<string, PlacedNode>();
-  columns.forEach((column, colIndex) => {
-    const columnHeight =
-      column.length * NODE_H + (column.length - 1) * NODE_GAP;
-    const startY = PAD + (height - PAD * 2 - columnHeight) / 2;
-    column.forEach((node, rowIndex) => {
-      placed.set(node.id, {
-        ...node,
-        x: PAD + colIndex * COL_W,
-        y: startY + rowIndex * (NODE_H + NODE_GAP),
-      });
-    });
-  });
-  return { placed, width, height };
-}
-
-/** The fill class per tier (colors live in styles.css for theme support). */
-const TIER_CLASS: Record<string, string> = {
-  source: "arch-node-source",
-  cribl: "arch-node-cribl",
-  azure: "arch-node-azure",
-  destination: "arch-node-destination",
-};
-
-function PatternDiagramSvg({ diagram }: { diagram: PatternDiagram }) {
-  const { placed, width, height } = placeNodes(diagram);
-
-  return (
-    <svg
-      className="arch-diagram-svg"
-      viewBox={`0 0 ${width} ${height}`}
-      role="img"
-      aria-label="Architecture flow diagram"
-    >
-      <defs>
-        <marker
-          id="arch-arrow"
-          viewBox="0 0 8 8"
-          refX="7"
-          refY="4"
-          markerWidth="7"
-          markerHeight="7"
-          orient="auto-start-reverse"
-        >
-          <path d="M 0 0 L 8 4 L 0 8 z" className="arch-arrowhead" />
-        </marker>
-      </defs>
-
-      {diagram.edges.map((edge, index) => {
-        const from = placed.get(edge.from);
-        const to = placed.get(edge.to);
-        if (from === undefined || to === undefined) {
-          return null;
-        }
-        let x1: number;
-        let y1: number;
-        let x2: number;
-        let y2: number;
-        let back = false;
-        if (from.x < to.x) {
-          // Forward edge: right edge -> left edge.
-          x1 = from.x + NODE_W;
-          y1 = from.y + NODE_H / 2;
-          x2 = to.x;
-          y2 = to.y + NODE_H / 2;
-        } else if (from.x > to.x) {
-          // Back edge (e.g. replay): left edge -> right edge, dashed.
-          back = true;
-          x1 = from.x;
-          y1 = from.y + NODE_H / 2;
-          x2 = to.x + NODE_W;
-          y2 = to.y + NODE_H / 2;
-        } else if (from.y < to.y) {
-          // Same column, downward: bottom -> top.
-          x1 = from.x + NODE_W / 2;
-          y1 = from.y + NODE_H;
-          x2 = to.x + NODE_W / 2;
-          y2 = to.y;
-        } else {
-          // Same column, upward: top -> bottom.
-          x1 = from.x + NODE_W / 2;
-          y1 = from.y;
-          x2 = to.x + NODE_W / 2;
-          y2 = to.y + NODE_H;
-        }
-        const midX = (x1 + x2) / 2;
-        const midY = (y1 + y2) / 2;
-        return (
-          <g key={`${edge.from}-${edge.to}-${index}`}>
-            <line
-              x1={x1}
-              y1={y1}
-              x2={x2}
-              y2={y2}
-              className={back ? "arch-edge arch-edge-back" : "arch-edge"}
-              markerEnd="url(#arch-arrow)"
-            />
-            {edge.label !== undefined && (
-              <text x={midX} y={midY - 5} className="arch-edge-label">
-                {edge.label}
-              </text>
-            )}
-          </g>
-        );
-      })}
-
-      {[...placed.values()].map((node) => {
-        const lines = wrapLabel(node.label);
-        return (
-          <g key={node.id}>
-            <rect
-              x={node.x}
-              y={node.y}
-              width={NODE_W}
-              height={NODE_H}
-              rx="8"
-              className={`arch-node ${TIER_CLASS[node.tier] ?? ""}`}
-            />
-            <text
-              x={node.x + NODE_W / 2}
-              y={node.y + NODE_H / 2 + (lines.length === 1 ? 4 : -2)}
-              className="arch-node-label"
-            >
-              {lines.map((line, lineIndex) => (
-                <tspan
-                  key={lineIndex}
-                  x={node.x + NODE_W / 2}
-                  dy={lineIndex === 0 ? 0 : 12}
-                >
-                  {line}
-                </tspan>
-              ))}
-            </text>
-          </g>
-        );
-      })}
-    </svg>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Pattern cards
-// ---------------------------------------------------------------------------
-
+/** One pattern's textual rationale + considerations (the diagram is unified). */
 function PatternCard({ pattern }: { pattern: ArchitecturePattern }) {
   return (
     <div className="arch-card">
@@ -234,9 +39,6 @@ function PatternCard({ pattern }: { pattern: ArchitecturePattern }) {
         <span className="arch-card-title">{pattern.title}</span>
       </div>
       <p className="panel-desc">{pattern.summary}</p>
-      <div className="arch-diagram">
-        <PatternDiagramSvg diagram={pattern.diagram} />
-      </div>
       <p className="panel-desc">
         <strong>Why this pattern:</strong> {pattern.why}
       </p>
@@ -262,10 +64,6 @@ function NearMissCard({ rec }: { rec: PatternRecommendation }) {
   );
 }
 
-// ---------------------------------------------------------------------------
-// The screen
-// ---------------------------------------------------------------------------
-
 export function ArchitectureScreen() {
   const [products, setProducts] = useState<string[]>([]);
   const [resources, setResources] = useState<string[]>([]);
@@ -281,14 +79,23 @@ export function ArchitectureScreen() {
   const matches = recommendations.filter((r) => r.fit === "match");
   const nears = recommendations.filter((r) => r.fit === "near");
 
+  // The single interactive diagram merges every matched pattern's flow.
+  const unifiedDiagram = useMemo(
+    () => unifyPatternDiagrams(matches.map((m) => m.pattern)),
+    [matches],
+  );
+
+  const hasSelection = products.length > 0 || resources.length > 0;
+
   return (
     <div className="panel arch-screen">
       <h2 className="panel-title">Architecture Patterns</h2>
       <p className="panel-desc">
-        Select the Cribl products and Azure resources in use to see the
-        matching reference architectures - each with a flow diagram, the
-        rationale, and the operational considerations. Advisory only: nothing
-        here deploys anything.
+        See how data flows from your sources through Cribl into Microsoft
+        Sentinel. Select the Cribl products and Azure resources in use and the
+        diagram below reshapes to match - drag nodes to explore, and read each
+        pattern's rationale and considerations underneath. Advisory only:
+        nothing here deploys anything.
       </p>
 
       <div className="form-grid arch-pickers">
@@ -323,21 +130,23 @@ export function ArchitectureScreen() {
         </label>
       </div>
 
-      {products.length === 0 && resources.length === 0 ? (
+      {!hasSelection ? (
         <p className="field-hint">
-          Pick at least one product or resource to see recommendations. Not
-          sure where to start? Cribl Stream + Microsoft Sentinel shows the
-          pattern this app deploys.
+          Pick at least one product or resource to see the data flow. Not sure
+          where to start? Cribl Stream + Microsoft Sentinel shows the pattern
+          this app deploys.
         </p>
       ) : (
         <>
-          {matches.length === 0 && (
+          {matches.length === 0 ? (
             <p className="field-hint">
               No pattern matches this exact combination yet
               {nears.length > 0
                 ? " - the near matches below show what one more selection unlocks."
                 : "."}
             </p>
+          ) : (
+            <ArchitectureFlow diagram={unifiedDiagram} />
           )}
           {matches.map((rec) => (
             <PatternCard key={rec.pattern.id} pattern={rec.pattern} />

--- a/soc-optimizationtoolkit/packages/ui/src/styles.css
+++ b/soc-optimizationtoolkit/packages/ui/src/styles.css
@@ -3999,6 +3999,119 @@ button.journey-step-main:hover .journey-step-label {
 .arch-arrowhead {
   fill: var(--text-muted);
 }
+
+/* ---- Interactive data-flow canvas (React Flow + dagre) ------------------- */
+.arch-flow-canvas {
+  height: 460px;
+  width: 100%;
+  margin: 12px 0 16px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  overflow: hidden;
+  background: var(--surface);
+}
+.arch-flow-node {
+  min-width: 148px;
+  max-width: 210px;
+  padding: 8px 12px;
+  border-radius: 12px;
+  border: 1.4px solid var(--border);
+  background: var(--surface-raised);
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.18);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  text-align: center;
+  cursor: grab;
+}
+.arch-flow-node:active {
+  cursor: grabbing;
+}
+.arch-flow-node-tier {
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  color: var(--text-faint);
+}
+.arch-flow-node-label {
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--text);
+  line-height: 15px;
+}
+.arch-flow-node-source {
+  border-color: var(--text-faint);
+}
+.arch-flow-node-cribl {
+  border-color: var(--accent);
+  background: var(--accent-bg);
+}
+.arch-flow-node-cribl .arch-flow-node-tier {
+  color: var(--accent-strong);
+}
+.arch-flow-node-azure {
+  border-color: var(--info-cyan);
+}
+.arch-flow-node-destination {
+  border-color: var(--ok);
+  background: var(--ok-bg);
+}
+.arch-flow-node-destination .arch-flow-node-tier {
+  color: var(--ok-strong);
+}
+/* Read-only graph: hide the connection handles. */
+.arch-flow-handle {
+  opacity: 0;
+  pointer-events: none;
+  min-width: 1px;
+  min-height: 1px;
+  width: 1px;
+  height: 1px;
+  border: none;
+}
+/* The flowing "pipe": a dashed edge animated in CSS (Firefox-safe, not SMIL). */
+.arch-flow-pipe {
+  stroke: var(--accent);
+  stroke-width: 2;
+  fill: none;
+  opacity: 0.5;
+  stroke-dasharray: 7 9;
+  animation: arch-flow-dash 1s linear infinite;
+}
+@keyframes arch-flow-dash {
+  to {
+    stroke-dashoffset: -16;
+  }
+}
+/* The data packets riding the exact edge path via <animateMotion>. */
+.arch-flow-dot {
+  fill: var(--accent-strong);
+  filter: drop-shadow(0 0 3px var(--accent));
+}
+.arch-flow-edge-label {
+  position: absolute;
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--text-muted);
+  background: var(--surface);
+  padding: 1px 5px;
+  border-radius: 4px;
+  border: 1px solid var(--border-subtle);
+  pointer-events: none;
+  white-space: nowrap;
+}
+/* Theme the React Flow controls to match the app. */
+.arch-flow-canvas .react-flow__controls-button {
+  background: var(--surface-raised);
+  border-bottom: 1px solid var(--border-subtle);
+  color: var(--text);
+  fill: var(--text);
+}
+.arch-flow-canvas .react-flow__controls-button:hover {
+  background: var(--surface);
+}
 .arch-considerations {
   margin: 0 0 0 18px;
   padding: 0;


### PR DESCRIPTION
Replaces the per-pattern static SVGs on the Architecture Patterns landing page with ONE interactive canvas: as the user toggles Cribl products and Azure resources, the matched patterns' tiered diagrams merge into a single graph that re-lays-out and animates data flowing through each edge. Nodes are draggable and stay connected; each pattern's rationale/considerations remain as text below.

- **core**: `unifyPatternDiagrams` merges matched patterns into one canonical graph (shared-label nodes collapse, edges dedupe). Pure + tested.
- **ui**: `ArchitectureFlow` on @xyflow/react (React Flow v12, MIT) + @dagrejs/dagre (MIT) left->right tier layout, tier-colored draggable node cards, and a `FlowingEdge` animating SVG `<animateMotion>` packets along a CSS `stroke-dashoffset` pipe.
- **STRICT-CSP SAFE (verified)**: production bundle scanned - zero eval/new Function/WebAssembly; React Flow ships static CSS (imported by the shells, no runtime `<style>` injection); dagre is pure JS. No external assets, no unsafe-eval, no unsafe-inline.

Chosen via cited deep research (React Flow beat vis-network/Mermaid/Cytoscape/GoJS on CSP + license). Full suites green (core 2476, ui 565). Packaged 1.2.165.

Generated with Claude Code