### PR TITLE
Getting-started docs for Cribl Apps deployment

### DIFF
--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -1,26 +1,86 @@
 # Quick Start
 
 The active project is the SOC Optimization Toolkit in
-`soc-optimizationtoolkit/` - see the [repository README](README.md).
+`soc-optimizationtoolkit/` - a Cribl App for the Cribl Apps platform
+(Cribl.Cloud), with a local Node-hosted variant for customer-managed
+deployments. This page gets the app installed and producing value; the
+[repository README](README.md) describes what it does.
 
-## Cribl.Cloud app (recommended)
+## Install the app in Cribl.Cloud (recommended)
+
+No build needed - the latest release is committed in the repository.
+
+### 1. Get the package
+
+Download the single `.tgz` from
+[`soc-optimizationtoolkit/apps/cribl-app/release/`](soc-optimizationtoolkit/apps/cribl-app/release/).
+It is always the latest release; the version is in the filename and inside
+the package metadata.
+
+### 2. Install it (Organization administrator)
+
+Cribl Apps is a Cribl.Cloud Preview capability, and only Organization
+administrators can install, upgrade, or delete Apps.
+
+1. In your Cribl.Cloud workspace, select **Apps** in the top navigation.
+2. Select **Add App**, then **Import from File**, and choose the `.tgz`.
+3. Review the install summary. The app declares up front:
+   - External endpoints it calls (`proxies.yml`): Azure management and
+     login endpoints, GitHub content access.
+   - Cribl product-API routes it may call (`policies.yml`): read/write
+     scopes reviewed line by line at install time.
+4. Confirm to finish the install.
+
+### 3. Grant access
+
+1. Open **Apps** - **Installed**, find the app row, and choose **Share**.
+2. On the **Members** and **Teams** tabs assign **App user** to whoever
+   should run it, then save.
+
+Users open the app from the Apps bar (or **Apps** - **Installed**).
+
+### 4. First run inside the app
+
+The app lands on **Dataflow** (the journey overview). Do these once:
+
+1. **Setup**: connect the Entra app registration (tenant, client id,
+   secret - stored in the app's encrypted KV store), discover and select
+   the Azure subscription/resource group/workspace, and run the generated
+   role-assignment script if permissions are missing.
+2. Optional: connect a GitHub PAT on **Repositories** for Sentinel
+   solution content access.
+
+From there the journey is: **Sentinel Integration** (pick a solution,
+analyze samples, deploy DCRs + Cribl pack) - **DCR Automation** -
+**Pack Maintenance**.
+
+### Upgrading
+
+**Apps** - **Installed** - row actions - **Upgrade** - upload the new
+`.tgz` - confirm. KV store data and settings are preserved, so the Azure
+connection and app state survive upgrades; access permissions are kept.
+
+## Local app (customer-managed Cribl)
+
+For self-hosted leaders where Cribl Apps is not available:
 
 ```bash
 cd soc-optimizationtoolkit
 npm install
-npm run package
+npm run local     # builds and starts the local Node host
 ```
 
-Upload `apps/cribl-app/build/soc-optimizationtoolkit-<version>.tgz` to your
-Cribl.Cloud workspace, then open it and follow the journey: Setup ->
-Sentinel Integration -> DCR Automation -> Pack Maintenance.
+The first run is an onboarding GUI that walks through connecting the
+leader and Azure. Configuration lives in
+`apps/local-app/config/local-config.json`.
 
-## Local app
+## Build the package from source
 
 ```bash
 cd soc-optimizationtoolkit
 npm install
-npm run dev --workspace apps/local-app
+npm run package   # from apps/cribl-app: mints the next version, writes
+                  # build/<name>-<version>.tgz and refreshes release/
 ```
 
 The previous Electron quick start moved to `deprecated/` - see

--- a/README.md
+++ b/README.md
@@ -31,12 +31,28 @@ selection to production:
 
 ## Getting started
 
-Build the Cribl.Cloud app package and upload it to your workspace:
+The latest installable app package is COMMITTED in this repository - no
+build required. See [QUICK_START.md](QUICK_START.md) for the full
+walkthrough; the short version:
+
+1. Download
+   [`soc-optimizationtoolkit/apps/cribl-app/release/`](soc-optimizationtoolkit/apps/cribl-app/release/)
+   (one `.tgz`, always the latest release).
+2. As a Cribl.Cloud **Organization administrator**: **Apps** (top
+   navigation) - **Add App** - **Import from File** - select the `.tgz`,
+   review the declared endpoints and product-API policies, and confirm.
+3. Share the app (**Apps** - **Installed** - **Share**) with the members
+   or teams who should use it, then open it from the Apps bar.
+4. Inside the app, start at **Setup** to connect Azure (Entra app
+   registration, resource targeting, permission validation).
+
+To build from source instead:
 
 ```bash
 cd soc-optimizationtoolkit
 npm install
-npm run package   # writes apps/cribl-app/build/soc-optimizationtoolkit-<version>.tgz
+npm run package   # mints the next version, writes build/<name>-<version>.tgz
+                  # and refreshes apps/cribl-app/release/
 ```
 
 Development gates: `npm run typecheck`, `npm run lint`, `npm test`,

--- a/soc-optimizationtoolkit/README.md
+++ b/soc-optimizationtoolkit/README.md
@@ -9,11 +9,21 @@ Cribl + Microsoft Sentinel SOC optimization, delivered as two targets from one s
 
 ## Getting started
 
+**Install without building:** the latest packaged app is committed at
+[apps/cribl-app/release/](apps/cribl-app/release/). A Cribl.Cloud
+Organization administrator installs it via **Apps** - **Add App** -
+**Import from File**, then shares it (**Apps** - **Installed** -
+**Share**) with the members or teams who should run it. The full
+walkthrough, including first-run Azure setup and upgrades, is in the
+repository [QUICK_START.md](../QUICK_START.md).
+
+Working from source:
+
 ```
 npm install
 npm run dev        # cribl-app dev server (live preview inside Cribl)
 npm run build      # build all workspaces
-npm run package    # build and produce the installable cribl-app .tgz
+npm run package    # build the installable cribl-app .tgz + refresh release/
 npm run local      # build and start the local Node-hosted app
 ```
 

--- a/soc-optimizationtoolkit/apps/cribl-app/README.md
+++ b/soc-optimizationtoolkit/apps/cribl-app/README.md
@@ -6,11 +6,20 @@ The Cribl.Cloud app target of the SOC Optimization Toolkit: the shared
 ## Install the latest release
 
 The latest packaged app is committed at [release/](release/) - one .tgz,
-replaced on every release. Install it without building anything:
+replaced on every release. Install it without building anything
+(Organization administrator required; Cribl Apps is a Preview capability):
 
 1. Download the `soc-optimizationtoolkit-<version>.tgz` from `release/`.
-2. In your Cribl.Cloud workspace, open the Apps page and upload the .tgz.
-3. Open the app from the workspace navigation.
+2. In your Cribl.Cloud workspace: **Apps** (top navigation) - **Add App**
+   - **Import from File** - select the .tgz.
+3. Review the install summary (the declared external endpoints from
+   `config/proxies.yml` and the product-API policies from
+   `config/policies.yml`) and confirm.
+4. Share it: **Apps** - **Installed** - row actions - **Share** - assign
+   **App user** to the members or teams who should run it.
+5. Users open it from the Apps bar. First run: start at the **Setup**
+   page to connect Azure. Upgrades go through **Apps** - **Installed** -
+   **Upgrade** and preserve the app's KV-stored settings.
 
 ## Build and package from source
 


### PR DESCRIPTION
Rewrites the root README getting-started, QUICK_START.md, the toolkit README, and the app README around the Cribl Apps platform deployment flow: install the committed release .tgz without building (Apps > Add App > Import from File, admin-only, policy review at install), share access, first-run Setup journey, upgrades, local-app alternative, then build-from-source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)