### PR TITLE
Let the operator accept a suggested route filter

### DIFF
--- a/.claude/skills/architecture-audit/SKILL.md
+++ b/.claude/skills/architecture-audit/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: architecture-audit
+description: Periodic architecture audit for the SOC Optimization Toolkit - layering and coupling, duplicated decisions, test-pin integrity, dead code and stale docs. Use when the commit-count hook says an audit is due, when the user asks for an architecture audit / review of structural health, or before a release.
+---
+
+# Architecture audit
+
+A periodic structural check on `soc-optimizationtoolkit/`. Four checks, each
+with a bias toward evidence over impression. Report findings; do not silently
+refactor unless the user asks.
+
+Run it against the **branch diff since the last audit** where possible, not the
+whole repo — the point is catching drift as it happens.
+
+```bash
+# What has changed since the last audit (the hook writes this marker).
+marker=$(cat .claude/.last-architecture-audit 2>/dev/null || echo "")
+[ -n "$marker" ] && git diff --stat "$marker"..HEAD -- soc-optimizationtoolkit/
+```
+
+## 1. Layering and coupling
+
+This repo's layering is enforced by convention, not by tooling, so it can only
+drift silently.
+
+- `domain/` must not import from `usecases/`, `ports/` adapters, or React.
+  Test files are the one accepted exception.
+- `usecases/` may import `domain/` and `ports/`, never a shell.
+- `packages/ui` may import `@soc/core`; `@soc/core` must never import `@soc/ui`.
+- Shells may import both; neither package may import a shell.
+
+```bash
+cd soc-optimizationtoolkit
+grep -rn "from \"\.\./\.\./usecases" packages/core/src/domain --include="*.ts" | grep -v ".test.ts"
+grep -rn "@soc/ui" packages/core/src || echo "core->ui clean"
+grep -rn "from \"react\"" packages/core/src || echo "core is React-free"
+```
+
+Also check purity where it is claimed: `@soc/core` must not read a clock
+(`Date.now()`, argless `new Date()`), `Math.random`, or `crypto`. Parsing an
+INJECTED timestamp is fine and is the established pattern.
+
+```bash
+grep -rn "Date.now()\|Math.random()\|new Date()" packages/core/src --include="*.ts" | grep -v ".test.ts"
+```
+
+## 2. Duplicated decisions
+
+The failure this codebase most often hits: the same rule implemented twice, in
+two places that can disagree. Recent real examples — the capability model exists
+because app modes were a second, drifting proxy for permissions; the preflight
+panel and the audit both had to project verdicts, so they were forced through
+one `capabilitiesFromSides`.
+
+Look for:
+
+- Two functions answering the same question with different words
+  (`canDeploy` vs `hasRequiredAccess` is a DELIBERATE distinction — check the
+  comments before flagging a pair).
+- A constant or table restated in a shell instead of shared
+  (`ROUTE_CAPABILITIES` is shared for exactly this reason).
+- A predicate reimplemented inline rather than imported.
+
+For each candidate, confirm the two really can disagree before reporting it.
+Distinctions that are deliberate are usually documented as such — read the
+comment first.
+
+## 3. Test-pin integrity
+
+CLAUDE.md and the capability plan both say it: **the contract tests ARE the
+specification**. A pin deleted or weakened to make a suite pass is a silent
+spec change.
+
+```bash
+cd soc-optimizationtoolkit
+marker=$(cat ../.claude/.last-architecture-audit 2>/dev/null || echo "")
+# Deleted or shrunken test files since the last audit.
+[ -n "$marker" ] && git diff --stat "$marker"..HEAD -- "*.test.ts" "*.test.tsx"
+```
+
+Flag: removed `it(...)` blocks, assertions turned into weaker ones, `.skip`,
+and any suite whose count fell. Also flag NEW behaviour that arrived with no
+pin — the frame's nav rewrite passed 2,754 tests because it had none.
+
+## 4. Dead code and stale docs
+
+- Exports no longer imported anywhere (superseded but still public).
+- Comments describing behaviour that has since changed — especially module
+  headers, which are load-bearing documentation here.
+- Backlog entries describing work that is already done.
+
+```bash
+cd soc-optimizationtoolkit
+# Example shape: is a superseded export still referenced outside its own tests?
+grep -rn "filterNavItems" packages apps --include="*.ts" --include="*.tsx" | grep -v node_modules
+```
+
+Standing exemption, added 2026-08-17 (ADR-0002): the setup wizard's **target
+chooser and leader-connect step** are unreachable and will stay that way.
+`WizardTarget`, `TargetChooser`, `LeaderConnectStep`, `TARGET_TRADEOFFS`,
+`deriveLeaderBaseUrl`, and the target-specific step visibility in
+`setup-wizard-state` are all live code that no user can reach, because
+`cribl-app` passes `initialTarget="cribl-hosted"` with `lockTarget`. Do not
+report them as dead code.
+
+They are kept on purpose: they are the only asset that would onboard a
+customer-managed leader, and the local shell they were built for is gone. What
+retires this exemption - delete the code and this paragraph together when
+EITHER happens:
+
+- Cribl Apps become installable on customer-managed leaders and the wizard is
+  wired to that path (the exemption's purpose is served; it stops being dead
+  code), or
+- a decision records that on-prem is permanently out of scope (the purpose is
+  void; nothing justifies the code).
+
+If neither has happened but the code has DRIFTED - a new caller, a changed
+signature, a test pinning target behaviour that no target exercises - that IS
+reportable. An exemption covers code standing still, not code quietly growing.
+
+(`filterNavItems` / `AppMode` used to be listed here as dead-pending-step-5;
+step 5 has landed and both are gone, so that exemption was removed on
+2026-08-12. If you add one, date it and say what retires it, or it outlives the
+thing it was protecting.)
+
+## Reporting
+
+Report as a short list, most structural first. For each: what it is, why it can
+bite, and the cheapest correct fix. Distinguish **confirmed** (you read the code
+and it really can disagree) from **suspected**.
+
+If nothing is found, say so plainly — a clean audit is a real result, and
+inventing findings to look thorough is worse than none.
+
+Finally, record the audit point so the next one diffs from here:
+
+```bash
+git rev-parse HEAD > .claude/.last-architecture-audit
+```

