### PR TITLE
Architecture audit 2026-08-11: fixes

### DIFF
--- a/soc-optimizationtoolkit/docs/backlog.md
+++ b/soc-optimizationtoolkit/docs/backlog.md
@@ -247,13 +247,14 @@ Worth settling when picking it up:
 
 ## 4. Unverified empty inventories report "none" (BUG)
 
-**Reported 2026-08-10. Standard written, fix NOT applied.** See
-[inventory-standard.md](inventory-standard.md), which is BINDING for every
-inventory scenario.
+**Reported 2026-08-10. Reported instance and three more FIXED; two open
+questions below.** See [inventory-standard.md](inventory-standard.md), which is
+BINDING for every inventory scenario.
 
-With insufficient RBAC the app reports "No workspaces found - create one below".
-That is a confident wrong answer, and the harmful kind: it invites the operator
-to create a workspace that may already exist and that they simply cannot see.
+With insufficient RBAC the app reported "No workspaces found - create one
+below". That is a confident wrong answer, and the harmful kind: it invites the
+operator to create a workspace that may already exist and that they simply
+cannot see.
 
 **The trap, and why this is not error handling.** Azure ARM list operations
 return `200 OK` with an empty `value` array when RBAC filters the caller out.
@@ -267,17 +268,40 @@ in the response at all; it has to come from a permission check.
 capability is GRANTED; denied means "cannot list", and unknown means "cannot
 confirm" - three answers, never collapsed into one.
 
-**Where to apply it:**
+**Applied so far (2026-08-10):** the reported workspace instance, the
+subscription and resource-group pickers beside it, the DCR inventory, and the
+table listing's pure decision (`emptyTableListMessage` - the picker screen owes
+the wiring). Shared helper:
+`packages/ui/src/capabilities/empty-inventory.ts`.
 
-- `azure-targeting-screen` line ~632, the "No workspaces found" option - the
-  reported instance.
-- `listWorkspaceTables` - throws on explicit denial, but an RBAC-filtered
-  `200 []` would still read as an empty workspace.
-- Then audit the rest as they are touched: subscriptions, resource groups, DCR
-  inventory, Event Hub discovery, worker groups, pack inventory.
+**The rule the first fix missed, worth knowing before touching another lister.**
+A verdict is evidence ONLY about the scope it was measured at. `runAzurePreflight`
+evaluates ONE ARM scope built from the COMMITTED target, and the screens that
+list are the screens that BROWSE - Azure targeting exists to look at other
+subscriptions, the DCR inventory says in its own hint that it browses other
+resource groups. Reusing the committed verdict there reproduces the bug one
+scope over with a permission check as cover, which is worse than no check.
+`emptyInventoryMessage` now REQUIRES a scope argument so the next call site has
+to decide. Off-scope is unmeasured, and that includes off-scope DENIALS.
 
 Do NOT hide or gate these surfaces while fixing them - rule 3 still holds, the
 list stays loadable, and reads have no fallback artifact.
+
+**Open question 1: the unmeasured listers.** Subscriptions, resource groups,
+Resource Graph (Event Hub discovery) and Cribl worker groups have NO capability
+in the settled 11-item taxonomy. They currently take
+`unmeasuredInventoryMessage`, which hedges without pointing at a permission
+check that cannot settle it - honest, but inert. The two real options are the
+same pair already recorded for Resource Graph in item 1: add the capability plus
+a probe, or accept these lists stay unmeasured. Needs a decision; do not resolve
+it by reusing a neighbouring capability.
+
+**Open question 2: prop-drilling.** `capabilities`/`capabilityContext` are
+threaded from both shells into each screen that lists (Integrate ->
+AzureTargeting, DcrInventoryPanel so far). At ~8 listers that is the duplication
+that drifts. The alternative is carrying them in `PortsContext` beside `config`,
+which every screen already reads - one seam change against updating every
+`PortsProvider` call site in both shells. Cheap now, less so later.
 
 ## 5. Verification gaps
 
@@ -324,10 +348,17 @@ four commits behind before anyone noticed. Cheapest fix that does not need write
 access to a protected branch: a CI check that warns when `soc-optimizationtoolkit/**`
 source changed without a version bump since the last packaged release.
 