--- a/soc-optimizationtoolkit/packages/ui/src/screens/integrate/integrate-screen.tsx
+++ b/soc-optimizationtoolkit/packages/ui/src/screens/integrate/integrate-screen.tsx
@@ -651,6 +651,25 @@ export function IntegrateScreen({
   const [identityOverrides, setIdentityOverrides] = useState<
     Readonly<Record<string, CefIdentityOverride>>
   >({});
+  // Route filters the operator accepted from the preview's suggestions, per
+  // logType. Held HERE rather than in the preview section because the pack
+  // build reads its plan from this level - a filter accepted in a component
+  // that owns it alone would be shown, then dropped at build time, which is
+  // exactly the trap identityOverrides above is documented against.
+  const [routeFilterOverrides, setRouteFilterOverrides] = useState<
+    Readonly<Record<string, string>>
+  >({});
+  const acceptRouteFilter = useCallback((logType: string, filter: string) => {
+    setRouteFilterOverrides((prev) => ({ ...prev, [logType]: filter }));
+  }, []);
+  const undoRouteFilter = useCallback((logType: string) => {
+    setRouteFilterOverrides((prev) => {
+      if (!(logType in prev)) return prev;
+      const next = { ...prev };
+      delete next[logType];
+      return next;
+    });
+  }, []);
   // What the solution's OWN analytic rules compare these fields against, per
   // logType. Derived from the rule queries the coverage section already fetched
   // - never typed in, so the app can only ever suggest a value the content
@@ -789,6 +808,7 @@ export function IntegrateScreen({
         sampleFormats,
         sampleFieldValues,
         identityOverrides,
+        routeFilterOverrides,
         enrichments,
         approved: mappingsApproved,
         version: packVersion,
@@ -1005,6 +1025,7 @@ export function IntegrateScreen({
     // The DCR listing that resolves real destination values.
     ports.azure,
     identityOverrides,
+    routeFilterOverrides,
     ports.packInstall,
     ports.logger,
     packBuilding,
@@ -1310,6 +1331,9 @@ export function IntegrateScreen({
           sampleFieldValues={sampleFieldValues}
           enrichments={enrichments}
           identityOverrides={identityOverrides}
+          routeFilterOverrides={routeFilterOverrides}
+          onAcceptRouteFilter={acceptRouteFilter}
+          onUndoRouteFilter={undoRouteFilter}
           approved={mappingsApproved}
         />
       </details>

--- a/soc-optimizationtoolkit/packages/ui/src/screens/pipeline-preview/pipeline-preview-section.tsx
+++ b/soc-optimizationtoolkit/packages/ui/src/screens/pipeline-preview/pipeline-preview-section.tsx
@@ -54,6 +54,19 @@ export interface PipelinePreviewSectionProps {
   enrichments?: Readonly<Record<string, readonly EnrichmentField[]>>;
   /** Corrected DeviceVendor/DeviceProduct keyed by logType. */
   identityOverrides?: Readonly<Record<string, CefIdentityOverride>>;
+  /** Accepted route filters keyed by logType (replace that log type's filter). */
+  routeFilterOverrides?: Readonly<Record<string, string>>;
+  /**
+   * Accept a suggested route filter. Absent = the suggestions render read-only,
+   * which is what a caller that cannot persist the choice should do: an Accept
+   * button whose result the build would not see is worse than no button.
+   */
+  onAcceptRouteFilter?: (logType: string, filter: string) => void;
+  /**
+   * Undo an accepted filter, returning that log type to its placeholder. Absent
+   * = accepted filters render without an Undo control.
+   */
+  onUndoRouteFilter?: (logType: string) => void;
   /** The mapping-review content-path gate (every table approved, not stale). */
   approved: boolean;
 }
@@ -112,6 +125,9 @@ export function PipelinePreviewSection({
   sampleFieldValues,
   enrichments,
   identityOverrides,
+  routeFilterOverrides,
+  onAcceptRouteFilter,
+  onUndoRouteFilter,
   approved,
 }: PipelinePreviewSectionProps) {
   const view = useMemo(
@@ -126,6 +142,7 @@ export function PipelinePreviewSection({
         ...(sampleFieldValues !== undefined ? { sampleFieldValues } : {}),
         ...(enrichments !== undefined ? { enrichments } : {}),
         ...(identityOverrides !== undefined ? { identityOverrides } : {}),
+        ...(routeFilterOverrides !== undefined ? { routeFilterOverrides } : {}),
         approved,
       }),
     [
@@ -138,9 +155,21 @@ export function PipelinePreviewSection({
       sampleFieldValues,
       enrichments,
       identityOverrides,
+      routeFilterOverrides,
       approved,
     ],
   );
+
+  // Only overrides for log types the CURRENT plan still has. An override left
+  // behind by a solution the operator has since changed is not something they
+  // accepted here, and offering Undo for a log type that is not on screen
+  // would be a control with no visible effect.
+  const acceptedFilters = useMemo(() => {
+    const entries = Object.entries(routeFilterOverrides ?? {});
+    if (entries.length === 0) return entries;
+    const present = new Set(view.tables.map((t) => t.logType));
+    return entries.filter(([logType]) => present.has(logType));
+  }, [routeFilterOverrides, view.tables]);
 
   if (!view.available) {
     return (
@@ -196,7 +225,8 @@ export function PipelinePreviewSection({
         <div className="pipeline-preview-valid pipeline-preview-valid-bad">
           <strong>
             {view.placeholderLogTypes.length} log type
-            {view.placeholderLogTypes.length === 1 ? "" : "s"} need a route
+            {view.placeholderLogTypes.length === 1 ? "" : "s"}{" "}
+            {view.placeholderLogTypes.length === 1 ? "needs" : "need"} a route
             filter before {view.placeholderLogTypes.length === 1 ? "it" : "they"}{" "}
             can receive events.
           </strong>{" "}
@@ -216,19 +246,65 @@ export function PipelinePreviewSection({
         The derivation often DID work out a filter and withheld it because the
         samples were too thin to bet a route on. Showing it costs nothing and
         saves the operator rediscovering what the generator already found -
-        they know the vendor that three sample events do not describe. Shown,
-        never applied: accepting is a human act, which is the whole point.
+        they know the vendor that three sample events do not describe.
+
+        Never applied AUTOMATICALLY, which is not the same as never applied.
+        The generator will not bet a route on three events; the operator can,
+        because they know the vendor. Accept is that act, and it writes the
+        filter into the same derivation the build reads - so a filter shown
+        here and accepted cannot be dropped on the way to route.yml.
       */}
       {view.routeFilterSuggestions.length > 0 && (
         <div className="pipeline-preview-suggestions">
           <span className="field-label">
             Suggested filters, from too few events to apply automatically
-            <InfoTip text="These are structurally valid discriminators - a field constant within the log type and different in every sibling that carries it - found in samples too small to trust. A filter that fits three events can be precise on the sample and wrong on live traffic, so the generator will not apply one; it shows you what it found instead. Check each against what you know the vendor sends, then paste it over the __UNSET__ filter in route.yml. Adding more sample events and re-analyzing will apply them automatically." />
+            <InfoTip text="These are structurally valid discriminators - a field constant within the log type and different in every sibling that carries it - found in samples too small to trust. A filter that fits three events can be precise on the sample and wrong on live traffic, so the generator will not apply one on its own; it shows you what it found. Accept the ones you recognise as how this vendor labels its log types and they go into the pack's route.yml; leave the rest and edit route.yml by hand. Adding more sample events and re-analyzing applies them without asking." />
           </span>
           {view.routeFilterSuggestions.map((s) => (
             <div className="pipeline-preview-suggestion-row" key={s.logType}>
               <code className="code-chip">{s.logType}</code>
               <code className="pipeline-preview-suggestion-filter">{s.filter}</code>
+              {onAcceptRouteFilter !== undefined && (
+                <button
+                  type="button"
+                  className="pipeline-preview-suggestion-accept"
+                  onClick={() => onAcceptRouteFilter(s.logType, s.filter)}
+                >
+                  Accept
+                </button>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/*
+        Accepted filters leave routeFilterSuggestions (the log type is no longer
+        placeholdered), so without this they would vanish with no trace of what
+        was applied - the operator could not tell an accepted filter from one
+        the generator derived on its own, nor undo it. Listed separately rather
+        than left in the suggestions block, because these two ask nothing and
+        everything of the reader respectively.
+      */}
+      {acceptedFilters.length > 0 && (
+        <div className="pipeline-preview-suggestions">
+          <span className="field-label">
+            Route filters you accepted
+            <InfoTip text="These filters came from sample evidence the generator judged too thin to apply on its own, and you accepted them. They are in the plan and will be written to the pack's route.yml exactly as shown. Undo returns the log type to a placeholder filter that matches nothing, which is where it started." />
+          </span>
+          {acceptedFilters.map(([logType, filter]) => (
+            <div className="pipeline-preview-suggestion-row" key={logType}>
+              <code className="code-chip">{logType}</code>
+              <code className="pipeline-preview-suggestion-filter">{filter}</code>
+              {onUndoRouteFilter !== undefined && (
+                <button
+                  type="button"
+                  className="pipeline-preview-suggestion-accept"
+                  onClick={() => onUndoRouteFilter(logType)}
+                >
+                  Undo
+                </button>
+              )}
             </div>
           ))}
         </div>

--- a/soc-optimizationtoolkit/packages/ui/src/screens/pipeline-preview/pipeline-preview-state.test.ts
+++ b/soc-optimizationtoolkit/packages/ui/src/screens/pipeline-preview/pipeline-preview-state.test.ts
@@ -611,3 +611,87 @@ describe("derivePipelinePreview - suggested route filters", () => {
     expect(byType.dns).toContain("Query");
   });
 })
+
+/**
+ * Accepting a suggestion is the operator supplying the judgement the sample
+ * corpus could not. The threshold stays where it is - the app still never
+ * applies thin evidence on its own - so acceptance is the ONLY path from a
+ * suggested filter to a shipped one, and every step of that path is pinned
+ * here. The failure this guards is silent: a filter shown, accepted, and then
+ * dropped somewhere between the preview and route.yml would look exactly like
+ * a filter that was never accepted.
+ */
+describe("derivePipelinePreview - accepted route filters", () => {
+  const vals = (v: string) => ({
+    eventCount: 2,
+    values: { act: Array.from({ length: 2 }, () => v) },
+  });
+  function view(routeFilterOverrides?: Readonly<Record<string, string>>) {
+    return derivePipelinePreview({
+      solutionName: "Vendor",
+      packName: "vendor-sentinel",
+      reports: [
+        report({ logType: "firewall", routeCondition: "true" }),
+        report({ logType: "dns", routeCondition: "true" }),
+      ],
+      sampleFormats: { firewall: "cef", dns: "cef" },
+      sampleFieldValues: { firewall: vals("Allow"), dns: vals("Query") },
+      ...(routeFilterOverrides !== undefined ? { routeFilterOverrides } : {}),
+      approved: true,
+    });
+  }
+
+  it("writes the accepted filter into the emitted route.yml", () => {
+    // The whole point. Without this the Accept button is decoration - the
+    // operator would see it applied on screen and get __UNSET__ in the pack.
+    const accepted = "act === 'Allow'";
+    const v = view({ firewall: accepted });
+    expect(v.routeYml).toContain(`filter: "${accepted}"`);
+    expect(v.routeYml).not.toContain("__UNSET__ === \"firewall\"");
+  });
+
+  it("takes the accepted log type out of the placeholder and suggestion lists", () => {
+    // Both lists are calls to ACTION. Leaving a log type in either after its
+    // filter is in force reads as work still outstanding.
+    const v = view({ firewall: "act === 'Allow'" });
+    expect(v.placeholderLogTypes).toEqual(["dns"]);
+    expect(v.routeFilterSuggestions.map((s) => s.logType)).toEqual(["dns"]);
+  });
+
+  it("leaves every OTHER log type exactly as it was", () => {
+    // Accepting one filter silently rerouting a sibling is the failure that
+    // would be hardest to see - the pack builds, the YAML validates, and the
+    // wrong events land in the wrong table.
+    const before = view();
+    const after = view({ firewall: "act === 'Allow'" });
+    const dnsBefore = before.tables.find((t) => t.logType === "dns");
+    const dnsAfter = after.tables.find((t) => t.logType === "dns");
+    expect(dnsAfter?.routeCondition).toBe(dnsBefore?.routeCondition);
+    expect(dnsAfter?.routeCondition).toContain("__UNSET__");
+  });
+
+  it("applies the operator's filter verbatim, not a re-derived one", () => {
+    // The operator may accept a suggestion and then hand-correct it. Whatever
+    // reaches this input is what ships; the planner must not "improve" it.
+    const handWritten = "act.startsWith('Allo') && src != null";
+    const v = view({ firewall: handWritten });
+    const firewall = v.tables.find((t) => t.logType === "firewall");
+    expect(firewall?.routeCondition).toBe(handWritten);
+  });
+
+  it("keeps the pack valid, so an accepted filter can actually be built", () => {
+    // A filter that breaks route.yml validation would block the build entirely,
+    // which is a worse outcome than the placeholder it replaced.
+    const v = view({ firewall: "act === 'Allow'" });
+    expect(v.valid).toBe(true);
+    expect(v.routeYmlIssues).toEqual([]);
+  });
+
+  it("ignores an override for a log type that is not in the plan", () => {
+    // Overrides outlive solution changes. One naming a log type this plan does
+    // not have must not invent a route or throw.
+    const v = view({ nonexistent: "act === 'Nope'" });
+    expect(v.routeYml).not.toContain("Nope");
+    expect(v.placeholderLogTypes.sort()).toEqual(["dns", "firewall"]);
+  });
+})

--- a/soc-optimizationtoolkit/packages/ui/src/screens/pipeline-preview/pipeline-preview-state.ts
+++ b/soc-optimizationtoolkit/packages/ui/src/screens/pipeline-preview/pipeline-preview-state.ts
@@ -166,6 +166,29 @@ export interface PipelinePreviewInputs {
    */
   identityOverrides?: Readonly<Record<string, CefIdentityOverride>>;
   /**
+   * Route filters the operator ACCEPTED from routeFilterSuggestions, keyed by
+   * logType. Each replaces that log type's route condition, which takes it out
+   * of the planner's discrimination ladder entirely (a table whose condition is
+   * not match-all is skipped), so the accepted filter reaches route.yml verbatim.
+   *
+   * Why acceptance exists at all: the value discriminator withholds a filter it
+   * cannot back with enough events, and curated sample corpora are exactly the
+   * thin case - 8 of 10 Zscaler log types placeholdered, several with a correct
+   * filter derived and then withheld. Showing that filter and making the
+   * operator retype it into route.yml is the worst of both. The threshold stays
+   * honest (the app still never applies thin evidence on its own); this is the
+   * operator supplying the judgement the events could not.
+   *
+   * Accepting one log type's filter does NOT change any sibling's: each table's
+   * discrimination is derived from the sample values independently, and the
+   * planner placeholders every table it cannot separate rather than leaving a
+   * catch-all to be promoted. So accepting is local by construction - it takes
+   * one log type out of placeholderLogTypes and leaves the rest exactly as they
+   * were. Pinned, because "accepting one quietly rerouted another" is the
+   * failure that would be hardest to see.
+   */
+  routeFilterOverrides?: Readonly<Record<string, string>>;
+  /**
    * The mapping-review content-path gate (deriveMappingReviewGate().ready): every
    * table-with-mappings approved and not stale. The preview renders its tables
    * only when this is true (else the always-visible-disabled empty state).
@@ -312,6 +335,7 @@ export function reportToPlanInput(
   enrichments?: readonly EnrichmentField[],
   identityOverride?: CefIdentityOverride,
   sampleFieldValues?: LogTypeFieldValues,
+  routeFilterOverride?: string,
 ): TablePlanInput {
   const mappings = effectiveReportMappings(report, overrides);
   return {
@@ -342,11 +366,13 @@ export function reportToPlanInput(
         }
       : {}),
     // The report mirrors the Cribl route condition; feed it as routing so the
-    // emitted route.yml filter matches what the gap analysis showed.
+    // emitted route.yml filter matches what the gap analysis showed. An
+    // ACCEPTED suggestion wins over the report: the operator chose it after
+    // being shown it, which is stronger evidence than the report's default.
     routing: {
       tableName: report.tableName,
       outputStream: "",
-      routeCondition: report.routeCondition,
+      routeCondition: routeFilterOverride ?? report.routeCondition,
       eventSimpleNames: [],
       columns: [],
       typeConversions: [],
@@ -499,6 +525,7 @@ export function derivePipelinePreview(
         inputs.enrichments?.[r.logType],
         inputs.identityOverrides?.[r.logType],
         inputs.sampleFieldValues?.[r.logType],
+        inputs.routeFilterOverrides?.[r.logType],
       ),
     ),
   });

--- a/soc-optimizationtoolkit/packages/ui/src/screens/pipeline-preview/pipeline-preview-suggestions.dom.test.tsx
+++ b/soc-optimizationtoolkit/packages/ui/src/screens/pipeline-preview/pipeline-preview-suggestions.dom.test.tsx
@@ -1,0 +1,190 @@
+// @vitest-environment happy-dom
+/**
+ * DOM pins for accepting a suggested route filter.
+ *
+ * The derivation withholds a filter it cannot back with enough events, and a
+ * curated sample corpus is exactly the thin case - 8 of 10 Zscaler log types
+ * shipped placeholdered, several with a correct filter derived and then
+ * withheld. Showing that filter and making the operator retype it into
+ * route.yml was the worst of both, so Accept exists.
+ *
+ * These are DOM pins because the state tests cannot see any of it. Those pins
+ * prove that an override REACHES route.yml; none of them can tell whether a
+ * button exists to produce one, whether it reports the right log type, or
+ * whether an accepted filter leaves any trace on screen. The identity-block
+ * defect (a value that could be set but never changed) was exactly this shape:
+ * resolvers correct, controls missing, and no resolver test can see a missing
+ * button.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { EMPTY_OVERFLOW_TRIAGE } from "@soc/core";
+import type { GapReport } from "@soc/core";
+import { PipelinePreviewSection } from "./pipeline-preview-section";
+
+afterEach(cleanup);
+
+function report(logType: string): GapReport {
+  return {
+    tableName: "CommonSecurityLog",
+    logType,
+    stats: [],
+    sourceFieldCount: 0,
+    destFieldCount: 0,
+    passthroughCount: 0,
+    dcrHandledCount: 0,
+    criblHandledCount: 0,
+    overflowCount: 0,
+    dcrRenames: [],
+    dcrCoercions: [],
+    criblRenames: [],
+    criblCoercions: [],
+    dcrHandlesSummary: "DCR handles: 0 rename(s), 0 coercion(s)",
+    criblHandlesSummary: "Cribl handles: 1 rename(s), 0 coercion(s)",
+    routeCondition: "true",
+    fieldMappings: [
+      {
+        source: "src",
+        dest: "SourceIP",
+        sourceType: "string",
+        destType: "string",
+        confidence: "alias",
+        action: "rename",
+        needsCoercion: false,
+        description: "",
+      },
+    ],
+    destSchema: [{ name: "SourceIP", type: "string" }],
+    overflowLossy: false,
+    overflowTriage: EMPTY_OVERFLOW_TRIAGE,
+    warnings: [],
+  };
+}
+
+/** Two CEF log types telling themselves apart by ONE value, on 2 events each -
+ *  under the 3-event threshold, so the filters are suggested and not applied. */
+const THIN_VALUES = {
+  firewall: { eventCount: 2, values: { act: ["Allow", "Allow"] } },
+  dns: { eventCount: 2, values: { act: ["Query", "Query"] } },
+};
+
+function renderPreview(props: {
+  routeFilterOverrides?: Readonly<Record<string, string>>;
+  onAccept?: (logType: string, filter: string) => void;
+  onUndo?: (logType: string) => void;
+}) {
+  render(
+    <PipelinePreviewSection
+      solutionName="Vendor"
+      packName="vendor-sentinel"
+      reports={[report("firewall"), report("dns")]}
+      sampleFormats={{ firewall: "cef", dns: "cef" }}
+      sampleFieldValues={THIN_VALUES}
+      {...(props.routeFilterOverrides !== undefined
+        ? { routeFilterOverrides: props.routeFilterOverrides }
+        : {})}
+      {...(props.onAccept !== undefined
+        ? { onAcceptRouteFilter: props.onAccept }
+        : {})}
+      {...(props.onUndo !== undefined ? { onUndoRouteFilter: props.onUndo } : {})}
+      approved
+    />,
+  );
+}
+
+describe("PipelinePreviewSection - accepting a suggested route filter", () => {
+  it("offers an Accept per suggestion, reporting THAT log type's filter", () => {
+    // The pin that matters most: two suggestions render two buttons, and the
+    // second one must not report the first one's filter. A single shared
+    // handler closing over the wrong row would route DNS events as firewall.
+    const onAccept = vi.fn();
+    renderPreview({ onAccept });
+
+    const buttons = screen.getAllByRole("button", { name: "Accept" });
+    expect(buttons).toHaveLength(2);
+
+    for (const button of buttons) {
+      fireEvent.click(button);
+    }
+    const calls = onAccept.mock.calls as Array<[string, string]>;
+    const byLogType = Object.fromEntries(calls);
+    expect(byLogType.firewall).toContain("'Allow'");
+    expect(byLogType.dns).toContain("'Query'");
+  });
+
+  it("renders NO Accept when the caller cannot persist the choice", () => {
+    // A button whose result the build would never see is worse than no button:
+    // it reports work as done that was silently discarded.
+    renderPreview({});
+    expect(screen.queryByRole("button", { name: "Accept" })).toBeNull();
+  });
+
+  it("moves an accepted filter out of the suggestions and into its own list", () => {
+    // Accepted filters leave routeFilterSuggestions, so without the accepted
+    // list they would vanish with no trace of what was applied - the operator
+    // could not tell an accepted filter from one derived automatically.
+    const onAccept = vi.fn();
+    renderPreview({
+      routeFilterOverrides: { firewall: "act === 'Allow'" },
+      onAccept,
+      onUndo: vi.fn(),
+    });
+
+    expect(screen.getByText("Route filters you accepted")).toBeTruthy();
+    // One suggestion left (dns), so one Accept - firewall is no longer offered.
+    expect(screen.getAllByRole("button", { name: "Accept" })).toHaveLength(1);
+    expect(screen.getAllByRole("button", { name: "Undo" })).toHaveLength(1);
+  });
+
+  it("reports the right log type to Undo", () => {
+    const onUndo = vi.fn();
+    renderPreview({
+      routeFilterOverrides: { firewall: "act === 'Allow'" },
+      onAccept: vi.fn(),
+      onUndo,
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Undo" }));
+    expect(onUndo).toHaveBeenCalledWith("firewall");
+  });
+
+  it("stops naming an accepted log type as needing a filter", () => {
+    // The placeholder banner is a call to action. Leaving firewall in it after
+    // its filter is in force reads as outstanding work that is already done.
+    renderPreview({
+      routeFilterOverrides: { firewall: "act === 'Allow'" },
+      onAccept: vi.fn(),
+    });
+    // The count sits in a <strong>; the log-type NAMES are in its parent.
+    const banner =
+      screen.getByText(/needs a route filter/).parentElement?.textContent ?? "";
+    expect(banner).toContain("dns");
+    expect(banner).not.toContain("firewall");
+  });
+
+  it("agrees with itself about how many log types are left", () => {
+    // The count, the verb and the pronoun are three separate ternaries over
+    // the same length. "1 log type need a route filter before it can" shipped
+    // because only the count and pronoun were pluralized - a state that was
+    // rare until Accept started producing it one log type at a time.
+    renderPreview({
+      routeFilterOverrides: { firewall: "act === 'Allow'" },
+      onAccept: vi.fn(),
+    });
+    const banner =
+      screen.getByText(/needs a route filter/).textContent ?? "";
+    expect(banner).toContain("1 log type needs a route filter before it can");
+  });
+
+  it("does not offer Undo for an override whose log type left the plan", () => {
+    // Overrides outlive solution changes. An Undo control for a log type that
+    // is not on screen is a control with no visible effect.
+    renderPreview({
+      routeFilterOverrides: { gone: "act === 'Nope'" },
+      onAccept: vi.fn(),
+      onUndo: vi.fn(),
+    });
+    expect(screen.queryByText("Route filters you accepted")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Undo" })).toBeNull();
+  });
+});

--- a/soc-optimizationtoolkit/packages/ui/src/styles.css
+++ b/soc-optimizationtoolkit/packages/ui/src/styles.css
@@ -4697,6 +4697,52 @@ details[open] > summary::before {
   border-color: var(--accent, var(--text));
 }
 
+/* Route-filter suggestions (2026-08-17). The block shipped in 1.11.5 naming
+   these three classes, none of which existed - it has been rendering as bare
+   divs since. Modelled on .identity-suggestions above, which solves the same
+   problem one section up: a derived value the app shows and the operator
+   applies. Same chip vocabulary, one row per log type so a filter expression
+   has room to be read before it is accepted. */
+.pipeline-preview-suggestions {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin: 10px 0;
+}
+.pipeline-preview-suggestion-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.pipeline-preview-suggestion-filter {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--text-dim);
+  background: var(--surface-raised);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 2px 8px;
+  /* A long expression wraps rather than pushing Accept off the row. */
+  overflow-wrap: anywhere;
+}
+.pipeline-preview-suggestion-accept {
+  font-family: inherit;
+  font-size: 12px;
+  padding: 3px 10px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--surface-raised);
+  color: var(--text);
+  cursor: pointer;
+  /* Pinned to the row's end so Accept sits in one column down the list,
+     rather than wherever the filter above it happened to stop. */
+  margin-left: auto;
+}
+.pipeline-preview-suggestion-accept:hover {
+  border-color: var(--accent, var(--text));
+}
+
 /* Collapsible numbered sections (2026-07-12): Expand sits at the right edge
    of a collapsed section's header; Collapse sits at the bottom of the
    expanded body (user direction 2026-07-13 - a section is finished at its


### PR DESCRIPTION
The value discriminator withholds any filter it cannot back with three events, and a curated sample corpus is exactly the thin case — 8 of 10 Zscaler log types shipped placeholdered, several with a **correct filter derived and then withheld**. Showing that filter and making someone retype it into `route.yml` was the worst of both.

Accept applies it. The threshold does not move: the app still never bets a route on thin evidence by itself. What changes is that the operator — who knows what the vendor sends — can, and the filter they accept is what ships.

## No core change was needed

`resolveRouteCondition` already honours a caller-supplied `routing.routeCondition`, and the ladder skips any table whose condition is not match-all. An accepted filter therefore flows to `route.yml` untouched, through the derivation that already exists.

## Where the overrides live, and why it matters

On the **integrate screen**, not in the preview component — because the pack build resolves its plan at that level by calling the same `derivePipelinePreview`. A filter accepted in a component that owned it alone would be shown on screen and dropped at build time. That is the exact trap `identityOverrides` is documented against one field up:

> a correction the preview showed and the build dropped would be worse than never offering it

Both call sites now pass it.

## Two defects found in code I shipped in 1.11.5

- **The suggestions block has been rendering unstyled.** It names `pipeline-preview-suggestions`, `-suggestion-row` and `-suggestion-filter`; none of the three exist in `styles.css`. Styled here, modelled on `.identity-suggestions`, which solves the same problem one section up — a derived value the app shows and the operator applies.
- **"1 log type need a route filter before it can receive events."** The count and the pronoun pluralize, the verb does not. Rare before; Accept produces that exact state one log type at a time.

## Accepting is local by construction

Each table's discrimination is derived from sample values independently, and the planner placeholders every table it cannot separate rather than leaving a catch-all to be promoted. So accepting one filter cannot silently reroute a sibling — pinned, because that failure would be the hardest to see: the pack builds, the YAML validates, and the wrong events land in the wrong table.

While writing this I had claimed the opposite in a doc comment (that accepting could promote another log type out of the unreachable set). Checked it against the planner, found it false for any multi-table plan, and corrected the comment rather than pinning a claim that is not true.

## Verification

| check | result |
|---|---|
| tests | 3,642 pass (2,928 core + 714 ui), +13 new |
| typecheck / lint / build | clean |
| mutation: drop the override | 3 state pins fail with `__UNSET__` where the filter belongs |
| mutation: remove the button | 2 DOM pins fail — no accessible Accept |
| mutation: revert the verb | 2 DOM pins fail |

New pins: 6 state (reaches `route.yml`, leaves both action lists, applies verbatim, keeps the pack valid, ignores a stale log type) and 7 DOM (a button per suggestion reporting **its own** log type, no button when the caller cannot persist the choice, the accepted list and Undo, the banner agreeing with itself).

## Also

Records the ADR-0002 dormant wizard-target code as a dated standing exemption in the `architecture-audit` skill, with the two events that retire it — and an explicit note that **drift is still reportable**, since an exemption covers code standing still, not code quietly growing.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)