-**1.4.0 PACKAGED 2026-08-06.** `release/soc-optimizationtoolkit-1.4.0.tgz`,
-with [release-notes.md](release-notes.md) started as an accumulating file. Minor
-rather than patch deliberately: removing operating modes is a visible feature
-removal, and every existing install sees the setup wizard once.
+**1.5.4 IS CURRENT (2026-08-11).** `release/soc-optimizationtoolkit-1.5.4.tgz`.
+1.4.0 through 1.5.4 are described in [release-notes.md](release-notes.md), which
+was started as an accumulating file at 1.4.0.
+
+**`release/` HOLDS EXACTLY THE LATEST TGZ** - a user directive from 2026-07-30,
+enforced by `package.mjs`, which prunes older tarballs on every run. Publishing
+1.5.2 through 1.5.4 the prune was worked around three times (restoring the older
+tarballs on the reasoning that pruning breaks download links already handed out)
+before being corrected. If keeping older versions reachable does matter, GitHub
+Releases is the answer, not tarballs in the tree - do not re-litigate it by
+quietly restoring files after packaging.
 
 Two things learned while packaging, worth knowing next time:
 

--- a/soc-optimizationtoolkit/packages/core/src/domain/app-permissions/index.ts
+++ b/soc-optimizationtoolkit/packages/core/src/domain/app-permissions/index.ts
@@ -1,6 +1,10 @@
+// FEATURE_ROLES and GRAPH_PERMISSIONS are deliberately NOT re-exported: they are
+// the catalog's raw input, and every consumer wants the resolved plan (which
+// applies the suppression rule) rather than the unfiltered lists. Exporting them
+// would invite a caller to render FEATURE_ROLES directly and ask a lab path for
+// roles its Contributor grant already covers. The module's own tests import them
+// from "./app-permissions" directly.
 export {
-  FEATURE_ROLES,
-  GRAPH_PERMISSIONS,
   appPermissionPlan,
   graphPermissions,
   rbacPermissions,

--- a/soc-optimizationtoolkit/packages/ui/src/screens/setup-wizard/setup-wizard.dom.test.tsx
+++ b/soc-optimizationtoolkit/packages/ui/src/screens/setup-wizard/setup-wizard.dom.test.tsx
@@ -1,0 +1,139 @@
+// @vitest-environment happy-dom
+/**
+ * DOM pin for the wizard's Connect Azure step.
+ *
+ * ADDED BY ARCHITECTURE AUDIT 2026-08-11, retroactively. The 1.5.2 fix shipped
+ * with no test at all: `azureConnectSection` appeared in exactly two source
+ * files and nowhere else, so deleting either the prop or the line that renders
+ * it left all 665 UI tests green - and restored the reported defect, a step
+ * titled "Connect Azure" that was the one place you could not connect Azure.
+ *
+ * That is the audit's named failure mode (new behaviour arriving with no pin),
+ * and it is worse here than usual because the defect is INVISIBLE to the suite:
+ * nothing errors, the step still renders, it just quietly stops offering the
+ * form. Only a rendered wizard can catch it.
+ *
+ * The pins are deliberately about PLACEMENT rather than the form's contents -
+ * the section is a shell-owned node, so what matters here is that the step
+ * renders whatever it is handed, in the step named for it, alongside (not
+ * instead of) the change-request guidance the step already carried.
+ */
+
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { AzureConfig, WizardCapabilities } from "@soc/core";
+import { PortsProvider } from "../../ports-context";
+import type { UiPorts } from "../../ports-context";
+import { SetupWizard } from "./setup-wizard";
+
+afterEach(cleanup);
+
+/**
+ * Ports stub. Steps before the Azure one (the GitHub content step) read ports on
+ * render, so the wizard cannot mount without a provider - but nothing these
+ * pins assert reaches a port, so an empty bundle is honest rather than a
+ * shortcut. If a future step calls one on mount, this fails loudly with the
+ * missing method rather than silently passing.
+ */
+const PORTS = {} as UiPorts;
+/**
+ * Connection PRESENCE, which is what this prop means - not a permission verdict.
+ * Both true so the wizard shows the full step list and the Azure step is
+ * reachable; these pins are about that step's contents, not about step gating.
+ */
+const CAPABILITIES: WizardCapabilities = { hasCribl: true, hasAzure: true };
+const CONFIG = {
+  clientId: "",
+  tenantId: "",
+  subscriptionId: "",
+  resourceGroup: "",
+  workspaceName: "",
+  setupPath: "existing",
+} as AzureConfig;
+
+/**
+ * Render the wizard already on the Azure step. `installedInLeader` skips the
+ * target and upload steps, and `initialTarget: "cribl-hosted"` matches the
+ * cloud shell - the only shell that wires the section.
+ */
+function renderOnAzureStep(section?: ReactNode) {
+  return render(
+    <PortsProvider ports={PORTS} config={CONFIG}>
+      <SetupWizard
+        capabilities={CAPABILITIES}
+        criblShellMode="cloud"
+        contentPlatform="cloud"
+        initialTarget="cribl-hosted"
+        lockTarget
+        installedInLeader
+        onGetStarted={() => {}}
+        {...(section !== undefined ? { azureConnectSection: section } : {})}
+      />
+    </PortsProvider>,
+  );
+}
+
+/**
+ * Click Next until the Connect Azure step is on screen, identified by its own
+ * HEADING rather than by the injected node - so the helper works identically in
+ * the wired and unwired cases, and a test asserting the node is absent still
+ * proves it reached the right step.
+ *
+ * Matched as a heading, not as text: the wizard subtitle also contains the words
+ * "connect Azure", so a plain text match reports success on step one and every
+ * assertion after it fails somewhere unrelated.
+ */
+function advanceToAzureStep(): void {
+  for (let i = 0; i < 6; i += 1) {
+    if (
+      screen.queryByRole("heading", { name: /^connect azure$/i }) !== null
+    ) {
+      return;
+    }
+    const next = screen.queryByRole("button", { name: /^next$/i });
+    if (next === null) {
+      break;
+    }
+    fireEvent.click(next);
+  }
+  throw new Error(
+    "never reached the Connect Azure step: " +
+      screen
+        .queryAllByRole("heading")
+        .map((h) => h.textContent)
+        .join(" | "),
+  );
+}
+
+describe("SetupWizard - Connect Azure step", () => {
+  it("RENDERS the section the shell hands it, so the step can actually connect", () => {
+    // The whole point of 1.5.2. If this fails, the operator is back to a step
+    // that explains how to get credentials and gives them nowhere to go.
+    renderOnAzureStep(<div data-testid="azure-connect-slot">connect form</div>);
+    advanceToAzureStep();
+    expect(screen.getByText("connect form")).toBeTruthy();
+  });
+
+  it("keeps the step's own guidance BESIDE the form, not replaced by it", () => {
+    // The change-request path was not a workaround to retire - most operators
+    // genuinely have to ask another team for credentials. The form was added
+    // alongside it, and a future edit that swaps one for the other would be a
+    // regression for whichever half it dropped.
+    renderOnAzureStep(<div data-testid="azure-connect-slot">connect form</div>);
+    advanceToAzureStep();
+    expect(screen.getByText("connect form")).toBeTruthy();
+    expect(screen.getByText(/change request/i)).toBeTruthy();
+  });
+
+  it("is OPTIONAL - an unwired shell renders the step unchanged", () => {
+    // The local shell has no in-app identity surface (its credentials live in
+    // config/local-config.json) and deliberately passes nothing. Absent must
+    // stay a working guidance-only step, never an empty one or a crash.
+    renderOnAzureStep();
+    advanceToAzureStep();
+    expect(screen.queryByTestId("azure-connect-slot")).toBeNull();
+    // Reached the step and it still has its content - not a blank panel.
+    expect(screen.getByText(/change request/i)).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Fixes from the scheduled architecture audit over the 5 commits since `7b06680`.

**Pin the 1.5.2 Connect Azure fix.** It shipped with no test at all — `azureConnectSection` appeared in exactly two source files and nowhere else, so deleting the prop *or* the line rendering it left all 665 UI tests green, while restoring the reported defect. Invisible to the suite by construction: nothing errors, the step still renders, it just stops offering the form. Mutation-checked — removing the render line fails 2 of the 3 new pins.

**Narrow the app-permissions export surface.** `FEATURE_ROLES` / `GRAPH_PERMISSIONS` were re-exported from core's public index but used nowhere outside their own module. They are raw catalog input; every consumer wants the resolved plan, which applies the suppression rule. A caller rendering `FEATURE_ROLES` directly would ask a lab path for roles its Contributor grant already covers.

**Backlog release-hygiene section** was three releases stale (still announcing 1.4.0), and did not record the latest-only `release/` rule that was worked around three times this week.

Core 2,795, UI 668 (+3), typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)