### PR TITLE
Restore DCR-Templates at the path Cribl Docs links

### DIFF
--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/ADAssessmentRecommendation.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/ADAssessmentRecommendation.json
@@ -1,0 +1,154 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "dataCollectionRuleName": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the name of the Data Collection Rule to create."
+      }
+    },
+    "location": {
+      "defaultValue": "[resourceGroup().location]",
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the location in which to create the Data Collection Rule."
+      }
+    },
+    "workspaceResourceId": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+      }
+    },
+    "endpointResourceId": {
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Data Collection Endpoint to use."
+      },
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Insights/dataCollectionRules",
+      "apiVersion": "2023-03-11",
+      "name": "[parameters('dataCollectionRuleName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "streamDeclarations": {
+          "Custom-ADAssessmentRecommendation": {
+            "columns": [
+              {
+                "name": "ActionArea",
+                "type": "string"
+              },
+              {
+                "name": "ActionAreaId",
+                "type": "guid"
+              },
+              {
+                "name": "AffectedObjectName",
+                "type": "string"
+              },
+              {
+                "name": "AffectedObjectType",
+                "type": "string"
+              },
+              {
+                "name": "AssessmentId",
+                "type": "guid"
+              },
+              {
+                "name": "Computer",
+                "type": "string"
+              },
+              {
+                "name": "CustomData",
+                "type": "string"
+              },
+              {
+                "name": "Description",
+                "type": "string"
+              },
+              {
+                "name": "Domain",
+                "type": "string"
+              },
+              {
+                "name": "DomainController",
+                "type": "string"
+              },
+              {
+                "name": "FocusArea",
+                "type": "string"
+              },
+              {
+                "name": "FocusAreaId",
+                "type": "guid"
+              },
+              {
+                "name": "Forest",
+                "type": "string"
+              },
+              {
+                "name": "Recommendation",
+                "type": "string"
+              },
+              {
+                "name": "RecommendationId",
+                "type": "guid"
+              },
+              {
+                "name": "RecommendationResult",
+                "type": "string"
+              },
+              {
+                "name": "RecommendationWeight",
+                "type": "real"
+              },
+              {
+                "name": "SourceSystem",
+                "type": "string"
+              },
+              {
+                "name": "Technology",
+                "type": "string"
+              },
+              {
+                "name": "TimeGenerated",
+                "type": "datetime"
+              }
+            ]
+          }
+        },
+        "destinations": {
+          "logAnalytics": [
+            {
+              "workspaceResourceId": "[parameters('workspaceResourceId')]",
+              "name": "logAnalyticsWorkspace"
+            }
+          ]
+        },
+        "dataFlows": [
+          {
+            "streams": [
+              "Custom-ADAssessmentRecommendation"
+            ],
+            "destinations": [
+              "logAnalyticsWorkspace"
+            ],
+            "transformKql": "source",
+            "outputStream": "Microsoft-ADAssessmentRecommendation"
+          }
+        ],
+        "dataCollectionEndpointId": "[parameters('endpointResourceId')]"
+      }
+    }
+  ],
+  "outputs": {
+    "dataCollectionRuleId": {
+      "type": "string",
+      "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+    }
+  }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/ADSecurityAssessmentRecommendation.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/ADSecurityAssessmentRecommendation.json
@@ -1,0 +1,170 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "dataCollectionRuleName": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the name of the Data Collection Rule to create."
+      }
+    },
+    "location": {
+      "defaultValue": "[resourceGroup().location]",
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the location in which to create the Data Collection Rule."
+      }
+    },
+    "workspaceResourceId": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+      }
+    },
+    "endpointResourceId": {
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Data Collection Endpoint to use."
+      },
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Insights/dataCollectionRules",
+      "apiVersion": "2023-03-11",
+      "name": "[parameters('dataCollectionRuleName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "streamDeclarations": {
+          "Custom-ADSecurityAssessmentRecommendation": {
+            "columns": [
+              {
+                "name": "ActionArea",
+                "type": "string"
+              },
+              {
+                "name": "ActionAreaId",
+                "type": "string"
+              },
+              {
+                "name": "AffectedObjectName",
+                "type": "string"
+              },
+              {
+                "name": "AffectedObjectType",
+                "type": "string"
+              },
+              {
+                "name": "AssessmentId",
+                "type": "string"
+              },
+              {
+                "name": "Computer",
+                "type": "string"
+              },
+              {
+                "name": "CustomData",
+                "type": "string"
+              },
+              {
+                "name": "Description",
+                "type": "string"
+              },
+              {
+                "name": "DNSServer",
+                "type": "string"
+              },
+              {
+                "name": "DNSZone",
+                "type": "string"
+              },
+              {
+                "name": "Domain",
+                "type": "string"
+              },
+              {
+                "name": "DomainController",
+                "type": "string"
+              },
+              {
+                "name": "FocusArea",
+                "type": "string"
+              },
+              {
+                "name": "FocusAreaId",
+                "type": "string"
+              },
+              {
+                "name": "Forest",
+                "type": "string"
+              },
+              {
+                "name": "GroupPolicyObject",
+                "type": "string"
+              },
+              {
+                "name": "NamingContext",
+                "type": "string"
+              },
+              {
+                "name": "Recommendation",
+                "type": "string"
+              },
+              {
+                "name": "RecommendationId",
+                "type": "string"
+              },
+              {
+                "name": "RecommendationResult",
+                "type": "string"
+              },
+              {
+                "name": "RecommendationWeight",
+                "type": "real"
+              },
+              {
+                "name": "SourceSystem",
+                "type": "string"
+              },
+              {
+                "name": "Technology",
+                "type": "string"
+              },
+              {
+                "name": "TimeGenerated",
+                "type": "datetime"
+              }
+            ]
+          }
+        },
+        "destinations": {
+          "logAnalytics": [
+            {
+              "workspaceResourceId": "[parameters('workspaceResourceId')]",
+              "name": "logAnalyticsWorkspace"
+            }
+          ]
+        },
+        "dataFlows": [
+          {
+            "streams": [
+              "Custom-ADSecurityAssessmentRecommendation"
+            ],
+            "destinations": [
+              "logAnalyticsWorkspace"
+            ],
+            "transformKql": "source",
+            "outputStream": "Microsoft-ADSecurityAssessmentRecommendation"
+          }
+        ],
+        "dataCollectionEndpointId": "[parameters('endpointResourceId')]"
+      }
+    }
+  ],
+  "outputs": {
+    "dataCollectionRuleId": {
+      "type": "string",
+      "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+    }
+  }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/ASimAuditEventLogs.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/ASimAuditEventLogs.json
@@ -1,0 +1,562 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "dataCollectionRuleName": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the name of the Data Collection Rule to create."
+      }
+    },
+    "location": {
+      "defaultValue": "[resourceGroup().location]",
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the location in which to create the Data Collection Rule."
+      }
+    },
+    "workspaceResourceId": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+      }
+    },
+    "endpointResourceId": {
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Data Collection Endpoint to use."
+      },
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Insights/dataCollectionRules",
+      "apiVersion": "2023-03-11",
+      "name": "[parameters('dataCollectionRuleName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "streamDeclarations": {
+          "Custom-ASimAuditEventLogs": {
+            "columns": [
+              {
+                "name": "ActingAppId",
+                "type": "string"
+              },
+              {
+                "name": "ActingAppName",
+                "type": "string"
+              },
+              {
+                "name": "ActingAppType",
+                "type": "string"
+              },
+              {
+                "name": "ActingOriginalAppType",
+                "type": "string"
+              },
+              {
+                "name": "ActorOriginalUserType",
+                "type": "string"
+              },
+              {
+                "name": "ActorScope",
+                "type": "string"
+              },
+              {
+                "name": "ActorScopeId",
+                "type": "string"
+              },
+              {
+                "name": "ActorSessionId",
+                "type": "string"
+              },
+              {
+                "name": "ActorUserAadId",
+                "type": "string"
+              },
+              {
+                "name": "ActorUserId",
+                "type": "string"
+              },
+              {
+                "name": "ActorUserIdType",
+                "type": "string"
+              },
+              {
+                "name": "ActorUsername",
+                "type": "string"
+              },
+              {
+                "name": "ActorUsernameType",
+                "type": "string"
+              },
+              {
+                "name": "ActorUserSid",
+                "type": "string"
+              },
+              {
+                "name": "ActorUserType",
+                "type": "string"
+              },
+              {
+                "name": "AdditionalFields",
+                "type": "dynamic"
+              },
+              {
+                "name": "DvcAction",
+                "type": "string"
+              },
+              {
+                "name": "DvcDescription",
+                "type": "string"
+              },
+              {
+                "name": "DvcDomain",
+                "type": "string"
+              },
+              {
+                "name": "DvcDomainType",
+                "type": "string"
+              },
+              {
+                "name": "DvcFQDN",
+                "type": "string"
+              },
+              {
+                "name": "DvcHostname",
+                "type": "string"
+              },
+              {
+                "name": "DvcId",
+                "type": "string"
+              },
+              {
+                "name": "DvcIdType",
+                "type": "string"
+              },
+              {
+                "name": "DvcInterface",
+                "type": "string"
+              },
+              {
+                "name": "DvcIpAddr",
+                "type": "string"
+              },
+              {
+                "name": "DvcMacAddr",
+                "type": "string"
+              },
+              {
+                "name": "DvcOriginalAction",
+                "type": "string"
+              },
+              {
+                "name": "DvcOs",
+                "type": "string"
+              },
+              {
+                "name": "DvcOsVersion",
+                "type": "string"
+              },
+              {
+                "name": "DvcScope",
+                "type": "string"
+              },
+              {
+                "name": "DvcScopeId",
+                "type": "string"
+              },
+              {
+                "name": "DvcZone",
+                "type": "string"
+              },
+              {
+                "name": "EventCount",
+                "type": "int"
+              },
+              {
+                "name": "EventEndTime",
+                "type": "datetime"
+              },
+              {
+                "name": "EventMessage",
+                "type": "string"
+              },
+              {
+                "name": "EventOriginalResultDetails",
+                "type": "string"
+              },
+              {
+                "name": "EventOriginalSeverity",
+                "type": "string"
+              },
+              {
+                "name": "EventOriginalSubType",
+                "type": "string"
+              },
+              {
+                "name": "EventOriginalType",
+                "type": "string"
+              },
+              {
+                "name": "EventOriginalUid",
+                "type": "string"
+              },
+              {
+                "name": "EventOwner",
+                "type": "string"
+              },
+              {
+                "name": "EventProduct",
+                "type": "string"
+              },
+              {
+                "name": "EventProductVersion",
+                "type": "string"
+              },
+              {
+                "name": "EventReportUrl",
+                "type": "string"
+              },
+              {
+                "name": "EventResult",
+                "type": "string"
+              },
+              {
+                "name": "EventResultDetails",
+                "type": "string"
+              },
+              {
+                "name": "EventSchemaVersion",
+                "type": "string"
+              },
+              {
+                "name": "EventSeverity",
+                "type": "string"
+              },
+              {
+                "name": "EventStartTime",
+                "type": "datetime"
+              },
+              {
+                "name": "EventSubType",
+                "type": "string"
+              },
+              {
+                "name": "EventType",
+                "type": "string"
+              },
+              {
+                "name": "EventVendor",
+                "type": "string"
+              },
+              {
+                "name": "HttpUserAgent",
+                "type": "string"
+              },
+              {
+                "name": "NewValue",
+                "type": "string"
+              },
+              {
+                "name": "Object",
+                "type": "string"
+              },
+              {
+                "name": "ObjectId",
+                "type": "string"
+              },
+              {
+                "name": "ObjectType",
+                "type": "string"
+              },
+              {
+                "name": "OldValue",
+                "type": "string"
+              },
+              {
+                "name": "Operation",
+                "type": "string"
+              },
+              {
+                "name": "OriginalObjectType",
+                "type": "string"
+              },
+              {
+                "name": "RuleName",
+                "type": "string"
+              },
+              {
+                "name": "RuleNumber",
+                "type": "int"
+              },
+              {
+                "name": "SourceSystem",
+                "type": "string"
+              },
+              {
+                "name": "SrcDescription",
+                "type": "string"
+              },
+              {
+                "name": "SrcDeviceType",
+                "type": "string"
+              },
+              {
+                "name": "SrcDomain",
+                "type": "string"
+              },
+              {
+                "name": "SrcDomainType",
+                "type": "string"
+              },
+              {
+                "name": "SrcDvcId",
+                "type": "string"
+              },
+              {
+                "name": "SrcDvcIdType",
+                "type": "string"
+              },
+              {
+                "name": "SrcDvcScope",
+                "type": "string"
+              },
+              {
+                "name": "SrcDvcScopeId",
+                "type": "string"
+              },
+              {
+                "name": "SrcFQDN",
+                "type": "string"
+              },
+              {
+                "name": "SrcGeoCity",
+                "type": "string"
+              },
+              {
+                "name": "SrcGeoCountry",
+                "type": "string"
+              },
+              {
+                "name": "SrcGeoLatitude",
+                "type": "real"
+              },
+              {
+                "name": "SrcGeoLongitude",
+                "type": "real"
+              },
+              {
+                "name": "SrcGeoRegion",
+                "type": "string"
+              },
+              {
+                "name": "SrcHostname",
+                "type": "string"
+              },
+              {
+                "name": "SrcIpAddr",
+                "type": "string"
+              },
+              {
+                "name": "SrcOriginalRiskLevel",
+                "type": "string"
+              },
+              {
+                "name": "SrcPortNumber",
+                "type": "int"
+              },
+              {
+                "name": "SrcRiskLevel",
+                "type": "int"
+              },
+              {
+                "name": "TargetAppId",
+                "type": "string"
+              },
+              {
+                "name": "TargetAppName",
+                "type": "string"
+              },
+              {
+                "name": "TargetAppType",
+                "type": "string"
+              },
+              {
+                "name": "TargetDescription",
+                "type": "string"
+              },
+              {
+                "name": "TargetDeviceType",
+                "type": "string"
+              },
+              {
+                "name": "TargetDomain",
+                "type": "string"
+              },
+              {
+                "name": "TargetDomainType",
+                "type": "string"
+              },
+              {
+                "name": "TargetDvcId",
+                "type": "string"
+              },
+              {
+                "name": "TargetDvcIdType",
+                "type": "string"
+              },
+              {
+                "name": "TargetDvcOs",
+                "type": "string"
+              },
+              {
+                "name": "TargetDvcScope",
+                "type": "string"
+              },
+              {
+                "name": "TargetDvcScopeId",
+                "type": "string"
+              },
+              {
+                "name": "TargetFQDN",
+                "type": "string"
+              },
+              {
+                "name": "TargetGeoCity",
+                "type": "string"
+              },
+              {
+                "name": "TargetGeoCountry",
+                "type": "string"
+              },
+              {
+                "name": "TargetGeoLatitude",
+                "type": "real"
+              },
+              {
+                "name": "TargetGeoLongitude",
+                "type": "real"
+              },
+              {
+                "name": "TargetGeoRegion",
+                "type": "string"
+              },
+              {
+                "name": "TargetHostname",
+                "type": "string"
+              },
+              {
+                "name": "TargetIpAddr",
+                "type": "string"
+              },
+              {
+                "name": "TargetOriginalAppType",
+                "type": "string"
+              },
+              {
+                "name": "TargetOriginalRiskLevel",
+                "type": "string"
+              },
+              {
+                "name": "TargetPortNumber",
+                "type": "int"
+              },
+              {
+                "name": "TargetRiskLevel",
+                "type": "int"
+              },
+              {
+                "name": "TargetUrl",
+                "type": "string"
+              },
+              {
+                "name": "ThreatCategory",
+                "type": "string"
+              },
+              {
+                "name": "ThreatConfidence",
+                "type": "int"
+              },
+              {
+                "name": "ThreatField",
+                "type": "string"
+              },
+              {
+                "name": "ThreatFirstReportedTime",
+                "type": "datetime"
+              },
+              {
+                "name": "ThreatId",
+                "type": "string"
+              },
+              {
+                "name": "ThreatIpAddr",
+                "type": "string"
+              },
+              {
+                "name": "ThreatIsActive",
+                "type": "boolean"
+              },
+              {
+                "name": "ThreatLastReportedTime",
+                "type": "datetime"
+              },
+              {
+                "name": "ThreatName",
+                "type": "string"
+              },
+              {
+                "name": "ThreatOriginalConfidence",
+                "type": "string"
+              },
+              {
+                "name": "ThreatOriginalRiskLevel",
+                "type": "string"
+              },
+              {
+                "name": "ThreatRiskLevel",
+                "type": "int"
+              },
+              {
+                "name": "TimeGenerated",
+                "type": "datetime"
+              },
+              {
+                "name": "ValueType",
+                "type": "string"
+              }
+            ]
+          }
+        },
+        "destinations": {
+          "logAnalytics": [
+            {
+              "workspaceResourceId": "[parameters('workspaceResourceId')]",
+              "name": "logAnalyticsWorkspace"
+            }
+          ]
+        },
+        "dataFlows": [
+          {
+            "streams": [
+              "Custom-ASimAuditEventLogs"
+            ],
+            "destinations": [
+              "logAnalyticsWorkspace"
+            ],
+            "transformKql": "source",
+            "outputStream": "Microsoft-ASimAuditEventLogs"
+          }
+        ],
+        "dataCollectionEndpointId": "[parameters('endpointResourceId')]"
+      }
+    }
+  ],
+  "outputs": {
+    "dataCollectionRuleId": {
+      "type": "string",
+      "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+    }
+  }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/ASimAuthenticationEventLogs.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/ASimAuthenticationEventLogs.json
@@ -1,0 +1,574 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "dataCollectionRuleName": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the name of the Data Collection Rule to create."
+      }
+    },
+    "location": {
+      "defaultValue": "[resourceGroup().location]",
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the location in which to create the Data Collection Rule."
+      }
+    },
+    "workspaceResourceId": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+      }
+    },
+    "endpointResourceId": {
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Data Collection Endpoint to use."
+      },
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Insights/dataCollectionRules",
+      "apiVersion": "2023-03-11",
+      "name": "[parameters('dataCollectionRuleName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "streamDeclarations": {
+          "Custom-ASimAuthenticationEventLogs": {
+            "columns": [
+              {
+                "name": "ActingAppId",
+                "type": "string"
+              },
+              {
+                "name": "ActingAppName",
+                "type": "string"
+              },
+              {
+                "name": "ActingAppType",
+                "type": "string"
+              },
+              {
+                "name": "ActingOriginalAppType",
+                "type": "string"
+              },
+              {
+                "name": "ActorOriginalUserType",
+                "type": "string"
+              },
+              {
+                "name": "ActorScope",
+                "type": "string"
+              },
+              {
+                "name": "ActorScopeId",
+                "type": "string"
+              },
+              {
+                "name": "ActorSessionId",
+                "type": "string"
+              },
+              {
+                "name": "ActorUserId",
+                "type": "string"
+              },
+              {
+                "name": "ActorUserIdType",
+                "type": "string"
+              },
+              {
+                "name": "ActorUsername",
+                "type": "string"
+              },
+              {
+                "name": "ActorUsernameType",
+                "type": "string"
+              },
+              {
+                "name": "ActorUserType",
+                "type": "string"
+              },
+              {
+                "name": "AdditionalFields",
+                "type": "dynamic"
+              },
+              {
+                "name": "DvcAction",
+                "type": "string"
+              },
+              {
+                "name": "DvcDescription",
+                "type": "string"
+              },
+              {
+                "name": "DvcDomain",
+                "type": "string"
+              },
+              {
+                "name": "DvcDomainType",
+                "type": "string"
+              },
+              {
+                "name": "DvcFQDN",
+                "type": "string"
+              },
+              {
+                "name": "DvcHostname",
+                "type": "string"
+              },
+              {
+                "name": "DvcId",
+                "type": "string"
+              },
+              {
+                "name": "DvcIdType",
+                "type": "string"
+              },
+              {
+                "name": "DvcInterface",
+                "type": "string"
+              },
+              {
+                "name": "DvcIpAddr",
+                "type": "string"
+              },
+              {
+                "name": "DvcMacAddr",
+                "type": "string"
+              },
+              {
+                "name": "DvcOriginalAction",
+                "type": "string"
+              },
+              {
+                "name": "DvcOs",
+                "type": "string"
+              },
+              {
+                "name": "DvcOsVersion",
+                "type": "string"
+              },
+              {
+                "name": "DvcScope",
+                "type": "string"
+              },
+              {
+                "name": "DvcScopeId",
+                "type": "string"
+              },
+              {
+                "name": "DvcZone",
+                "type": "string"
+              },
+              {
+                "name": "EventCount",
+                "type": "int"
+              },
+              {
+                "name": "EventEndTime",
+                "type": "datetime"
+              },
+              {
+                "name": "EventMessage",
+                "type": "string"
+              },
+              {
+                "name": "EventOriginalResultDetails",
+                "type": "string"
+              },
+              {
+                "name": "EventOriginalSeverity",
+                "type": "string"
+              },
+              {
+                "name": "EventOriginalSubType",
+                "type": "string"
+              },
+              {
+                "name": "EventOriginalType",
+                "type": "string"
+              },
+              {
+                "name": "EventOriginalUid",
+                "type": "string"
+              },
+              {
+                "name": "EventOwner",
+                "type": "string"
+              },
+              {
+                "name": "EventProduct",
+                "type": "string"
+              },
+              {
+                "name": "EventProductVersion",
+                "type": "string"
+              },
+              {
+                "name": "EventReportUrl",
+                "type": "string"
+              },
+              {
+                "name": "EventResult",
+                "type": "string"
+              },
+              {
+                "name": "EventResultDetails",
+                "type": "string"
+              },
+              {
+                "name": "EventSchemaVersion",
+                "type": "string"
+              },
+              {
+                "name": "EventSeverity",
+                "type": "string"
+              },
+              {
+                "name": "EventStartTime",
+                "type": "datetime"
+              },
+              {
+                "name": "EventSubType",
+                "type": "string"
+              },
+              {
+                "name": "EventType",
+                "type": "string"
+              },
+              {
+                "name": "EventVendor",
+                "type": "string"
+              },
+              {
+                "name": "HttpUserAgent",
+                "type": "string"
+              },
+              {
+                "name": "LogonMethod",
+                "type": "string"
+              },
+              {
+                "name": "LogonProtocol",
+                "type": "string"
+              },
+              {
+                "name": "RuleName",
+                "type": "string"
+              },
+              {
+                "name": "RuleNumber",
+                "type": "int"
+              },
+              {
+                "name": "SourceSystem",
+                "type": "string"
+              },
+              {
+                "name": "SrcDescription",
+                "type": "string"
+              },
+              {
+                "name": "SrcDeviceType",
+                "type": "string"
+              },
+              {
+                "name": "SrcDomain",
+                "type": "string"
+              },
+              {
+                "name": "SrcDomainType",
+                "type": "string"
+              },
+              {
+                "name": "SrcDvcId",
+                "type": "string"
+              },
+              {
+                "name": "SrcDvcIdType",
+                "type": "string"
+              },
+              {
+                "name": "SrcDvcOs",
+                "type": "string"
+              },
+              {
+                "name": "SrcDvcScope",
+                "type": "string"
+              },
+              {
+                "name": "SrcDvcScopeId",
+                "type": "string"
+              },
+              {
+                "name": "SrcFQDN",
+                "type": "string"
+              },
+              {
+                "name": "SrcGeoCity",
+                "type": "string"
+              },
+              {
+                "name": "SrcGeoCountry",
+                "type": "string"
+              },
+              {
+                "name": "SrcGeoLatitude",
+                "type": "real"
+              },
+              {
+                "name": "SrcGeoLongitude",
+                "type": "real"
+              },
+              {
+                "name": "SrcGeoRegion",
+                "type": "string"
+              },
+              {
+                "name": "SrcHostname",
+                "type": "string"
+              },
+              {
+                "name": "SrcIpAddr",
+                "type": "string"
+              },
+              {
+                "name": "SrcIsp",
+                "type": "string"
+              },
+              {
+                "name": "SrcOriginalRiskLevel",
+                "type": "string"
+              },
+              {
+                "name": "SrcPortNumber",
+                "type": "int"
+              },
+              {
+                "name": "SrcRiskLevel",
+                "type": "int"
+              },
+              {
+                "name": "TargetAppId",
+                "type": "string"
+              },
+              {
+                "name": "TargetAppName",
+                "type": "string"
+              },
+              {
+                "name": "TargetAppType",
+                "type": "string"
+              },
+              {
+                "name": "TargetDescription",
+                "type": "string"
+              },
+              {
+                "name": "TargetDeviceType",
+                "type": "string"
+              },
+              {
+                "name": "TargetDomain",
+                "type": "string"
+              },
+              {
+                "name": "TargetDomainType",
+                "type": "string"
+              },
+              {
+                "name": "TargetDvcId",
+                "type": "string"
+              },
+              {
+                "name": "TargetDvcIdType",
+                "type": "string"
+              },
+              {
+                "name": "TargetDvcOs",
+                "type": "string"
+              },
+              {
+                "name": "TargetDvcScope",
+                "type": "string"
+              },
+              {
+                "name": "TargetDvcScopeId",
+                "type": "string"
+              },
+              {
+                "name": "TargetFQDN",
+                "type": "string"
+              },
+              {
+                "name": "TargetGeoCity",
+                "type": "string"
+              },
+              {
+                "name": "TargetGeoCountry",
+                "type": "string"
+              },
+              {
+                "name": "TargetGeoLatitude",
+                "type": "real"
+              },
+              {
+                "name": "TargetGeoLongitude",
+                "type": "real"
+              },
+              {
+                "name": "TargetGeoRegion",
+                "type": "string"
+              },
+              {
+                "name": "TargetHostname",
+                "type": "string"
+              },
+              {
+                "name": "TargetIpAddr",
+                "type": "string"
+              },
+              {
+                "name": "TargetOriginalAppType",
+                "type": "string"
+              },
+              {
+                "name": "TargetOriginalRiskLevel",
+                "type": "string"
+              },
+              {
+                "name": "TargetOriginalUserType",
+                "type": "string"
+              },
+              {
+                "name": "TargetPortNumber",
+                "type": "int"
+              },
+              {
+                "name": "TargetRiskLevel",
+                "type": "int"
+              },
+              {
+                "name": "TargetSessionId",
+                "type": "string"
+              },
+              {
+                "name": "TargetUrl",
+                "type": "string"
+              },
+              {
+                "name": "TargetUserId",
+                "type": "string"
+              },
+              {
+                "name": "TargetUserIdType",
+                "type": "string"
+              },
+              {
+                "name": "TargetUsername",
+                "type": "string"
+              },
+              {
+                "name": "TargetUsernameType",
+                "type": "string"
+              },
+              {
+                "name": "TargetUserScope",
+                "type": "string"
+              },
+              {
+                "name": "TargetUserScopeId",
+                "type": "string"
+              },
+              {
+                "name": "TargetUserType",
+                "type": "string"
+              },
+              {
+                "name": "ThreatCategory",
+                "type": "string"
+              },
+              {
+                "name": "ThreatConfidence",
+                "type": "int"
+              },
+              {
+                "name": "ThreatField",
+                "type": "string"
+              },
+              {
+                "name": "ThreatFirstReportedTime",
+                "type": "datetime"
+              },
+              {
+                "name": "ThreatId",
+                "type": "string"
+              },
+              {
+                "name": "ThreatIpAddr",
+                "type": "string"
+              },
+              {
+                "name": "ThreatIsActive",
+                "type": "boolean"
+              },
+              {
+                "name": "ThreatLastReportedTime",
+                "type": "datetime"
+              },
+              {
+                "name": "ThreatName",
+                "type": "string"
+              },
+              {
+                "name": "ThreatOriginalConfidence",
+                "type": "string"
+              },
+              {
+                "name": "ThreatOriginalRiskLevel",
+                "type": "string"
+              },
+              {
+                "name": "ThreatRiskLevel",
+                "type": "int"
+              },
+              {
+                "name": "TimeGenerated",
+                "type": "datetime"
+              }
+            ]
+          }
+        },
+        "destinations": {
+          "logAnalytics": [
+            {
+              "workspaceResourceId": "[parameters('workspaceResourceId')]",
+              "name": "logAnalyticsWorkspace"
+            }
+          ]
+        },
+        "dataFlows": [
+          {
+            "streams": [
+              "Custom-ASimAuthenticationEventLogs"
+            ],
+            "destinations": [
+              "logAnalyticsWorkspace"
+            ],
+            "transformKql": "source",
+            "outputStream": "Microsoft-ASimAuthenticationEventLogs"
+          }
+        ],
+        "dataCollectionEndpointId": "[parameters('endpointResourceId')]"
+      }
+    }
+  ],
+  "outputs": {
+    "dataCollectionRuleId": {
+      "type": "string",
+      "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+    }
+  }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/ASimDhcpEventLogs.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/ASimDhcpEventLogs.json
@@ -1,0 +1,454 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "dataCollectionRuleName": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the name of the Data Collection Rule to create."
+      }
+    },
+    "location": {
+      "defaultValue": "[resourceGroup().location]",
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the location in which to create the Data Collection Rule."
+      }
+    },
+    "workspaceResourceId": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+      }
+    },
+    "endpointResourceId": {
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Data Collection Endpoint to use."
+      },
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Insights/dataCollectionRules",
+      "apiVersion": "2023-03-11",
+      "name": "[parameters('dataCollectionRuleName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "streamDeclarations": {
+          "Custom-ASimDhcpEventLogs": {
+            "columns": [
+              {
+                "name": "AdditionalFields",
+                "type": "dynamic"
+              },
+              {
+                "name": "DhcpCircuitId",
+                "type": "string"
+              },
+              {
+                "name": "DhcpLeaseDuration",
+                "type": "int"
+              },
+              {
+                "name": "DhcpSessionDuration",
+                "type": "int"
+              },
+              {
+                "name": "DhcpSessionId",
+                "type": "string"
+              },
+              {
+                "name": "DhcpSrcDHCId",
+                "type": "string"
+              },
+              {
+                "name": "DhcpSubscriberId",
+                "type": "string"
+              },
+              {
+                "name": "DhcpUserClass",
+                "type": "string"
+              },
+              {
+                "name": "DhcpUserClassId",
+                "type": "string"
+              },
+              {
+                "name": "DhcpVendorClass",
+                "type": "string"
+              },
+              {
+                "name": "DhcpVendorClassId",
+                "type": "string"
+              },
+              {
+                "name": "DvcAction",
+                "type": "string"
+              },
+              {
+                "name": "DvcDescription",
+                "type": "string"
+              },
+              {
+                "name": "DvcDomain",
+                "type": "string"
+              },
+              {
+                "name": "DvcDomainType",
+                "type": "string"
+              },
+              {
+                "name": "DvcFQDN",
+                "type": "string"
+              },
+              {
+                "name": "DvcHostname",
+                "type": "string"
+              },
+              {
+                "name": "DvcId",
+                "type": "string"
+              },
+              {
+                "name": "DvcIdType",
+                "type": "string"
+              },
+              {
+                "name": "DvcInterface",
+                "type": "string"
+              },
+              {
+                "name": "DvcIpAddr",
+                "type": "string"
+              },
+              {
+                "name": "DvcMacAddr",
+                "type": "string"
+              },
+              {
+                "name": "DvcOriginalAction",
+                "type": "string"
+              },
+              {
+                "name": "DvcOs",
+                "type": "string"
+              },
+              {
+                "name": "DvcOsVersion",
+                "type": "string"
+              },
+              {
+                "name": "DvcScope",
+                "type": "string"
+              },
+              {
+                "name": "DvcScopeId",
+                "type": "string"
+              },
+              {
+                "name": "DvcZone",
+                "type": "string"
+              },
+              {
+                "name": "EventCount",
+                "type": "int"
+              },
+              {
+                "name": "EventEndTime",
+                "type": "datetime"
+              },
+              {
+                "name": "EventMessage",
+                "type": "string"
+              },
+              {
+                "name": "EventOriginalResultDetails",
+                "type": "string"
+              },
+              {
+                "name": "EventOriginalSeverity",
+                "type": "string"
+              },
+              {
+                "name": "EventOriginalSubType",
+                "type": "string"
+              },
+              {
+                "name": "EventOriginalType",
+                "type": "string"
+              },
+              {
+                "name": "EventOriginalUid",
+                "type": "string"
+              },
+              {
+                "name": "EventOwner",
+                "type": "string"
+              },
+              {
+                "name": "EventProduct",
+                "type": "string"
+              },
+              {
+                "name": "EventProductVersion",
+                "type": "string"
+              },
+              {
+                "name": "EventReportUrl",
+                "type": "string"
+              },
+              {
+                "name": "EventResult",
+                "type": "string"
+              },
+              {
+                "name": "EventResultDetails",
+                "type": "string"
+              },
+              {
+                "name": "EventSchema",
+                "type": "string"
+              },
+              {
+                "name": "EventSchemaVersion",
+                "type": "string"
+              },
+              {
+                "name": "EventSeverity",
+                "type": "string"
+              },
+              {
+                "name": "EventStartTime",
+                "type": "datetime"
+              },
+              {
+                "name": "EventSubType",
+                "type": "string"
+              },
+              {
+                "name": "EventType",
+                "type": "string"
+              },
+              {
+                "name": "EventVendor",
+                "type": "string"
+              },
+              {
+                "name": "RequestedIpAddr",
+                "type": "string"
+              },
+              {
+                "name": "RuleName",
+                "type": "string"
+              },
+              {
+                "name": "RuleNumber",
+                "type": "int"
+              },
+              {
+                "name": "SourceSystem",
+                "type": "string"
+              },
+              {
+                "name": "SrcDescription",
+                "type": "string"
+              },
+              {
+                "name": "SrcDeviceType",
+                "type": "string"
+              },
+              {
+                "name": "SrcDomain",
+                "type": "string"
+              },
+              {
+                "name": "SrcDomainType",
+                "type": "string"
+              },
+              {
+                "name": "SrcDvcId",
+                "type": "string"
+              },
+              {
+                "name": "SrcDvcIdType",
+                "type": "string"
+              },
+              {
+                "name": "SrcDvcScope",
+                "type": "string"
+              },
+              {
+                "name": "SrcDvcScopeId",
+                "type": "string"
+              },
+              {
+                "name": "SrcFQDN",
+                "type": "string"
+              },
+              {
+                "name": "SrcGeoCity",
+                "type": "string"
+              },
+              {
+                "name": "SrcGeoCountry",
+                "type": "string"
+              },
+              {
+                "name": "SrcGeoLatitude",
+                "type": "real"
+              },
+              {
+                "name": "SrcGeoLongitude",
+                "type": "real"
+              },
+              {
+                "name": "SrcGeoRegion",
+                "type": "string"
+              },
+              {
+                "name": "SrcHostname",
+                "type": "string"
+              },
+              {
+                "name": "SrcIpAddr",
+                "type": "string"
+              },
+              {
+                "name": "SrcMacAddr",
+                "type": "string"
+              },
+              {
+                "name": "SrcOriginalRiskLevel",
+                "type": "string"
+              },
+              {
+                "name": "SrcOriginalUserType",
+                "type": "string"
+              },
+              {
+                "name": "SrcPortNumber",
+                "type": "int"
+              },
+              {
+                "name": "SrcRiskLevel",
+                "type": "int"
+              },
+              {
+                "name": "SrcUserId",
+                "type": "string"
+              },
+              {
+                "name": "SrcUserIdType",
+                "type": "string"
+              },
+              {
+                "name": "SrcUsername",
+                "type": "string"
+              },
+              {
+                "name": "SrcUsernameType",
+                "type": "string"
+              },
+              {
+                "name": "SrcUserScope",
+                "type": "string"
+              },
+              {
+                "name": "SrcUserScopeId",
+                "type": "string"
+              },
+              {
+                "name": "SrcUserSessionId",
+                "type": "string"
+              },
+              {
+                "name": "SrcUserType",
+                "type": "string"
+              },
+              {
+                "name": "SrcUserUid",
+                "type": "string"
+              },
+              {
+                "name": "ThreatCategory",
+                "type": "string"
+              },
+              {
+                "name": "ThreatConfidence",
+                "type": "int"
+              },
+              {
+                "name": "ThreatField",
+                "type": "string"
+              },
+              {
+                "name": "ThreatFirstReportedTime",
+                "type": "datetime"
+              },
+              {
+                "name": "ThreatId",
+                "type": "string"
+              },
+              {
+                "name": "ThreatIsActive",
+                "type": "boolean"
+              },
+              {
+                "name": "ThreatLastReportedTime",
+                "type": "datetime"
+              },
+              {
+                "name": "ThreatName",
+                "type": "string"
+              },
+              {
+                "name": "ThreatOriginalConfidence",
+                "type": "string"
+              },
+              {
+                "name": "ThreatOriginalRiskLevel",
+                "type": "string"
+              },
+              {
+                "name": "ThreatRiskLevel",
+                "type": "int"
+              },
+              {
+                "name": "TimeGenerated",
+                "type": "datetime"
+              }
+            ]
+          }
+        },
+        "destinations": {
+          "logAnalytics": [
+            {
+              "workspaceResourceId": "[parameters('workspaceResourceId')]",
+              "name": "logAnalyticsWorkspace"
+            }
+          ]
+        },
+        "dataFlows": [
+          {
+            "streams": [
+              "Custom-ASimDhcpEventLogs"
+            ],
+            "destinations": [
+              "logAnalyticsWorkspace"
+            ],
+            "transformKql": "source",
+            "outputStream": "Microsoft-ASimDhcpEventLogs"
+          }
+        ],
+        "dataCollectionEndpointId": "[parameters('endpointResourceId')]"
+      }
+    }
+  ],
+  "outputs": {
+    "dataCollectionRuleId": {
+      "type": "string",
+      "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+    }
+  }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/ASimDnsActivityLogs.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/ASimDnsActivityLogs.json
@@ -1,0 +1,598 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "dataCollectionRuleName": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the name of the Data Collection Rule to create."
+      }
+    },
+    "location": {
+      "defaultValue": "[resourceGroup().location]",
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the location in which to create the Data Collection Rule."
+      }
+    },
+    "workspaceResourceId": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+      }
+    },
+    "endpointResourceId": {
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Data Collection Endpoint to use."
+      },
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Insights/dataCollectionRules",
+      "apiVersion": "2023-03-11",
+      "name": "[parameters('dataCollectionRuleName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "streamDeclarations": {
+          "Custom-ASimDnsActivityLogs": {
+            "columns": [
+              {
+                "name": "AdditionalFields",
+                "type": "dynamic"
+              },
+              {
+                "name": "DnsFlags",
+                "type": "string"
+              },
+              {
+                "name": "DnsFlagsAuthenticated",
+                "type": "boolean"
+              },
+              {
+                "name": "DnsFlagsAuthoritative",
+                "type": "boolean"
+              },
+              {
+                "name": "DnsFlagsCheckingDisabled",
+                "type": "boolean"
+              },
+              {
+                "name": "DnsFlagsRecursionAvailable",
+                "type": "boolean"
+              },
+              {
+                "name": "DnsFlagsRecursionDesired",
+                "type": "boolean"
+              },
+              {
+                "name": "DnsFlagsTruncated",
+                "type": "boolean"
+              },
+              {
+                "name": "DnsFlagsZ",
+                "type": "boolean"
+              },
+              {
+                "name": "DnsNetworkDuration",
+                "type": "int"
+              },
+              {
+                "name": "DnsQuery",
+                "type": "string"
+              },
+              {
+                "name": "DnsQueryClass",
+                "type": "int"
+              },
+              {
+                "name": "DnsQueryClassName",
+                "type": "string"
+              },
+              {
+                "name": "DnsQueryType",
+                "type": "int"
+              },
+              {
+                "name": "DnsQueryTypeName",
+                "type": "string"
+              },
+              {
+                "name": "DnsResponseCode",
+                "type": "int"
+              },
+              {
+                "name": "DnsResponseIpCity",
+                "type": "string"
+              },
+              {
+                "name": "DnsResponseIpCountry",
+                "type": "string"
+              },
+              {
+                "name": "DnsResponseIpLatitude",
+                "type": "real"
+              },
+              {
+                "name": "DnsResponseIpLongitude",
+                "type": "real"
+              },
+              {
+                "name": "DnsResponseIpRegion",
+                "type": "string"
+              },
+              {
+                "name": "DnsResponseName",
+                "type": "string"
+              },
+              {
+                "name": "DnsSessionId",
+                "type": "string"
+              },
+              {
+                "name": "Dst",
+                "type": "string"
+              },
+              {
+                "name": "DstDescription",
+                "type": "string"
+              },
+              {
+                "name": "DstDeviceType",
+                "type": "string"
+              },
+              {
+                "name": "DstDomain",
+                "type": "string"
+              },
+              {
+                "name": "DstDomainType",
+                "type": "string"
+              },
+              {
+                "name": "DstDvcId",
+                "type": "string"
+              },
+              {
+                "name": "DstDvcIdType",
+                "type": "string"
+              },
+              {
+                "name": "DstDvcScope",
+                "type": "string"
+              },
+              {
+                "name": "DstDvcScopeId",
+                "type": "string"
+              },
+              {
+                "name": "DstFQDN",
+                "type": "string"
+              },
+              {
+                "name": "DstGeoCity",
+                "type": "string"
+              },
+              {
+                "name": "DstGeoCountry",
+                "type": "string"
+              },
+              {
+                "name": "DstGeoLatitude",
+                "type": "real"
+              },
+              {
+                "name": "DstGeoLongitude",
+                "type": "real"
+              },
+              {
+                "name": "DstGeoRegion",
+                "type": "string"
+              },
+              {
+                "name": "DstHostname",
+                "type": "string"
+              },
+              {
+                "name": "DstIpAddr",
+                "type": "string"
+              },
+              {
+                "name": "DstOriginalRiskLevel",
+                "type": "string"
+              },
+              {
+                "name": "DstPortNumber",
+                "type": "int"
+              },
+              {
+                "name": "DstRiskLevel",
+                "type": "int"
+              },
+              {
+                "name": "Dvc",
+                "type": "string"
+              },
+              {
+                "name": "DvcAction",
+                "type": "string"
+              },
+              {
+                "name": "DvcDescription",
+                "type": "string"
+              },
+              {
+                "name": "DvcDomain",
+                "type": "string"
+              },
+              {
+                "name": "DvcDomainType",
+                "type": "string"
+              },
+              {
+                "name": "DvcFQDN",
+                "type": "string"
+              },
+              {
+                "name": "DvcHostname",
+                "type": "string"
+              },
+              {
+                "name": "DvcId",
+                "type": "string"
+              },
+              {
+                "name": "DvcIdType",
+                "type": "string"
+              },
+              {
+                "name": "DvcInterface",
+                "type": "string"
+              },
+              {
+                "name": "DvcIpAddr",
+                "type": "string"
+              },
+              {
+                "name": "DvcMacAddr",
+                "type": "string"
+              },
+              {
+                "name": "DvcOriginalAction",
+                "type": "string"
+              },
+              {
+                "name": "DvcOs",
+                "type": "string"
+              },
+              {
+                "name": "DvcOsVersion",
+                "type": "string"
+              },
+              {
+                "name": "DvcScope",
+                "type": "string"
+              },
+              {
+                "name": "DvcScopeId",
+                "type": "string"
+              },
+              {
+                "name": "DvcZone",
+                "type": "string"
+              },
+              {
+                "name": "EventCount",
+                "type": "int"
+              },
+              {
+                "name": "EventEndTime",
+                "type": "datetime"
+              },
+              {
+                "name": "EventMessage",
+                "type": "string"
+              },
+              {
+                "name": "EventOriginalSeverity",
+                "type": "string"
+              },
+              {
+                "name": "EventOriginalType",
+                "type": "string"
+              },
+              {
+                "name": "EventOriginalUid",
+                "type": "string"
+              },
+              {
+                "name": "EventOwner",
+                "type": "string"
+              },
+              {
+                "name": "EventProduct",
+                "type": "string"
+              },
+              {
+                "name": "EventProductVersion",
+                "type": "string"
+              },
+              {
+                "name": "EventReportUrl",
+                "type": "string"
+              },
+              {
+                "name": "EventResult",
+                "type": "string"
+              },
+              {
+                "name": "EventResultDetails",
+                "type": "string"
+              },
+              {
+                "name": "EventSchemaVersion",
+                "type": "string"
+              },
+              {
+                "name": "EventSeverity",
+                "type": "string"
+              },
+              {
+                "name": "EventStartTime",
+                "type": "datetime"
+              },
+              {
+                "name": "EventSubType",
+                "type": "string"
+              },
+              {
+                "name": "EventType",
+                "type": "string"
+              },
+              {
+                "name": "EventVendor",
+                "type": "string"
+              },
+              {
+                "name": "NetworkProtocol",
+                "type": "string"
+              },
+              {
+                "name": "NetworkProtocolVersion",
+                "type": "string"
+              },
+              {
+                "name": "RuleName",
+                "type": "string"
+              },
+              {
+                "name": "RuleNumber",
+                "type": "int"
+              },
+              {
+                "name": "SourceSystem",
+                "type": "string"
+              },
+              {
+                "name": "Src",
+                "type": "string"
+              },
+              {
+                "name": "SrcDescription",
+                "type": "string"
+              },
+              {
+                "name": "SrcDeviceType",
+                "type": "string"
+              },
+              {
+                "name": "SrcDomain",
+                "type": "string"
+              },
+              {
+                "name": "SrcDomainType",
+                "type": "string"
+              },
+              {
+                "name": "SrcDvcId",
+                "type": "string"
+              },
+              {
+                "name": "SrcDvcIdType",
+                "type": "string"
+              },
+              {
+                "name": "SrcDvcScope",
+                "type": "string"
+              },
+              {
+                "name": "SrcDvcScopeId",
+                "type": "string"
+              },
+              {
+                "name": "SrcFQDN",
+                "type": "string"
+              },
+              {
+                "name": "SrcGeoCity",
+                "type": "string"
+              },
+              {
+                "name": "SrcGeoCountry",
+                "type": "string"
+              },
+              {
+                "name": "SrcGeoLatitude",
+                "type": "real"
+              },
+              {
+                "name": "SrcGeoLongitude",
+                "type": "real"
+              },
+              {
+                "name": "SrcGeoRegion",
+                "type": "string"
+              },
+              {
+                "name": "SrcHostname",
+                "type": "string"
+              },
+              {
+                "name": "SrcIpAddr",
+                "type": "string"
+              },
+              {
+                "name": "SrcOriginalRiskLevel",
+                "type": "string"
+              },
+              {
+                "name": "SrcOriginalUserType",
+                "type": "string"
+              },
+              {
+                "name": "SrcPortNumber",
+                "type": "int"
+              },
+              {
+                "name": "SrcProcessGuid",
+                "type": "string"
+              },
+              {
+                "name": "SrcProcessId",
+                "type": "string"
+              },
+              {
+                "name": "SrcProcessName",
+                "type": "string"
+              },
+              {
+                "name": "SrcRiskLevel",
+                "type": "int"
+              },
+              {
+                "name": "SrcUserId",
+                "type": "string"
+              },
+              {
+                "name": "SrcUserIdType",
+                "type": "string"
+              },
+              {
+                "name": "SrcUsername",
+                "type": "string"
+              },
+              {
+                "name": "SrcUsernameType",
+                "type": "string"
+              },
+              {
+                "name": "SrcUserScope",
+                "type": "string"
+              },
+              {
+                "name": "SrcUserScopeId",
+                "type": "string"
+              },
+              {
+                "name": "SrcUserSessionId",
+                "type": "string"
+              },
+              {
+                "name": "SrcUserType",
+                "type": "string"
+              },
+              {
+                "name": "ThreatCategory",
+                "type": "string"
+              },
+              {
+                "name": "ThreatConfidence",
+                "type": "int"
+              },
+              {
+                "name": "ThreatField",
+                "type": "string"
+              },
+              {
+                "name": "ThreatFirstReportedTime",
+                "type": "datetime"
+              },
+              {
+                "name": "ThreatId",
+                "type": "string"
+              },
+              {
+                "name": "ThreatIpAddr",
+                "type": "string"
+              },
+              {
+                "name": "ThreatIsActive",
+                "type": "boolean"
+              },
+              {
+                "name": "ThreatLastReportedTime",
+                "type": "datetime"
+              },
+              {
+                "name": "ThreatName",
+                "type": "string"
+              },
+              {
+                "name": "ThreatOriginalConfidence",
+                "type": "string"
+              },
+              {
+                "name": "ThreatOriginalRiskLevel",
+                "type": "int"
+              },
+              {
+                "name": "ThreatRiskLevel",
+                "type": "int"
+              },
+              {
+                "name": "TimeGenerated",
+                "type": "datetime"
+              },
+              {
+                "name": "TransactionIdHex",
+                "type": "string"
+              },
+              {
+                "name": "UrlCategory",
+                "type": "string"
+              }
+            ]
+          }
+        },
+        "destinations": {
+          "logAnalytics": [
+            {
+              "workspaceResourceId": "[parameters('workspaceResourceId')]",
+              "name": "logAnalyticsWorkspace"
+            }
+          ]
+        },
+        "dataFlows": [
+          {
+            "streams": [
+              "Custom-ASimDnsActivityLogs"
+            ],
+            "destinations": [
+              "logAnalyticsWorkspace"
+            ],
+            "transformKql": "source",
+            "outputStream": "Microsoft-ASimDnsActivityLogs"
+          }
+        ],
+        "dataCollectionEndpointId": "[parameters('endpointResourceId')]"
+      }
+    }
+  ],
+  "outputs": {
+    "dataCollectionRuleId": {
+      "type": "string",
+      "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+    }
+  }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/ASimFileEventLogs.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/ASimFileEventLogs.json
@@ -1,0 +1,562 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "dataCollectionRuleName": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the name of the Data Collection Rule to create."
+      }
+    },
+    "location": {
+      "defaultValue": "[resourceGroup().location]",
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the location in which to create the Data Collection Rule."
+      }
+    },
+    "workspaceResourceId": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+      }
+    },
+    "endpointResourceId": {
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Data Collection Endpoint to use."
+      },
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Insights/dataCollectionRules",
+      "apiVersion": "2023-03-11",
+      "name": "[parameters('dataCollectionRuleName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "streamDeclarations": {
+          "Custom-ASimFileEventLogs": {
+            "columns": [
+              {
+                "name": "ActingProcessCommandLine",
+                "type": "string"
+              },
+              {
+                "name": "ActingProcessGuid",
+                "type": "string"
+              },
+              {
+                "name": "ActingProcessId",
+                "type": "string"
+              },
+              {
+                "name": "ActingProcessName",
+                "type": "string"
+              },
+              {
+                "name": "ActorOriginalUserType",
+                "type": "string"
+              },
+              {
+                "name": "ActorScope",
+                "type": "string"
+              },
+              {
+                "name": "ActorScopeId",
+                "type": "string"
+              },
+              {
+                "name": "ActorSessionId",
+                "type": "string"
+              },
+              {
+                "name": "ActorUserAadId",
+                "type": "string"
+              },
+              {
+                "name": "ActorUserId",
+                "type": "string"
+              },
+              {
+                "name": "ActorUserIdType",
+                "type": "string"
+              },
+              {
+                "name": "ActorUsername",
+                "type": "string"
+              },
+              {
+                "name": "ActorUsernameType",
+                "type": "string"
+              },
+              {
+                "name": "ActorUserSid",
+                "type": "string"
+              },
+              {
+                "name": "ActorUserType",
+                "type": "string"
+              },
+              {
+                "name": "AdditionalFields",
+                "type": "dynamic"
+              },
+              {
+                "name": "DvcAction",
+                "type": "string"
+              },
+              {
+                "name": "DvcDescription",
+                "type": "string"
+              },
+              {
+                "name": "DvcDomain",
+                "type": "string"
+              },
+              {
+                "name": "DvcDomainType",
+                "type": "string"
+              },
+              {
+                "name": "DvcFQDN",
+                "type": "string"
+              },
+              {
+                "name": "DvcHostname",
+                "type": "string"
+              },
+              {
+                "name": "DvcId",
+                "type": "string"
+              },
+              {
+                "name": "DvcIdType",
+                "type": "string"
+              },
+              {
+                "name": "DvcInterface",
+                "type": "string"
+              },
+              {
+                "name": "DvcIpAddr",
+                "type": "string"
+              },
+              {
+                "name": "DvcMacAddr",
+                "type": "string"
+              },
+              {
+                "name": "DvcOriginalAction",
+                "type": "string"
+              },
+              {
+                "name": "DvcOs",
+                "type": "string"
+              },
+              {
+                "name": "DvcOsVersion",
+                "type": "string"
+              },
+              {
+                "name": "DvcScope",
+                "type": "string"
+              },
+              {
+                "name": "DvcScopeId",
+                "type": "string"
+              },
+              {
+                "name": "DvcZone",
+                "type": "string"
+              },
+              {
+                "name": "EventCount",
+                "type": "int"
+              },
+              {
+                "name": "EventEndTime",
+                "type": "datetime"
+              },
+              {
+                "name": "EventMessage",
+                "type": "string"
+              },
+              {
+                "name": "EventOriginalResultDetails",
+                "type": "string"
+              },
+              {
+                "name": "EventOriginalSeverity",
+                "type": "string"
+              },
+              {
+                "name": "EventOriginalSubType",
+                "type": "string"
+              },
+              {
+                "name": "EventOriginalType",
+                "type": "string"
+              },
+              {
+                "name": "EventOriginalUid",
+                "type": "string"
+              },
+              {
+                "name": "EventOwner",
+                "type": "string"
+              },
+              {
+                "name": "EventProduct",
+                "type": "string"
+              },
+              {
+                "name": "EventProductVersion",
+                "type": "string"
+              },
+              {
+                "name": "EventReportUrl",
+                "type": "string"
+              },
+              {
+                "name": "EventResult",
+                "type": "string"
+              },
+              {
+                "name": "EventResultDetails",
+                "type": "string"
+              },
+              {
+                "name": "EventSchema",
+                "type": "string"
+              },
+              {
+                "name": "EventSchemaVersion",
+                "type": "string"
+              },
+              {
+                "name": "EventSeverity",
+                "type": "string"
+              },
+              {
+                "name": "EventStartTime",
+                "type": "datetime"
+              },
+              {
+                "name": "EventSubType",
+                "type": "string"
+              },
+              {
+                "name": "EventType",
+                "type": "string"
+              },
+              {
+                "name": "EventVendor",
+                "type": "string"
+              },
+              {
+                "name": "HashType",
+                "type": "string"
+              },
+              {
+                "name": "HttpUserAgent",
+                "type": "string"
+              },
+              {
+                "name": "NetworkApplicationProtocol",
+                "type": "string"
+              },
+              {
+                "name": "RuleName",
+                "type": "string"
+              },
+              {
+                "name": "RuleNumber",
+                "type": "int"
+              },
+              {
+                "name": "SourceSystem",
+                "type": "string"
+              },
+              {
+                "name": "SrcDescription",
+                "type": "string"
+              },
+              {
+                "name": "SrcDeviceType",
+                "type": "string"
+              },
+              {
+                "name": "SrcDomain",
+                "type": "string"
+              },
+              {
+                "name": "SrcDomainType",
+                "type": "string"
+              },
+              {
+                "name": "SrcDvcId",
+                "type": "string"
+              },
+              {
+                "name": "SrcDvcIdType",
+                "type": "string"
+              },
+              {
+                "name": "SrcDvcScope",
+                "type": "string"
+              },
+              {
+                "name": "SrcDvcScopeId",
+                "type": "string"
+              },
+              {
+                "name": "SrcFileCreationTime",
+                "type": "datetime"
+              },
+              {
+                "name": "SrcFileDirectory",
+                "type": "string"
+              },
+              {
+                "name": "SrcFileExtension",
+                "type": "string"
+              },
+              {
+                "name": "SrcFileMD5",
+                "type": "string"
+              },
+              {
+                "name": "SrcFileMimeType",
+                "type": "string"
+              },
+              {
+                "name": "SrcFileName",
+                "type": "string"
+              },
+              {
+                "name": "SrcFilePath",
+                "type": "string"
+              },
+              {
+                "name": "SrcFilePathType",
+                "type": "string"
+              },
+              {
+                "name": "SrcFileSHA1",
+                "type": "string"
+              },
+              {
+                "name": "SrcFileSHA256",
+                "type": "string"
+              },
+              {
+                "name": "SrcFileSHA512",
+                "type": "string"
+              },
+              {
+                "name": "SrcFileSize",
+                "type": "long"
+              },
+              {
+                "name": "SrcFQDN",
+                "type": "string"
+              },
+              {
+                "name": "SrcGeoCity",
+                "type": "string"
+              },
+              {
+                "name": "SrcGeoCountry",
+                "type": "string"
+              },
+              {
+                "name": "SrcGeoLatitude",
+                "type": "real"
+              },
+              {
+                "name": "SrcGeoLongitude",
+                "type": "real"
+              },
+              {
+                "name": "SrcGeoRegion",
+                "type": "string"
+              },
+              {
+                "name": "SrcHostname",
+                "type": "string"
+              },
+              {
+                "name": "SrcIpAddr",
+                "type": "string"
+              },
+              {
+                "name": "SrcMacAddr",
+                "type": "string"
+              },
+              {
+                "name": "SrcOriginalRiskLevel",
+                "type": "string"
+              },
+              {
+                "name": "SrcPortNumber",
+                "type": "int"
+              },
+              {
+                "name": "SrcRiskLevel",
+                "type": "int"
+              },
+              {
+                "name": "TargetAppId",
+                "type": "string"
+              },
+              {
+                "name": "TargetAppName",
+                "type": "string"
+              },
+              {
+                "name": "TargetAppType",
+                "type": "string"
+              },
+              {
+                "name": "TargetFileCreationTime",
+                "type": "datetime"
+              },
+              {
+                "name": "TargetFileDirectory",
+                "type": "string"
+              },
+              {
+                "name": "TargetFileExtension",
+                "type": "string"
+              },
+              {
+                "name": "TargetFileMD5",
+                "type": "string"
+              },
+              {
+                "name": "TargetFileMimeType",
+                "type": "string"
+              },
+              {
+                "name": "TargetFileName",
+                "type": "string"
+              },
+              {
+                "name": "TargetFilePath",
+                "type": "string"
+              },
+              {
+                "name": "TargetFilePathType",
+                "type": "string"
+              },
+              {
+                "name": "TargetFileSHA1",
+                "type": "string"
+              },
+              {
+                "name": "TargetFileSHA256",
+                "type": "string"
+              },
+              {
+                "name": "TargetFileSHA512",
+                "type": "string"
+              },
+              {
+                "name": "TargetFileSize",
+                "type": "long"
+              },
+              {
+                "name": "TargetOriginalAppType",
+                "type": "string"
+              },
+              {
+                "name": "TargetUrl",
+                "type": "string"
+              },
+              {
+                "name": "ThreatCategory",
+                "type": "string"
+              },
+              {
+                "name": "ThreatConfidence",
+                "type": "int"
+              },
+              {
+                "name": "ThreatField",
+                "type": "string"
+              },
+              {
+                "name": "ThreatFilePath",
+                "type": "string"
+              },
+              {
+                "name": "ThreatFirstReportedTime",
+                "type": "datetime"
+              },
+              {
+                "name": "ThreatId",
+                "type": "string"
+              },
+              {
+                "name": "ThreatIsActive",
+                "type": "boolean"
+              },
+              {
+                "name": "ThreatLastReportedTime",
+                "type": "datetime"
+              },
+              {
+                "name": "ThreatName",
+                "type": "string"
+              },
+              {
+                "name": "ThreatOriginalConfidence",
+                "type": "string"
+              },
+              {
+                "name": "ThreatOriginalRiskLevel",
+                "type": "string"
+              },
+              {
+                "name": "ThreatRiskLevel",
+                "type": "int"
+              },
+              {
+                "name": "TimeGenerated",
+                "type": "datetime"
+              }
+            ]
+          }
+        },
+        "destinations": {
+          "logAnalytics": [
+            {
+              "workspaceResourceId": "[parameters('workspaceResourceId')]",
+              "name": "logAnalyticsWorkspace"
+            }
+          ]
+        },
+        "dataFlows": [
+          {
+            "streams": [
+              "Custom-ASimFileEventLogs"
+            ],
+            "destinations": [
+              "logAnalyticsWorkspace"
+            ],
+            "transformKql": "source",
+            "outputStream": "Microsoft-ASimFileEventLogs"
+          }
+        ],
+        "dataCollectionEndpointId": "[parameters('endpointResourceId')]"
+      }
+    }
+  ],
+  "outputs": {
+    "dataCollectionRuleId": {
+      "type": "string",
+      "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+    }
+  }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/ASimNetworkSessionLogs.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/ASimNetworkSessionLogs.json
@@ -1,0 +1,634 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "dataCollectionRuleName": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the name of the Data Collection Rule to create."
+      }
+    },
+    "location": {
+      "defaultValue": "[resourceGroup().location]",
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the location in which to create the Data Collection Rule."
+      }
+    },
+    "workspaceResourceId": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+      }
+    },
+    "endpointResourceId": {
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Data Collection Endpoint to use."
+      },
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Insights/dataCollectionRules",
+      "apiVersion": "2023-03-11",
+      "name": "[parameters('dataCollectionRuleName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "streamDeclarations": {
+          "Custom-ASimNetworkSessionLogs": {
+            "columns": [
+              {
+                "name": "AdditionalFields",
+                "type": "dynamic"
+              },
+              {
+                "name": "DstAppId",
+                "type": "string"
+              },
+              {
+                "name": "DstAppName",
+                "type": "string"
+              },
+              {
+                "name": "DstAppType",
+                "type": "string"
+              },
+              {
+                "name": "DstBytes",
+                "type": "long"
+              },
+              {
+                "name": "DstDescription",
+                "type": "string"
+              },
+              {
+                "name": "DstDeviceType",
+                "type": "string"
+              },
+              {
+                "name": "DstDomain",
+                "type": "string"
+              },
+              {
+                "name": "DstDomainType",
+                "type": "string"
+              },
+              {
+                "name": "DstDvcId",
+                "type": "string"
+              },
+              {
+                "name": "DstDvcIdType",
+                "type": "string"
+              },
+              {
+                "name": "DstFQDN",
+                "type": "string"
+              },
+              {
+                "name": "DstGeoCity",
+                "type": "string"
+              },
+              {
+                "name": "DstGeoCountry",
+                "type": "string"
+              },
+              {
+                "name": "DstGeoLatitude",
+                "type": "real"
+              },
+              {
+                "name": "DstGeoLongitude",
+                "type": "real"
+              },
+              {
+                "name": "DstGeoRegion",
+                "type": "string"
+              },
+              {
+                "name": "DstHostname",
+                "type": "string"
+              },
+              {
+                "name": "DstInterfaceGuid",
+                "type": "string"
+              },
+              {
+                "name": "DstInterfaceName",
+                "type": "string"
+              },
+              {
+                "name": "DstIpAddr",
+                "type": "string"
+              },
+              {
+                "name": "DstMacAddr",
+                "type": "string"
+              },
+              {
+                "name": "DstNatIpAddr",
+                "type": "string"
+              },
+              {
+                "name": "DstNatPortNumber",
+                "type": "int"
+              },
+              {
+                "name": "DstOriginalUserType",
+                "type": "string"
+              },
+              {
+                "name": "DstPackets",
+                "type": "long"
+              },
+              {
+                "name": "DstPortNumber",
+                "type": "int"
+              },
+              {
+                "name": "DstSubscriptionId",
+                "type": "string"
+              },
+              {
+                "name": "DstUserId",
+                "type": "string"
+              },
+              {
+                "name": "DstUserIdType",
+                "type": "string"
+              },
+              {
+                "name": "DstUsername",
+                "type": "string"
+              },
+              {
+                "name": "DstUsernameType",
+                "type": "string"
+              },
+              {
+                "name": "DstUserType",
+                "type": "string"
+              },
+              {
+                "name": "DstVlanId",
+                "type": "string"
+              },
+              {
+                "name": "DstZone",
+                "type": "string"
+              },
+              {
+                "name": "Dvc",
+                "type": "string"
+              },
+              {
+                "name": "DvcAction",
+                "type": "string"
+              },
+              {
+                "name": "DvcDescription",
+                "type": "string"
+              },
+              {
+                "name": "DvcDomain",
+                "type": "string"
+              },
+              {
+                "name": "DvcDomainType",
+                "type": "string"
+              },
+              {
+                "name": "DvcFQDN",
+                "type": "string"
+              },
+              {
+                "name": "DvcHostname",
+                "type": "string"
+              },
+              {
+                "name": "DvcId",
+                "type": "string"
+              },
+              {
+                "name": "DvcIdType",
+                "type": "string"
+              },
+              {
+                "name": "DvcInboundInterface",
+                "type": "string"
+              },
+              {
+                "name": "DvcInterface",
+                "type": "string"
+              },
+              {
+                "name": "DvcIpAddr",
+                "type": "string"
+              },
+              {
+                "name": "DvcMacAddr",
+                "type": "string"
+              },
+              {
+                "name": "DvcOriginalAction",
+                "type": "string"
+              },
+              {
+                "name": "DvcOs",
+                "type": "string"
+              },
+              {
+                "name": "DvcOsVersion",
+                "type": "string"
+              },
+              {
+                "name": "DvcOutboundInterface",
+                "type": "string"
+              },
+              {
+                "name": "DvcSubscriptionId",
+                "type": "string"
+              },
+              {
+                "name": "DvcZone",
+                "type": "string"
+              },
+              {
+                "name": "EventCount",
+                "type": "int"
+              },
+              {
+                "name": "EventEndTime",
+                "type": "datetime"
+              },
+              {
+                "name": "EventMessage",
+                "type": "string"
+              },
+              {
+                "name": "EventOriginalResultDetails",
+                "type": "string"
+              },
+              {
+                "name": "EventOriginalSeverity",
+                "type": "string"
+              },
+              {
+                "name": "EventOriginalSubType",
+                "type": "string"
+              },
+              {
+                "name": "EventOriginalType",
+                "type": "string"
+              },
+              {
+                "name": "EventOriginalUid",
+                "type": "string"
+              },
+              {
+                "name": "EventProduct",
+                "type": "string"
+              },
+              {
+                "name": "EventProductVersion",
+                "type": "string"
+              },
+              {
+                "name": "EventReportUrl",
+                "type": "string"
+              },
+              {
+                "name": "EventResult",
+                "type": "string"
+              },
+              {
+                "name": "EventResultDetails",
+                "type": "string"
+              },
+              {
+                "name": "EventSchemaVersion",
+                "type": "string"
+              },
+              {
+                "name": "EventSeverity",
+                "type": "string"
+              },
+              {
+                "name": "EventStartTime",
+                "type": "datetime"
+              },
+              {
+                "name": "EventSubType",
+                "type": "string"
+              },
+              {
+                "name": "EventType",
+                "type": "string"
+              },
+              {
+                "name": "EventVendor",
+                "type": "string"
+              },
+              {
+                "name": "NetworkApplicationProtocol",
+                "type": "string"
+              },
+              {
+                "name": "NetworkBytes",
+                "type": "long"
+              },
+              {
+                "name": "NetworkConnectionHistory",
+                "type": "string"
+              },
+              {
+                "name": "NetworkDirection",
+                "type": "string"
+              },
+              {
+                "name": "NetworkDuration",
+                "type": "int"
+              },
+              {
+                "name": "NetworkIcmpCode",
+                "type": "int"
+              },
+              {
+                "name": "NetworkIcmpType",
+                "type": "string"
+              },
+              {
+                "name": "NetworkPackets",
+                "type": "long"
+              },
+              {
+                "name": "NetworkProtocol",
+                "type": "string"
+              },
+              {
+                "name": "NetworkProtocolVersion",
+                "type": "string"
+              },
+              {
+                "name": "NetworkRuleName",
+                "type": "string"
+              },
+              {
+                "name": "NetworkRuleNumber",
+                "type": "int"
+              },
+              {
+                "name": "NetworkSessionId",
+                "type": "string"
+              },
+              {
+                "name": "SourceSystem",
+                "type": "string"
+              },
+              {
+                "name": "SrcAppId",
+                "type": "string"
+              },
+              {
+                "name": "SrcAppName",
+                "type": "string"
+              },
+              {
+                "name": "SrcAppType",
+                "type": "string"
+              },
+              {
+                "name": "SrcBytes",
+                "type": "long"
+              },
+              {
+                "name": "SrcDescription",
+                "type": "string"
+              },
+              {
+                "name": "SrcDeviceType",
+                "type": "string"
+              },
+              {
+                "name": "SrcDomain",
+                "type": "string"
+              },
+              {
+                "name": "SrcDomainType",
+                "type": "string"
+              },
+              {
+                "name": "SrcDvcId",
+                "type": "string"
+              },
+              {
+                "name": "SrcDvcIdType",
+                "type": "string"
+              },
+              {
+                "name": "SrcFQDN",
+                "type": "string"
+              },
+              {
+                "name": "SrcGeoCity",
+                "type": "string"
+              },
+              {
+                "name": "SrcGeoCountry",
+                "type": "string"
+              },
+              {
+                "name": "SrcGeoLatitude",
+                "type": "real"
+              },
+              {
+                "name": "SrcGeoLongitude",
+                "type": "real"
+              },
+              {
+                "name": "SrcGeoRegion",
+                "type": "string"
+              },
+              {
+                "name": "SrcHostname",
+                "type": "string"
+              },
+              {
+                "name": "SrcInterfaceGuid",
+                "type": "string"
+              },
+              {
+                "name": "SrcInterfaceName",
+                "type": "string"
+              },
+              {
+                "name": "SrcIpAddr",
+                "type": "string"
+              },
+              {
+                "name": "SrcMacAddr",
+                "type": "string"
+              },
+              {
+                "name": "SrcNatIpAddr",
+                "type": "string"
+              },
+              {
+                "name": "SrcNatPortNumber",
+                "type": "int"
+              },
+              {
+                "name": "SrcOriginalUserType",
+                "type": "string"
+              },
+              {
+                "name": "SrcPackets",
+                "type": "long"
+              },
+              {
+                "name": "SrcPortNumber",
+                "type": "int"
+              },
+              {
+                "name": "SrcSubscriptionId",
+                "type": "string"
+              },
+              {
+                "name": "SrcUserId",
+                "type": "string"
+              },
+              {
+                "name": "SrcUserIdType",
+                "type": "string"
+              },
+              {
+                "name": "SrcUsername",
+                "type": "string"
+              },
+              {
+                "name": "SrcUsernameType",
+                "type": "string"
+              },
+              {
+                "name": "SrcUserType",
+                "type": "string"
+              },
+              {
+                "name": "SrcVlanId",
+                "type": "string"
+              },
+              {
+                "name": "SrcZone",
+                "type": "string"
+              },
+              {
+                "name": "TcpFlagsAck",
+                "type": "boolean"
+              },
+              {
+                "name": "TcpFlagsFin",
+                "type": "boolean"
+              },
+              {
+                "name": "TcpFlagsPsh",
+                "type": "boolean"
+              },
+              {
+                "name": "TcpFlagsRst",
+                "type": "boolean"
+              },
+              {
+                "name": "TcpFlagsSyn",
+                "type": "boolean"
+              },
+              {
+                "name": "TcpFlagsUrg",
+                "type": "boolean"
+              },
+              {
+                "name": "ThreatCategory",
+                "type": "string"
+              },
+              {
+                "name": "ThreatConfidence",
+                "type": "int"
+              },
+              {
+                "name": "ThreatField",
+                "type": "string"
+              },
+              {
+                "name": "ThreatFirstReportedTime",
+                "type": "datetime"
+              },
+              {
+                "name": "ThreatId",
+                "type": "string"
+              },
+              {
+                "name": "ThreatIpAddr",
+                "type": "string"
+              },
+              {
+                "name": "ThreatIsActive",
+                "type": "boolean"
+              },
+              {
+                "name": "ThreatLastReportedTime",
+                "type": "datetime"
+              },
+              {
+                "name": "ThreatName",
+                "type": "string"
+              },
+              {
+                "name": "ThreatOriginalConfidence",
+                "type": "string"
+              },
+              {
+                "name": "ThreatOriginalRiskLevel",
+                "type": "string"
+              },
+              {
+                "name": "ThreatRiskLevel",
+                "type": "int"
+              },
+              {
+                "name": "TimeGenerated",
+                "type": "datetime"
+              }
+            ]
+          }
+        },
+        "destinations": {
+          "logAnalytics": [
+            {
+              "workspaceResourceId": "[parameters('workspaceResourceId')]",
+              "name": "logAnalyticsWorkspace"
+            }
+          ]
+        },
+        "dataFlows": [
+          {
+            "streams": [
+              "Custom-ASimNetworkSessionLogs"
+            ],
+            "destinations": [
+              "logAnalyticsWorkspace"
+            ],
+            "transformKql": "source",
+            "outputStream": "Microsoft-ASimNetworkSessionLogs"
+          }
+        ],
+        "dataCollectionEndpointId": "[parameters('endpointResourceId')]"
+      }
+    }
+  ],
+  "outputs": {
+    "dataCollectionRuleId": {
+      "type": "string",
+      "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+    }
+  }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/ASimProcessEventLogs.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/ASimProcessEventLogs.json
@@ -1,0 +1,614 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "dataCollectionRuleName": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the name of the Data Collection Rule to create."
+      }
+    },
+    "location": {
+      "defaultValue": "[resourceGroup().location]",
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the location in which to create the Data Collection Rule."
+      }
+    },
+    "workspaceResourceId": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+      }
+    },
+    "endpointResourceId": {
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Data Collection Endpoint to use."
+      },
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Insights/dataCollectionRules",
+      "apiVersion": "2023-03-11",
+      "name": "[parameters('dataCollectionRuleName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "streamDeclarations": {
+          "Custom-ASimProcessEventLogs": {
+            "columns": [
+              {
+                "name": "ActingProcessCommandLine",
+                "type": "string"
+              },
+              {
+                "name": "ActingProcessCreationTime",
+                "type": "datetime"
+              },
+              {
+                "name": "ActingProcessFileCompany",
+                "type": "string"
+              },
+              {
+                "name": "ActingProcessFileDescription",
+                "type": "string"
+              },
+              {
+                "name": "ActingProcessFileInternalName",
+                "type": "string"
+              },
+              {
+                "name": "ActingProcessFilename",
+                "type": "string"
+              },
+              {
+                "name": "ActingProcessFileOriginalName",
+                "type": "string"
+              },
+              {
+                "name": "ActingProcessFileProduct",
+                "type": "string"
+              },
+              {
+                "name": "ActingProcessFileSize",
+                "type": "long"
+              },
+              {
+                "name": "ActingProcessFileVersion",
+                "type": "string"
+              },
+              {
+                "name": "ActingProcessGuid",
+                "type": "string"
+              },
+              {
+                "name": "ActingProcessId",
+                "type": "string"
+              },
+              {
+                "name": "ActingProcessIMPHASH",
+                "type": "string"
+              },
+              {
+                "name": "ActingProcessInjectedAddress",
+                "type": "string"
+              },
+              {
+                "name": "ActingProcessIntegrityLevel",
+                "type": "string"
+              },
+              {
+                "name": "ActingProcessIsHidden",
+                "type": "boolean"
+              },
+              {
+                "name": "ActingProcessMD5",
+                "type": "string"
+              },
+              {
+                "name": "ActingProcessName",
+                "type": "string"
+              },
+              {
+                "name": "ActingProcessSHA1",
+                "type": "string"
+              },
+              {
+                "name": "ActingProcessSHA256",
+                "type": "string"
+              },
+              {
+                "name": "ActingProcessSHA512",
+                "type": "string"
+              },
+              {
+                "name": "ActingProcessTokenElevation",
+                "type": "string"
+              },
+              {
+                "name": "ActorOriginalUserType",
+                "type": "string"
+              },
+              {
+                "name": "ActorScope",
+                "type": "string"
+              },
+              {
+                "name": "ActorScopeId",
+                "type": "string"
+              },
+              {
+                "name": "ActorSessionId",
+                "type": "string"
+              },
+              {
+                "name": "ActorUserId",
+                "type": "string"
+              },
+              {
+                "name": "ActorUserIdType",
+                "type": "string"
+              },
+              {
+                "name": "ActorUsername",
+                "type": "string"
+              },
+              {
+                "name": "ActorUsernameType",
+                "type": "string"
+              },
+              {
+                "name": "ActorUserType",
+                "type": "string"
+              },
+              {
+                "name": "AdditionalFields",
+                "type": "dynamic"
+              },
+              {
+                "name": "DvcAction",
+                "type": "string"
+              },
+              {
+                "name": "DvcDescription",
+                "type": "string"
+              },
+              {
+                "name": "DvcDomain",
+                "type": "string"
+              },
+              {
+                "name": "DvcDomainType",
+                "type": "string"
+              },
+              {
+                "name": "DvcFQDN",
+                "type": "string"
+              },
+              {
+                "name": "DvcHostname",
+                "type": "string"
+              },
+              {
+                "name": "DvcId",
+                "type": "string"
+              },
+              {
+                "name": "DvcIdType",
+                "type": "string"
+              },
+              {
+                "name": "DvcInterface",
+                "type": "string"
+              },
+              {
+                "name": "DvcIpAddr",
+                "type": "string"
+              },
+              {
+                "name": "DvcMacAddr",
+                "type": "string"
+              },
+              {
+                "name": "DvcOriginalAction",
+                "type": "string"
+              },
+              {
+                "name": "DvcOs",
+                "type": "string"
+              },
+              {
+                "name": "DvcOsVersion",
+                "type": "string"
+              },
+              {
+                "name": "DvcScope",
+                "type": "string"
+              },
+              {
+                "name": "DvcScopeId",
+                "type": "string"
+              },
+              {
+                "name": "DvcZone",
+                "type": "string"
+              },
+              {
+                "name": "EventCount",
+                "type": "int"
+              },
+              {
+                "name": "EventEndTime",
+                "type": "datetime"
+              },
+              {
+                "name": "EventMessage",
+                "type": "string"
+              },
+              {
+                "name": "EventOriginalResultDetails",
+                "type": "string"
+              },
+              {
+                "name": "EventOriginalSeverity",
+                "type": "string"
+              },
+              {
+                "name": "EventOriginalSubType",
+                "type": "string"
+              },
+              {
+                "name": "EventOriginalType",
+                "type": "string"
+              },
+              {
+                "name": "EventOriginalUid",
+                "type": "string"
+              },
+              {
+                "name": "EventOwner",
+                "type": "string"
+              },
+              {
+                "name": "EventProduct",
+                "type": "string"
+              },
+              {
+                "name": "EventProductVersion",
+                "type": "string"
+              },
+              {
+                "name": "EventReportUrl",
+                "type": "string"
+              },
+              {
+                "name": "EventResult",
+                "type": "string"
+              },
+              {
+                "name": "EventResultDetails",
+                "type": "string"
+              },
+              {
+                "name": "EventSchemaVersion",
+                "type": "string"
+              },
+              {
+                "name": "EventSeverity",
+                "type": "string"
+              },
+              {
+                "name": "EventStartTime",
+                "type": "datetime"
+              },
+              {
+                "name": "EventSubType",
+                "type": "string"
+              },
+              {
+                "name": "EventType",
+                "type": "string"
+              },
+              {
+                "name": "EventVendor",
+                "type": "string"
+              },
+              {
+                "name": "ParentProcessCreationTime",
+                "type": "datetime"
+              },
+              {
+                "name": "ParentProcessFileCompany",
+                "type": "string"
+              },
+              {
+                "name": "ParentProcessFileDescription",
+                "type": "string"
+              },
+              {
+                "name": "ParentProcessFileProduct",
+                "type": "string"
+              },
+              {
+                "name": "ParentProcessFileVersion",
+                "type": "string"
+              },
+              {
+                "name": "ParentProcessGuid",
+                "type": "string"
+              },
+              {
+                "name": "ParentProcessId",
+                "type": "string"
+              },
+              {
+                "name": "ParentProcessIMPHASH",
+                "type": "string"
+              },
+              {
+                "name": "ParentProcessInjectedAddress",
+                "type": "string"
+              },
+              {
+                "name": "ParentProcessIntegrityLevel",
+                "type": "string"
+              },
+              {
+                "name": "ParentProcessIsHidden",
+                "type": "boolean"
+              },
+              {
+                "name": "ParentProcessMD5",
+                "type": "string"
+              },
+              {
+                "name": "ParentProcessName",
+                "type": "string"
+              },
+              {
+                "name": "ParentProcessSHA1",
+                "type": "string"
+              },
+              {
+                "name": "ParentProcessSHA256",
+                "type": "string"
+              },
+              {
+                "name": "ParentProcessSHA512",
+                "type": "string"
+              },
+              {
+                "name": "ParentProcessTokenElevation",
+                "type": "string"
+              },
+              {
+                "name": "RuleName",
+                "type": "string"
+              },
+              {
+                "name": "RuleNumber",
+                "type": "int"
+              },
+              {
+                "name": "SourceSystem",
+                "type": "string"
+              },
+              {
+                "name": "TargetOriginalUserType",
+                "type": "string"
+              },
+              {
+                "name": "TargetProcessCommandLine",
+                "type": "string"
+              },
+              {
+                "name": "TargetProcessCreationTime",
+                "type": "datetime"
+              },
+              {
+                "name": "TargetProcessCurrentDirectory",
+                "type": "string"
+              },
+              {
+                "name": "TargetProcessFileCompany",
+                "type": "string"
+              },
+              {
+                "name": "TargetProcessFileDescription",
+                "type": "string"
+              },
+              {
+                "name": "TargetProcessFileInternalName",
+                "type": "string"
+              },
+              {
+                "name": "TargetProcessFilename",
+                "type": "string"
+              },
+              {
+                "name": "TargetProcessFileOriginalName",
+                "type": "string"
+              },
+              {
+                "name": "TargetProcessFileProduct",
+                "type": "string"
+              },
+              {
+                "name": "TargetProcessFileSize",
+                "type": "long"
+              },
+              {
+                "name": "TargetProcessFileVersion",
+                "type": "string"
+              },
+              {
+                "name": "TargetProcessGuid",
+                "type": "string"
+              },
+              {
+                "name": "TargetProcessId",
+                "type": "string"
+              },
+              {
+                "name": "TargetProcessIMPHASH",
+                "type": "string"
+              },
+              {
+                "name": "TargetProcessInjectedAddress",
+                "type": "string"
+              },
+              {
+                "name": "TargetProcessIntegrityLevel",
+                "type": "string"
+              },
+              {
+                "name": "TargetProcessIsHidden",
+                "type": "boolean"
+              },
+              {
+                "name": "TargetProcessMD5",
+                "type": "string"
+              },
+              {
+                "name": "TargetProcessName",
+                "type": "string"
+              },
+              {
+                "name": "TargetProcessSHA1",
+                "type": "string"
+              },
+              {
+                "name": "TargetProcessSHA256",
+                "type": "string"
+              },
+              {
+                "name": "TargetProcessSHA512",
+                "type": "string"
+              },
+              {
+                "name": "TargetProcessStatusCode",
+                "type": "string"
+              },
+              {
+                "name": "TargetProcessTokenElevation",
+                "type": "string"
+              },
+              {
+                "name": "TargetScope",
+                "type": "string"
+              },
+              {
+                "name": "TargetScopeId",
+                "type": "string"
+              },
+              {
+                "name": "TargetUserId",
+                "type": "string"
+              },
+              {
+                "name": "TargetUserIdType",
+                "type": "string"
+              },
+              {
+                "name": "TargetUsername",
+                "type": "string"
+              },
+              {
+                "name": "TargetUsernameType",
+                "type": "string"
+              },
+              {
+                "name": "TargetUserSessionGuid",
+                "type": "string"
+              },
+              {
+                "name": "TargetUserSessionId",
+                "type": "string"
+              },
+              {
+                "name": "TargetUserType",
+                "type": "string"
+              },
+              {
+                "name": "ThreatCategory",
+                "type": "string"
+              },
+              {
+                "name": "ThreatConfidence",
+                "type": "int"
+              },
+              {
+                "name": "ThreatField",
+                "type": "string"
+              },
+              {
+                "name": "ThreatFirstReportedTime",
+                "type": "datetime"
+              },
+              {
+                "name": "ThreatId",
+                "type": "string"
+              },
+              {
+                "name": "ThreatIsActive",
+                "type": "boolean"
+              },
+              {
+                "name": "ThreatLastReportedTime",
+                "type": "datetime"
+              },
+              {
+                "name": "ThreatName",
+                "type": "string"
+              },
+              {
+                "name": "ThreatOriginalConfidence",
+                "type": "string"
+              },
+              {
+                "name": "ThreatOriginalRiskLevel",
+                "type": "string"
+              },
+              {
+                "name": "ThreatRiskLevel",
+                "type": "int"
+              },
+              {
+                "name": "TimeGenerated",
+                "type": "datetime"
+              }
+            ]
+          }
+        },
+        "destinations": {
+          "logAnalytics": [
+            {
+              "workspaceResourceId": "[parameters('workspaceResourceId')]",
+              "name": "logAnalyticsWorkspace"
+            }
+          ]
+        },
+        "dataFlows": [
+          {
+            "streams": [
+              "Custom-ASimProcessEventLogs"
+            ],
+            "destinations": [
+              "logAnalyticsWorkspace"
+            ],
+            "transformKql": "source",
+            "outputStream": "Microsoft-ASimProcessEventLogs"
+          }
+        ],
+        "dataCollectionEndpointId": "[parameters('endpointResourceId')]"
+      }
+    }
+  ],
+  "outputs": {
+    "dataCollectionRuleId": {
+      "type": "string",
+      "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+    }
+  }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/ASimRegistryEventLogs.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/ASimRegistryEventLogs.json
@@ -1,0 +1,398 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "dataCollectionRuleName": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the name of the Data Collection Rule to create."
+      }
+    },
+    "location": {
+      "defaultValue": "[resourceGroup().location]",
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the location in which to create the Data Collection Rule."
+      }
+    },
+    "workspaceResourceId": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+      }
+    },
+    "endpointResourceId": {
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Data Collection Endpoint to use."
+      },
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Insights/dataCollectionRules",
+      "apiVersion": "2023-03-11",
+      "name": "[parameters('dataCollectionRuleName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "streamDeclarations": {
+          "Custom-ASimRegistryEventLogs": {
+            "columns": [
+              {
+                "name": "ActingProcessCommandLine",
+                "type": "string"
+              },
+              {
+                "name": "ActingProcessGuid",
+                "type": "string"
+              },
+              {
+                "name": "ActingProcessId",
+                "type": "string"
+              },
+              {
+                "name": "ActingProcessName",
+                "type": "string"
+              },
+              {
+                "name": "ActorOriginalUserType",
+                "type": "string"
+              },
+              {
+                "name": "ActorScope",
+                "type": "string"
+              },
+              {
+                "name": "ActorScopeId",
+                "type": "string"
+              },
+              {
+                "name": "ActorSessionId",
+                "type": "string"
+              },
+              {
+                "name": "ActorUserAadId",
+                "type": "string"
+              },
+              {
+                "name": "ActorUserId",
+                "type": "string"
+              },
+              {
+                "name": "ActorUserIdType",
+                "type": "string"
+              },
+              {
+                "name": "ActorUsername",
+                "type": "string"
+              },
+              {
+                "name": "ActorUsernameType",
+                "type": "string"
+              },
+              {
+                "name": "ActorUserSid",
+                "type": "string"
+              },
+              {
+                "name": "ActorUserType",
+                "type": "string"
+              },
+              {
+                "name": "AdditionalFields",
+                "type": "dynamic"
+              },
+              {
+                "name": "DvcAction",
+                "type": "string"
+              },
+              {
+                "name": "DvcDescription",
+                "type": "string"
+              },
+              {
+                "name": "DvcDomain",
+                "type": "string"
+              },
+              {
+                "name": "DvcDomainType",
+                "type": "string"
+              },
+              {
+                "name": "DvcFQDN",
+                "type": "string"
+              },
+              {
+                "name": "DvcHostname",
+                "type": "string"
+              },
+              {
+                "name": "DvcId",
+                "type": "string"
+              },
+              {
+                "name": "DvcIdType",
+                "type": "string"
+              },
+              {
+                "name": "DvcInterface",
+                "type": "string"
+              },
+              {
+                "name": "DvcIpAddr",
+                "type": "string"
+              },
+              {
+                "name": "DvcMacAddr",
+                "type": "string"
+              },
+              {
+                "name": "DvcOriginalAction",
+                "type": "string"
+              },
+              {
+                "name": "DvcOs",
+                "type": "string"
+              },
+              {
+                "name": "DvcOsVersion",
+                "type": "string"
+              },
+              {
+                "name": "DvcScope",
+                "type": "string"
+              },
+              {
+                "name": "DvcScopeId",
+                "type": "string"
+              },
+              {
+                "name": "DvcZone",
+                "type": "string"
+              },
+              {
+                "name": "EventCount",
+                "type": "int"
+              },
+              {
+                "name": "EventEndTime",
+                "type": "datetime"
+              },
+              {
+                "name": "EventMessage",
+                "type": "string"
+              },
+              {
+                "name": "EventOriginalResultDetails",
+                "type": "string"
+              },
+              {
+                "name": "EventOriginalSeverity",
+                "type": "string"
+              },
+              {
+                "name": "EventOriginalSubType",
+                "type": "string"
+              },
+              {
+                "name": "EventOriginalType",
+                "type": "string"
+              },
+              {
+                "name": "EventOriginalUid",
+                "type": "string"
+              },
+              {
+                "name": "EventOwner",
+                "type": "string"
+              },
+              {
+                "name": "EventProduct",
+                "type": "string"
+              },
+              {
+                "name": "EventProductVersion",
+                "type": "string"
+              },
+              {
+                "name": "EventReportUrl",
+                "type": "string"
+              },
+              {
+                "name": "EventResult",
+                "type": "string"
+              },
+              {
+                "name": "EventResultDetails",
+                "type": "string"
+              },
+              {
+                "name": "EventSchema",
+                "type": "string"
+              },
+              {
+                "name": "EventSchemaVersion",
+                "type": "string"
+              },
+              {
+                "name": "EventSeverity",
+                "type": "string"
+              },
+              {
+                "name": "EventStartTime",
+                "type": "datetime"
+              },
+              {
+                "name": "EventSubType",
+                "type": "string"
+              },
+              {
+                "name": "EventType",
+                "type": "string"
+              },
+              {
+                "name": "EventVendor",
+                "type": "string"
+              },
+              {
+                "name": "ParentProcessCommandLine",
+                "type": "string"
+              },
+              {
+                "name": "ParentProcessGuid",
+                "type": "string"
+              },
+              {
+                "name": "ParentProcessId",
+                "type": "string"
+              },
+              {
+                "name": "ParentProcessName",
+                "type": "string"
+              },
+              {
+                "name": "RegistryKey",
+                "type": "string"
+              },
+              {
+                "name": "RegistryPreviousKey",
+                "type": "string"
+              },
+              {
+                "name": "RegistryPreviousValue",
+                "type": "string"
+              },
+              {
+                "name": "RegistryPreviousValueData",
+                "type": "string"
+              },
+              {
+                "name": "RegistryPreviousValueType",
+                "type": "string"
+              },
+              {
+                "name": "RegistryValue",
+                "type": "string"
+              },
+              {
+                "name": "RegistryValueData",
+                "type": "string"
+              },
+              {
+                "name": "RegistryValueType",
+                "type": "string"
+              },
+              {
+                "name": "RuleName",
+                "type": "string"
+              },
+              {
+                "name": "RuleNumber",
+                "type": "int"
+              },
+              {
+                "name": "SourceSystem",
+                "type": "string"
+              },
+              {
+                "name": "ThreatCategory",
+                "type": "string"
+              },
+              {
+                "name": "ThreatConfidence",
+                "type": "int"
+              },
+              {
+                "name": "ThreatField",
+                "type": "string"
+              },
+              {
+                "name": "ThreatFirstReportedTime",
+                "type": "datetime"
+              },
+              {
+                "name": "ThreatId",
+                "type": "string"
+              },
+              {
+                "name": "ThreatIsActive",
+                "type": "boolean"
+              },
+              {
+                "name": "ThreatLastReportedTime",
+                "type": "datetime"
+              },
+              {
+                "name": "ThreatName",
+                "type": "string"
+              },
+              {
+                "name": "ThreatOriginalConfidence",
+                "type": "string"
+              },
+              {
+                "name": "ThreatOriginalRiskLevel",
+                "type": "string"
+              },
+              {
+                "name": "ThreatRiskLevel",
+                "type": "int"
+              },
+              {
+                "name": "TimeGenerated",
+                "type": "datetime"
+              }
+            ]
+          }
+        },
+        "destinations": {
+          "logAnalytics": [
+            {
+              "workspaceResourceId": "[parameters('workspaceResourceId')]",
+              "name": "logAnalyticsWorkspace"
+            }
+          ]
+        },
+        "dataFlows": [
+          {
+            "streams": [
+              "Custom-ASimRegistryEventLogs"
+            ],
+            "destinations": [
+              "logAnalyticsWorkspace"
+            ],
+            "transformKql": "source",
+            "outputStream": "Microsoft-ASimRegistryEventLogs"
+          }
+        ],
+        "dataCollectionEndpointId": "[parameters('endpointResourceId')]"
+      }
+    }
+  ],
+  "outputs": {
+    "dataCollectionRuleId": {
+      "type": "string",
+      "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+    }
+  }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/ASimUserManagementActivityLogs.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/ASimUserManagementActivityLogs.json
@@ -1,0 +1,506 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "dataCollectionRuleName": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the name of the Data Collection Rule to create."
+      }
+    },
+    "location": {
+      "defaultValue": "[resourceGroup().location]",
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the location in which to create the Data Collection Rule."
+      }
+    },
+    "workspaceResourceId": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+      }
+    },
+    "endpointResourceId": {
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Data Collection Endpoint to use."
+      },
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Insights/dataCollectionRules",
+      "apiVersion": "2023-03-11",
+      "name": "[parameters('dataCollectionRuleName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "streamDeclarations": {
+          "Custom-ASimUserManagementActivityLogs": {
+            "columns": [
+              {
+                "name": "ActingAppId",
+                "type": "string"
+              },
+              {
+                "name": "ActingAppName",
+                "type": "string"
+              },
+              {
+                "name": "ActingAppType",
+                "type": "string"
+              },
+              {
+                "name": "ActingOriginalAppType",
+                "type": "string"
+              },
+              {
+                "name": "ActorOriginalUserType",
+                "type": "string"
+              },
+              {
+                "name": "ActorScope",
+                "type": "string"
+              },
+              {
+                "name": "ActorScopeId",
+                "type": "string"
+              },
+              {
+                "name": "ActorSessionId",
+                "type": "string"
+              },
+              {
+                "name": "ActorUserAadId",
+                "type": "string"
+              },
+              {
+                "name": "ActorUserId",
+                "type": "string"
+              },
+              {
+                "name": "ActorUserIdType",
+                "type": "string"
+              },
+              {
+                "name": "ActorUsername",
+                "type": "string"
+              },
+              {
+                "name": "ActorUsernameType",
+                "type": "string"
+              },
+              {
+                "name": "ActorUserSid",
+                "type": "string"
+              },
+              {
+                "name": "ActorUserType",
+                "type": "string"
+              },
+              {
+                "name": "AdditionalFields",
+                "type": "dynamic"
+              },
+              {
+                "name": "DvcAction",
+                "type": "string"
+              },
+              {
+                "name": "DvcDescription",
+                "type": "string"
+              },
+              {
+                "name": "DvcDomain",
+                "type": "string"
+              },
+              {
+                "name": "DvcDomainType",
+                "type": "string"
+              },
+              {
+                "name": "DvcFQDN",
+                "type": "string"
+              },
+              {
+                "name": "DvcHostname",
+                "type": "string"
+              },
+              {
+                "name": "DvcId",
+                "type": "string"
+              },
+              {
+                "name": "DvcIdType",
+                "type": "string"
+              },
+              {
+                "name": "DvcInterface",
+                "type": "string"
+              },
+              {
+                "name": "DvcIpAddr",
+                "type": "string"
+              },
+              {
+                "name": "DvcMacAddr",
+                "type": "string"
+              },
+              {
+                "name": "DvcOriginalAction",
+                "type": "string"
+              },
+              {
+                "name": "DvcOs",
+                "type": "string"
+              },
+              {
+                "name": "DvcOsVersion",
+                "type": "string"
+              },
+              {
+                "name": "DvcScope",
+                "type": "string"
+              },
+              {
+                "name": "DvcScopeId",
+                "type": "string"
+              },
+              {
+                "name": "DvcZone",
+                "type": "string"
+              },
+              {
+                "name": "EventCount",
+                "type": "int"
+              },
+              {
+                "name": "EventEndTime",
+                "type": "datetime"
+              },
+              {
+                "name": "EventMessage",
+                "type": "string"
+              },
+              {
+                "name": "EventOriginalResultDetails",
+                "type": "string"
+              },
+              {
+                "name": "EventOriginalSeverity",
+                "type": "string"
+              },
+              {
+                "name": "EventOriginalSubType",
+                "type": "string"
+              },
+              {
+                "name": "EventOriginalType",
+                "type": "string"
+              },
+              {
+                "name": "EventOriginalUid",
+                "type": "string"
+              },
+              {
+                "name": "EventOwner",
+                "type": "string"
+              },
+              {
+                "name": "EventProduct",
+                "type": "string"
+              },
+              {
+                "name": "EventProductVersion",
+                "type": "string"
+              },
+              {
+                "name": "EventReportUrl",
+                "type": "string"
+              },
+              {
+                "name": "EventResult",
+                "type": "string"
+              },
+              {
+                "name": "EventResultDetails",
+                "type": "string"
+              },
+              {
+                "name": "EventSchema",
+                "type": "string"
+              },
+              {
+                "name": "EventSchemaVersion",
+                "type": "string"
+              },
+              {
+                "name": "EventSeverity",
+                "type": "string"
+              },
+              {
+                "name": "EventStartTime",
+                "type": "datetime"
+              },
+              {
+                "name": "EventSubType",
+                "type": "string"
+              },
+              {
+                "name": "EventType",
+                "type": "string"
+              },
+              {
+                "name": "EventVendor",
+                "type": "string"
+              },
+              {
+                "name": "GroupId",
+                "type": "string"
+              },
+              {
+                "name": "GroupIdType",
+                "type": "string"
+              },
+              {
+                "name": "GroupName",
+                "type": "string"
+              },
+              {
+                "name": "GroupNameType",
+                "type": "string"
+              },
+              {
+                "name": "GroupOriginalType",
+                "type": "string"
+              },
+              {
+                "name": "GroupType",
+                "type": "string"
+              },
+              {
+                "name": "HttpUserAgent",
+                "type": "string"
+              },
+              {
+                "name": "NewPropertyValue",
+                "type": "string"
+              },
+              {
+                "name": "PreviousPropertyValue",
+                "type": "string"
+              },
+              {
+                "name": "RuleName",
+                "type": "string"
+              },
+              {
+                "name": "RuleNumber",
+                "type": "int"
+              },
+              {
+                "name": "SourceSystem",
+                "type": "string"
+              },
+              {
+                "name": "SrcDescription",
+                "type": "string"
+              },
+              {
+                "name": "SrcDeviceType",
+                "type": "string"
+              },
+              {
+                "name": "SrcDomain",
+                "type": "string"
+              },
+              {
+                "name": "SrcDomainType",
+                "type": "string"
+              },
+              {
+                "name": "SrcDvcId",
+                "type": "string"
+              },
+              {
+                "name": "SrcDvcIdType",
+                "type": "string"
+              },
+              {
+                "name": "SrcDvcScope",
+                "type": "string"
+              },
+              {
+                "name": "SrcDvcScopeId",
+                "type": "string"
+              },
+              {
+                "name": "SrcFQDN",
+                "type": "string"
+              },
+              {
+                "name": "SrcGeoCity",
+                "type": "string"
+              },
+              {
+                "name": "SrcGeoCountry",
+                "type": "string"
+              },
+              {
+                "name": "SrcGeoLatitude",
+                "type": "real"
+              },
+              {
+                "name": "SrcGeoLongitude",
+                "type": "real"
+              },
+              {
+                "name": "SrcGeoRegion",
+                "type": "string"
+              },
+              {
+                "name": "SrcHostname",
+                "type": "string"
+              },
+              {
+                "name": "SrcIpAddr",
+                "type": "string"
+              },
+              {
+                "name": "SrcMacAddr",
+                "type": "string"
+              },
+              {
+                "name": "SrcOriginalRiskLevel",
+                "type": "string"
+              },
+              {
+                "name": "SrcPortNumber",
+                "type": "int"
+              },
+              {
+                "name": "SrcRiskLevel",
+                "type": "int"
+              },
+              {
+                "name": "TargetOriginalUserType",
+                "type": "string"
+              },
+              {
+                "name": "TargetUserId",
+                "type": "string"
+              },
+              {
+                "name": "TargetUserIdType",
+                "type": "string"
+              },
+              {
+                "name": "TargetUsername",
+                "type": "string"
+              },
+              {
+                "name": "TargetUsernameType",
+                "type": "string"
+              },
+              {
+                "name": "TargetUserScope",
+                "type": "string"
+              },
+              {
+                "name": "TargetUserScopeId",
+                "type": "string"
+              },
+              {
+                "name": "TargetUserSessionId",
+                "type": "string"
+              },
+              {
+                "name": "TargetUserType",
+                "type": "string"
+              },
+              {
+                "name": "TargetUserUid",
+                "type": "string"
+              },
+              {
+                "name": "ThreatCategory",
+                "type": "string"
+              },
+              {
+                "name": "ThreatConfidence",
+                "type": "int"
+              },
+              {
+                "name": "ThreatField",
+                "type": "string"
+              },
+              {
+                "name": "ThreatFirstReportedTime",
+                "type": "datetime"
+              },
+              {
+                "name": "ThreatId",
+                "type": "string"
+              },
+              {
+                "name": "ThreatIsActive",
+                "type": "boolean"
+              },
+              {
+                "name": "ThreatLastReportedTime",
+                "type": "datetime"
+              },
+              {
+                "name": "ThreatName",
+                "type": "string"
+              },
+              {
+                "name": "ThreatOriginalConfidence",
+                "type": "string"
+              },
+              {
+                "name": "ThreatOriginalRiskLevel",
+                "type": "string"
+              },
+              {
+                "name": "ThreatRiskLevel",
+                "type": "int"
+              },
+              {
+                "name": "TimeGenerated",
+                "type": "datetime"
+              }
+            ]
+          }
+        },
+        "destinations": {
+          "logAnalytics": [
+            {
+              "workspaceResourceId": "[parameters('workspaceResourceId')]",
+              "name": "logAnalyticsWorkspace"
+            }
+          ]
+        },
+        "dataFlows": [
+          {
+            "streams": [
+              "Custom-ASimUserManagementActivityLogs"
+            ],
+            "destinations": [
+              "logAnalyticsWorkspace"
+            ],
+            "transformKql": "source",
+            "outputStream": "Microsoft-ASimUserManagementActivityLogs"
+          }
+        ],
+        "dataCollectionEndpointId": "[parameters('endpointResourceId')]"
+      }
+    }
+  ],
+  "outputs": {
+    "dataCollectionRuleId": {
+      "type": "string",
+      "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+    }
+  }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/ASimWebSessionLogs.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/ASimWebSessionLogs.json
@@ -1,0 +1,650 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "dataCollectionRuleName": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the name of the Data Collection Rule to create."
+      }
+    },
+    "location": {
+      "defaultValue": "[resourceGroup().location]",
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the location in which to create the Data Collection Rule."
+      }
+    },
+    "workspaceResourceId": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+      }
+    },
+    "endpointResourceId": {
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Data Collection Endpoint to use."
+      },
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Insights/dataCollectionRules",
+      "apiVersion": "2023-03-11",
+      "name": "[parameters('dataCollectionRuleName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "streamDeclarations": {
+          "Custom-ASimWebSessionLogs": {
+            "columns": [
+              {
+                "name": "AdditionalFields",
+                "type": "dynamic"
+              },
+              {
+                "name": "DstAppId",
+                "type": "string"
+              },
+              {
+                "name": "DstAppName",
+                "type": "string"
+              },
+              {
+                "name": "DstAppType",
+                "type": "string"
+              },
+              {
+                "name": "DstBytes",
+                "type": "long"
+              },
+              {
+                "name": "DstDeviceType",
+                "type": "string"
+              },
+              {
+                "name": "DstDomain",
+                "type": "string"
+              },
+              {
+                "name": "DstDomainType",
+                "type": "string"
+              },
+              {
+                "name": "DstDvcId",
+                "type": "string"
+              },
+              {
+                "name": "DstDvcIdType",
+                "type": "string"
+              },
+              {
+                "name": "DstDvcScope",
+                "type": "string"
+              },
+              {
+                "name": "DstDvcScopeId",
+                "type": "string"
+              },
+              {
+                "name": "DstFQDN",
+                "type": "string"
+              },
+              {
+                "name": "DstGeoCity",
+                "type": "string"
+              },
+              {
+                "name": "DstGeoCountry",
+                "type": "string"
+              },
+              {
+                "name": "DstGeoLatitude",
+                "type": "real"
+              },
+              {
+                "name": "DstGeoLongitude",
+                "type": "real"
+              },
+              {
+                "name": "DstGeoRegion",
+                "type": "string"
+              },
+              {
+                "name": "DstHostname",
+                "type": "string"
+              },
+              {
+                "name": "DstIpAddr",
+                "type": "string"
+              },
+              {
+                "name": "DstMacAddr",
+                "type": "string"
+              },
+              {
+                "name": "DstNatIpAddr",
+                "type": "string"
+              },
+              {
+                "name": "DstNatPortNumber",
+                "type": "int"
+              },
+              {
+                "name": "DstOriginalUserType",
+                "type": "string"
+              },
+              {
+                "name": "DstPackets",
+                "type": "long"
+              },
+              {
+                "name": "DstPortNumber",
+                "type": "int"
+              },
+              {
+                "name": "DstUserId",
+                "type": "string"
+              },
+              {
+                "name": "DstUserIdType",
+                "type": "string"
+              },
+              {
+                "name": "DstUsername",
+                "type": "string"
+              },
+              {
+                "name": "DstUsernameType",
+                "type": "string"
+              },
+              {
+                "name": "DstUserType",
+                "type": "string"
+              },
+              {
+                "name": "Dvc",
+                "type": "string"
+              },
+              {
+                "name": "DvcAction",
+                "type": "string"
+              },
+              {
+                "name": "DvcDomain",
+                "type": "string"
+              },
+              {
+                "name": "DvcDomainType",
+                "type": "string"
+              },
+              {
+                "name": "DvcFQDN",
+                "type": "string"
+              },
+              {
+                "name": "DvcHostname",
+                "type": "string"
+              },
+              {
+                "name": "DvcId",
+                "type": "string"
+              },
+              {
+                "name": "DvcIdType",
+                "type": "string"
+              },
+              {
+                "name": "DvcIpAddr",
+                "type": "string"
+              },
+              {
+                "name": "DvcOriginalAction",
+                "type": "string"
+              },
+              {
+                "name": "EventCount",
+                "type": "int"
+              },
+              {
+                "name": "EventEndTime",
+                "type": "datetime"
+              },
+              {
+                "name": "EventMessage",
+                "type": "string"
+              },
+              {
+                "name": "EventOriginalResultDetails",
+                "type": "string"
+              },
+              {
+                "name": "EventOriginalSeverity",
+                "type": "string"
+              },
+              {
+                "name": "EventOriginalSubType",
+                "type": "string"
+              },
+              {
+                "name": "EventOriginalType",
+                "type": "string"
+              },
+              {
+                "name": "EventOriginalUid",
+                "type": "string"
+              },
+              {
+                "name": "EventOwner",
+                "type": "string"
+              },
+              {
+                "name": "EventProduct",
+                "type": "string"
+              },
+              {
+                "name": "EventProductVersion",
+                "type": "string"
+              },
+              {
+                "name": "EventReportUrl",
+                "type": "string"
+              },
+              {
+                "name": "EventResult",
+                "type": "string"
+              },
+              {
+                "name": "EventResultDetails",
+                "type": "string"
+              },
+              {
+                "name": "EventSchemaVersion",
+                "type": "string"
+              },
+              {
+                "name": "EventSeverity",
+                "type": "string"
+              },
+              {
+                "name": "EventStartTime",
+                "type": "datetime"
+              },
+              {
+                "name": "EventSubType",
+                "type": "string"
+              },
+              {
+                "name": "EventType",
+                "type": "string"
+              },
+              {
+                "name": "EventVendor",
+                "type": "string"
+              },
+              {
+                "name": "FileContentType",
+                "type": "string"
+              },
+              {
+                "name": "FileMD5",
+                "type": "string"
+              },
+              {
+                "name": "FileName",
+                "type": "string"
+              },
+              {
+                "name": "FileSHA1",
+                "type": "string"
+              },
+              {
+                "name": "FileSHA256",
+                "type": "string"
+              },
+              {
+                "name": "FileSHA512",
+                "type": "string"
+              },
+              {
+                "name": "FileSize",
+                "type": "int"
+              },
+              {
+                "name": "HttpContentFormat",
+                "type": "string"
+              },
+              {
+                "name": "HttpContentType",
+                "type": "string"
+              },
+              {
+                "name": "HttpHost",
+                "type": "string"
+              },
+              {
+                "name": "HttpReferrer",
+                "type": "string"
+              },
+              {
+                "name": "HttpRequestMethod",
+                "type": "string"
+              },
+              {
+                "name": "HttpRequestTime",
+                "type": "int"
+              },
+              {
+                "name": "HttpRequestXff",
+                "type": "string"
+              },
+              {
+                "name": "HttpResponseTime",
+                "type": "int"
+              },
+              {
+                "name": "HttpUserAgent",
+                "type": "string"
+              },
+              {
+                "name": "HttpVersion",
+                "type": "string"
+              },
+              {
+                "name": "NetworkApplicationProtocol",
+                "type": "string"
+              },
+              {
+                "name": "NetworkBytes",
+                "type": "long"
+              },
+              {
+                "name": "NetworkConnectionHistory",
+                "type": "string"
+              },
+              {
+                "name": "NetworkDirection",
+                "type": "string"
+              },
+              {
+                "name": "NetworkDuration",
+                "type": "int"
+              },
+              {
+                "name": "NetworkIcmpCode",
+                "type": "int"
+              },
+              {
+                "name": "NetworkIcmpType",
+                "type": "string"
+              },
+              {
+                "name": "NetworkPackets",
+                "type": "long"
+              },
+              {
+                "name": "NetworkProtocol",
+                "type": "string"
+              },
+              {
+                "name": "NetworkProtocolVersion",
+                "type": "string"
+              },
+              {
+                "name": "NetworkSessionId",
+                "type": "string"
+              },
+              {
+                "name": "Rule",
+                "type": "string"
+              },
+              {
+                "name": "RuleName",
+                "type": "string"
+              },
+              {
+                "name": "RuleNumber",
+                "type": "int"
+              },
+              {
+                "name": "SourceSystem",
+                "type": "string"
+              },
+              {
+                "name": "SrcAppId",
+                "type": "string"
+              },
+              {
+                "name": "SrcAppName",
+                "type": "string"
+              },
+              {
+                "name": "SrcAppType",
+                "type": "string"
+              },
+              {
+                "name": "SrcBytes",
+                "type": "long"
+              },
+              {
+                "name": "SrcDeviceType",
+                "type": "string"
+              },
+              {
+                "name": "SrcDomain",
+                "type": "string"
+              },
+              {
+                "name": "SrcDomainType",
+                "type": "string"
+              },
+              {
+                "name": "SrcDvcId",
+                "type": "string"
+              },
+              {
+                "name": "SrcDvcIdType",
+                "type": "string"
+              },
+              {
+                "name": "SrcDvcScope",
+                "type": "string"
+              },
+              {
+                "name": "SrcDvcScopeId",
+                "type": "string"
+              },
+              {
+                "name": "SrcFQDN",
+                "type": "string"
+              },
+              {
+                "name": "SrcGeoCity",
+                "type": "string"
+              },
+              {
+                "name": "SrcGeoCountry",
+                "type": "string"
+              },
+              {
+                "name": "SrcGeoLatitude",
+                "type": "real"
+              },
+              {
+                "name": "SrcGeoLongitude",
+                "type": "real"
+              },
+              {
+                "name": "SrcGeoRegion",
+                "type": "string"
+              },
+              {
+                "name": "SrcHostname",
+                "type": "string"
+              },
+              {
+                "name": "SrcIpAddr",
+                "type": "string"
+              },
+              {
+                "name": "SrcMacAddr",
+                "type": "string"
+              },
+              {
+                "name": "SrcNatIpAddr",
+                "type": "string"
+              },
+              {
+                "name": "SrcNatPortNumber",
+                "type": "int"
+              },
+              {
+                "name": "SrcOriginalUserType",
+                "type": "string"
+              },
+              {
+                "name": "SrcPackets",
+                "type": "long"
+              },
+              {
+                "name": "SrcPortNumber",
+                "type": "int"
+              },
+              {
+                "name": "SrcProcessGuid",
+                "type": "string"
+              },
+              {
+                "name": "SrcProcessId",
+                "type": "string"
+              },
+              {
+                "name": "SrcProcessName",
+                "type": "string"
+              },
+              {
+                "name": "SrcUserId",
+                "type": "string"
+              },
+              {
+                "name": "SrcUserIdType",
+                "type": "string"
+              },
+              {
+                "name": "SrcUsername",
+                "type": "string"
+              },
+              {
+                "name": "SrcUsernameType",
+                "type": "string"
+              },
+              {
+                "name": "SrcUserScope",
+                "type": "string"
+              },
+              {
+                "name": "SrcUserScopeId",
+                "type": "string"
+              },
+              {
+                "name": "SrcUserType",
+                "type": "string"
+              },
+              {
+                "name": "ThreatCategory",
+                "type": "string"
+              },
+              {
+                "name": "ThreatConfidence",
+                "type": "int"
+              },
+              {
+                "name": "ThreatField",
+                "type": "string"
+              },
+              {
+                "name": "ThreatFirstReportedTime",
+                "type": "datetime"
+              },
+              {
+                "name": "ThreatId",
+                "type": "string"
+              },
+              {
+                "name": "ThreatIpAddr",
+                "type": "string"
+              },
+              {
+                "name": "ThreatIsActive",
+                "type": "boolean"
+              },
+              {
+                "name": "ThreatLastReportedTime",
+                "type": "datetime"
+              },
+              {
+                "name": "ThreatName",
+                "type": "string"
+              },
+              {
+                "name": "ThreatOriginalConfidence",
+                "type": "string"
+              },
+              {
+                "name": "ThreatOriginalRiskLevel",
+                "type": "string"
+              },
+              {
+                "name": "ThreatRiskLevel",
+                "type": "int"
+              },
+              {
+                "name": "TimeGenerated",
+                "type": "datetime"
+              },
+              {
+                "name": "Url",
+                "type": "string"
+              },
+              {
+                "name": "UrlCategory",
+                "type": "string"
+              },
+              {
+                "name": "UrlOriginal",
+                "type": "string"
+              }
+            ]
+          }
+        },
+        "destinations": {
+          "logAnalytics": [
+            {
+              "workspaceResourceId": "[parameters('workspaceResourceId')]",
+              "name": "logAnalyticsWorkspace"
+            }
+          ]
+        },
+        "dataFlows": [
+          {
+            "streams": [
+              "Custom-ASimWebSessionLogs"
+            ],
+            "destinations": [
+              "logAnalyticsWorkspace"
+            ],
+            "transformKql": "source",
+            "outputStream": "Microsoft-ASimWebSessionLogs"
+          }
+        ],
+        "dataCollectionEndpointId": "[parameters('endpointResourceId')]"
+      }
+    }
+  ],
+  "outputs": {
+    "dataCollectionRuleId": {
+      "type": "string",
+      "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+    }
+  }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/AWSCloudTrail.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/AWSCloudTrail.json
@@ -1,0 +1,270 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "dataCollectionRuleName": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the name of the Data Collection Rule to create."
+      }
+    },
+    "location": {
+      "defaultValue": "[resourceGroup().location]",
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the location in which to create the Data Collection Rule."
+      }
+    },
+    "workspaceResourceId": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+      }
+    },
+    "endpointResourceId": {
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Data Collection Endpoint to use."
+      },
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Insights/dataCollectionRules",
+      "apiVersion": "2023-03-11",
+      "name": "[parameters('dataCollectionRuleName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "streamDeclarations": {
+          "Custom-AWSCloudTrail": {
+            "columns": [
+              {
+                "name": "AdditionalEventData",
+                "type": "string"
+              },
+              {
+                "name": "APIVersion",
+                "type": "string"
+              },
+              {
+                "name": "AwsEventId",
+                "type": "guid"
+              },
+              {
+                "name": "AWSRegion",
+                "type": "string"
+              },
+              {
+                "name": "AwsRequestId",
+                "type": "guid"
+              },
+              {
+                "name": "AwsRequestId_",
+                "type": "string"
+              },
+              {
+                "name": "Category",
+                "type": "string"
+              },
+              {
+                "name": "CidrIp",
+                "type": "string"
+              },
+              {
+                "name": "CipherSuite",
+                "type": "string"
+              },
+              {
+                "name": "ClientProvidedHostHeader",
+                "type": "string"
+              },
+              {
+                "name": "DestinationPort",
+                "type": "string"
+              },
+              {
+                "name": "EC2RoleDelivery",
+                "type": "string"
+              },
+              {
+                "name": "ErrorCode",
+                "type": "string"
+              },
+              {
+                "name": "ErrorMessage",
+                "type": "string"
+              },
+              {
+                "name": "EventName",
+                "type": "string"
+              },
+              {
+                "name": "EventSource",
+                "type": "string"
+              },
+              {
+                "name": "EventTypeName",
+                "type": "string"
+              },
+              {
+                "name": "EventVersion",
+                "type": "string"
+              },
+              {
+                "name": "IpProtocol",
+                "type": "string"
+              },
+              {
+                "name": "ManagementEvent",
+                "type": "boolean"
+              },
+              {
+                "name": "OperationName",
+                "type": "string"
+              },
+              {
+                "name": "ReadOnly",
+                "type": "boolean"
+              },
+              {
+                "name": "RecipientAccountId",
+                "type": "string"
+              },
+              {
+                "name": "RequestParameters",
+                "type": "string"
+              },
+              {
+                "name": "Resources",
+                "type": "string"
+              },
+              {
+                "name": "ResponseElements",
+                "type": "string"
+              },
+              {
+                "name": "ServiceEventDetails",
+                "type": "string"
+              },
+              {
+                "name": "SessionCreationDate",
+                "type": "datetime"
+              },
+              {
+                "name": "SessionIssuerAccountId",
+                "type": "string"
+              },
+              {
+                "name": "SessionIssuerArn",
+                "type": "string"
+              },
+              {
+                "name": "SessionIssuerPrincipalId",
+                "type": "string"
+              },
+              {
+                "name": "SessionIssuerType",
+                "type": "string"
+              },
+              {
+                "name": "SessionIssuerUserName",
+                "type": "string"
+              },
+              {
+                "name": "SessionMfaAuthenticated",
+                "type": "boolean"
+              },
+              {
+                "name": "SharedEventId",
+                "type": "guid"
+              },
+              {
+                "name": "SourceIpAddress",
+                "type": "string"
+              },
+              {
+                "name": "SourcePort",
+                "type": "string"
+              },
+              {
+                "name": "SourceSystem",
+                "type": "string"
+              },
+              {
+                "name": "TimeGenerated",
+                "type": "datetime"
+              },
+              {
+                "name": "TlsVersion",
+                "type": "string"
+              },
+              {
+                "name": "UserAgent",
+                "type": "string"
+              },
+              {
+                "name": "UserIdentityAccessKeyId",
+                "type": "string"
+              },
+              {
+                "name": "UserIdentityAccountId",
+                "type": "string"
+              },
+              {
+                "name": "UserIdentityArn",
+                "type": "string"
+              },
+              {
+                "name": "UserIdentityInvokedBy",
+                "type": "string"
+              },
+              {
+                "name": "UserIdentityPrincipalid",
+                "type": "string"
+              },
+              {
+                "name": "UserIdentityType",
+                "type": "string"
+              },
+              {
+                "name": "UserIdentityUserName",
+                "type": "string"
+              },
+              {
+                "name": "VpcEndpointId",
+                "type": "string"
+              }
+            ]
+          }
+        },
+        "destinations": {
+          "logAnalytics": [
+            {
+              "workspaceResourceId": "[parameters('workspaceResourceId')]",
+              "name": "logAnalyticsWorkspace"
+            }
+          ]
+        },
+        "dataFlows": [
+          {
+            "streams": [
+              "Custom-AWSCloudTrail"
+            ],
+            "destinations": [
+              "logAnalyticsWorkspace"
+            ],
+            "transformKql": "source",
+            "outputStream": "Microsoft-AWSCloudTrail"
+          }
+        ],
+        "dataCollectionEndpointId": "[parameters('endpointResourceId')]"
+      }
+    }
+  ],
+  "outputs": {
+    "dataCollectionRuleId": {
+      "type": "string",
+      "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+    }
+  }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/AWSCloudWatch.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/AWSCloudWatch.json
@@ -1,0 +1,90 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "dataCollectionRuleName": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the name of the Data Collection Rule to create."
+      }
+    },
+    "location": {
+      "defaultValue": "[resourceGroup().location]",
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the location in which to create the Data Collection Rule."
+      }
+    },
+    "workspaceResourceId": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+      }
+    },
+    "endpointResourceId": {
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Data Collection Endpoint to use."
+      },
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Insights/dataCollectionRules",
+      "apiVersion": "2023-03-11",
+      "name": "[parameters('dataCollectionRuleName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "streamDeclarations": {
+          "Custom-AWSCloudWatch": {
+            "columns": [
+              {
+                "name": "ExtractedTime",
+                "type": "datetime"
+              },
+              {
+                "name": "Message",
+                "type": "string"
+              },
+              {
+                "name": "SourceSystem",
+                "type": "string"
+              },
+              {
+                "name": "TimeGenerated",
+                "type": "datetime"
+              }
+            ]
+          }
+        },
+        "destinations": {
+          "logAnalytics": [
+            {
+              "workspaceResourceId": "[parameters('workspaceResourceId')]",
+              "name": "logAnalyticsWorkspace"
+            }
+          ]
+        },
+        "dataFlows": [
+          {
+            "streams": [
+              "Custom-AWSCloudWatch"
+            ],
+            "destinations": [
+              "logAnalyticsWorkspace"
+            ],
+            "transformKql": "source",
+            "outputStream": "Microsoft-AWSCloudWatch"
+          }
+        ],
+        "dataCollectionEndpointId": "[parameters('endpointResourceId')]"
+      }
+    }
+  ],
+  "outputs": {
+    "dataCollectionRuleId": {
+      "type": "string",
+      "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+    }
+  }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/AWSGuardDuty.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/AWSGuardDuty.json
@@ -1,0 +1,134 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "dataCollectionRuleName": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the name of the Data Collection Rule to create."
+      }
+    },
+    "location": {
+      "defaultValue": "[resourceGroup().location]",
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the location in which to create the Data Collection Rule."
+      }
+    },
+    "workspaceResourceId": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+      }
+    },
+    "endpointResourceId": {
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Data Collection Endpoint to use."
+      },
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Insights/dataCollectionRules",
+      "apiVersion": "2023-03-11",
+      "name": "[parameters('dataCollectionRuleName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "streamDeclarations": {
+          "Custom-AWSGuardDuty": {
+            "columns": [
+              {
+                "name": "AccountId",
+                "type": "string"
+              },
+              {
+                "name": "ActivityType",
+                "type": "string"
+              },
+              {
+                "name": "Arn",
+                "type": "string"
+              },
+              {
+                "name": "Description",
+                "type": "string"
+              },
+              {
+                "name": "Id",
+                "type": "string"
+              },
+              {
+                "name": "Partition",
+                "type": "string"
+              },
+              {
+                "name": "Region",
+                "type": "string"
+              },
+              {
+                "name": "ResourceDetails",
+                "type": "dynamic"
+              },
+              {
+                "name": "SchemaVersion",
+                "type": "string"
+              },
+              {
+                "name": "ServiceDetails",
+                "type": "dynamic"
+              },
+              {
+                "name": "Severity",
+                "type": "int"
+              },
+              {
+                "name": "SourceSystem",
+                "type": "string"
+              },
+              {
+                "name": "TimeCreated",
+                "type": "datetime"
+              },
+              {
+                "name": "TimeGenerated",
+                "type": "datetime"
+              },
+              {
+                "name": "Title",
+                "type": "string"
+              }
+            ]
+          }
+        },
+        "destinations": {
+          "logAnalytics": [
+            {
+              "workspaceResourceId": "[parameters('workspaceResourceId')]",
+              "name": "logAnalyticsWorkspace"
+            }
+          ]
+        },
+        "dataFlows": [
+          {
+            "streams": [
+              "Custom-AWSGuardDuty"
+            ],
+            "destinations": [
+              "logAnalyticsWorkspace"
+            ],
+            "transformKql": "source",
+            "outputStream": "Microsoft-AWSGuardDuty"
+          }
+        ],
+        "dataCollectionEndpointId": "[parameters('endpointResourceId')]"
+      }
+    }
+  ],
+  "outputs": {
+    "dataCollectionRuleId": {
+      "type": "string",
+      "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+    }
+  }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/AWSVPCFlow.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/AWSVPCFlow.json
@@ -1,0 +1,238 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "dataCollectionRuleName": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the name of the Data Collection Rule to create."
+      }
+    },
+    "location": {
+      "defaultValue": "[resourceGroup().location]",
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the location in which to create the Data Collection Rule."
+      }
+    },
+    "workspaceResourceId": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+      }
+    },
+    "endpointResourceId": {
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Data Collection Endpoint to use."
+      },
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Insights/dataCollectionRules",
+      "apiVersion": "2023-03-11",
+      "name": "[parameters('dataCollectionRuleName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "streamDeclarations": {
+          "Custom-AWSVPCFlow": {
+            "columns": [
+              {
+                "name": "AccountId",
+                "type": "string"
+              },
+              {
+                "name": "Action",
+                "type": "string"
+              },
+              {
+                "name": "AzId",
+                "type": "string"
+              },
+              {
+                "name": "Bytes",
+                "type": "long"
+              },
+              {
+                "name": "DstAddr",
+                "type": "string"
+              },
+              {
+                "name": "DstPort",
+                "type": "int"
+              },
+              {
+                "name": "EcsClusterArn",
+                "type": "string"
+              },
+              {
+                "name": "EcsClusterName",
+                "type": "string"
+              },
+              {
+                "name": "EcsContainerId",
+                "type": "string"
+              },
+              {
+                "name": "EcsContainerInstanceArn",
+                "type": "string"
+              },
+              {
+                "name": "EcsContainerInstanceId",
+                "type": "string"
+              },
+              {
+                "name": "EcsSecondContainerId",
+                "type": "string"
+              },
+              {
+                "name": "EcsServiceName",
+                "type": "string"
+              },
+              {
+                "name": "EcsTaskArn",
+                "type": "string"
+              },
+              {
+                "name": "EcsTaskDefinitionArn",
+                "type": "string"
+              },
+              {
+                "name": "EcsTaskId",
+                "type": "string"
+              },
+              {
+                "name": "End",
+                "type": "datetime"
+              },
+              {
+                "name": "FlowDirection",
+                "type": "string"
+              },
+              {
+                "name": "InstanceId",
+                "type": "string"
+              },
+              {
+                "name": "InterfaceId",
+                "type": "string"
+              },
+              {
+                "name": "LogStatus",
+                "type": "string"
+              },
+              {
+                "name": "Packets",
+                "type": "int"
+              },
+              {
+                "name": "PktDstAddr",
+                "type": "string"
+              },
+              {
+                "name": "PktDstAwsService",
+                "type": "string"
+              },
+              {
+                "name": "PktSrcAddr",
+                "type": "string"
+              },
+              {
+                "name": "PktSrcAwsService",
+                "type": "string"
+              },
+              {
+                "name": "Protocol",
+                "type": "int"
+              },
+              {
+                "name": "Region",
+                "type": "string"
+              },
+              {
+                "name": "SourceSystem",
+                "type": "string"
+              },
+              {
+                "name": "SrcAddr",
+                "type": "string"
+              },
+              {
+                "name": "SrcPort",
+                "type": "int"
+              },
+              {
+                "name": "Start",
+                "type": "datetime"
+              },
+              {
+                "name": "SublocationId",
+                "type": "string"
+              },
+              {
+                "name": "SublocationType",
+                "type": "string"
+              },
+              {
+                "name": "SubnetId",
+                "type": "string"
+              },
+              {
+                "name": "TcpFlags",
+                "type": "int"
+              },
+              {
+                "name": "TimeGenerated",
+                "type": "datetime"
+              },
+              {
+                "name": "TrafficPath",
+                "type": "string"
+              },
+              {
+                "name": "TrafficType",
+                "type": "string"
+              },
+              {
+                "name": "Version",
+                "type": "int"
+              },
+              {
+                "name": "VpcId",
+                "type": "string"
+              }
+            ]
+          }
+        },
+        "destinations": {
+          "logAnalytics": [
+            {
+              "workspaceResourceId": "[parameters('workspaceResourceId')]",
+              "name": "logAnalyticsWorkspace"
+            }
+          ]
+        },
+        "dataFlows": [
+          {
+            "streams": [
+              "Custom-AWSVPCFlow"
+            ],
+            "destinations": [
+              "logAnalyticsWorkspace"
+            ],
+            "transformKql": "source",
+            "outputStream": "Microsoft-AWSVPCFlow"
+          }
+        ],
+        "dataCollectionEndpointId": "[parameters('endpointResourceId')]"
+      }
+    }
+  ],
+  "outputs": {
+    "dataCollectionRuleId": {
+      "type": "string",
+      "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+    }
+  }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/Anomalies.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/Anomalies.json
@@ -1,0 +1,210 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "dataCollectionRuleName": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the name of the Data Collection Rule to create."
+      }
+    },
+    "location": {
+      "defaultValue": "[resourceGroup().location]",
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the location in which to create the Data Collection Rule."
+      }
+    },
+    "workspaceResourceId": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+      }
+    },
+    "endpointResourceId": {
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Data Collection Endpoint to use."
+      },
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Insights/dataCollectionRules",
+      "apiVersion": "2023-03-11",
+      "name": "[parameters('dataCollectionRuleName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "streamDeclarations": {
+          "Custom-Anomalies": {
+            "columns": [
+              {
+                "name": "ActivityInsights",
+                "type": "dynamic"
+              },
+              {
+                "name": "AnomalyDetails",
+                "type": "dynamic"
+              },
+              {
+                "name": "AnomalyReasons",
+                "type": "dynamic"
+              },
+              {
+                "name": "AnomalyTemplateId",
+                "type": "string"
+              },
+              {
+                "name": "AnomalyTemplateName",
+                "type": "string"
+              },
+              {
+                "name": "AnomalyTemplateVersion",
+                "type": "string"
+              },
+              {
+                "name": "Description",
+                "type": "string"
+              },
+              {
+                "name": "DestinationDevice",
+                "type": "string"
+              },
+              {
+                "name": "DestinationIpAddress",
+                "type": "string"
+              },
+              {
+                "name": "DestinationLocation",
+                "type": "dynamic"
+              },
+              {
+                "name": "DeviceInsights",
+                "type": "dynamic"
+              },
+              {
+                "name": "EndTime",
+                "type": "datetime"
+              },
+              {
+                "name": "Entities",
+                "type": "dynamic"
+              },
+              {
+                "name": "ExtendedLinks",
+                "type": "dynamic"
+              },
+              {
+                "name": "ExtendedProperties",
+                "type": "dynamic"
+              },
+              {
+                "name": "Id",
+                "type": "string"
+              },
+              {
+                "name": "RuleConfigVersion",
+                "type": "string"
+              },
+              {
+                "name": "RuleId",
+                "type": "string"
+              },
+              {
+                "name": "RuleName",
+                "type": "string"
+              },
+              {
+                "name": "RuleStatus",
+                "type": "string"
+              },
+              {
+                "name": "Score",
+                "type": "real"
+              },
+              {
+                "name": "SourceDevice",
+                "type": "string"
+              },
+              {
+                "name": "SourceIpAddress",
+                "type": "string"
+              },
+              {
+                "name": "SourceLocation",
+                "type": "dynamic"
+              },
+              {
+                "name": "SourceSystem",
+                "type": "string"
+              },
+              {
+                "name": "StartTime",
+                "type": "datetime"
+              },
+              {
+                "name": "Tactics",
+                "type": "string"
+              },
+              {
+                "name": "Techniques",
+                "type": "string"
+              },
+              {
+                "name": "TimeGenerated",
+                "type": "datetime"
+              },
+              {
+                "name": "UserInsights",
+                "type": "dynamic"
+              },
+              {
+                "name": "UserName",
+                "type": "string"
+              },
+              {
+                "name": "UserPrincipalName",
+                "type": "string"
+              },
+              {
+                "name": "VendorName",
+                "type": "string"
+              },
+              {
+                "name": "WorkspaceId",
+                "type": "string"
+              }
+            ]
+          }
+        },
+        "destinations": {
+          "logAnalytics": [
+            {
+              "workspaceResourceId": "[parameters('workspaceResourceId')]",
+              "name": "logAnalyticsWorkspace"
+            }
+          ]
+        },
+        "dataFlows": [
+          {
+            "streams": [
+              "Custom-Anomalies"
+            ],
+            "destinations": [
+              "logAnalyticsWorkspace"
+            ],
+            "transformKql": "source",
+            "outputStream": "Microsoft-Anomalies"
+          }
+        ],
+        "dataCollectionEndpointId": "[parameters('endpointResourceId')]"
+      }
+    }
+  ],
+  "outputs": {
+    "dataCollectionRuleId": {
+      "type": "string",
+      "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+    }
+  }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/AzureActivity.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/AzureActivity.json
@@ -1,0 +1,198 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "dataCollectionRuleName": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the name of the Data Collection Rule to create."
+      }
+    },
+    "location": {
+      "defaultValue": "[resourceGroup().location]",
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the location in which to create the Data Collection Rule."
+      }
+    },
+    "workspaceResourceId": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+      }
+    },
+    "endpointResourceId": {
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Data Collection Endpoint to use."
+      },
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Insights/dataCollectionRules",
+      "apiVersion": "2023-03-11",
+      "name": "[parameters('dataCollectionRuleName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "streamDeclarations": {
+          "Custom-AzureActivity": {
+            "columns": [
+              {
+                "name": "ActivityStatus",
+                "type": "string"
+              },
+              {
+                "name": "ActivityStatusValue",
+                "type": "string"
+              },
+              {
+                "name": "ActivitySubstatus",
+                "type": "string"
+              },
+              {
+                "name": "ActivitySubstatusValue",
+                "type": "string"
+              },
+              {
+                "name": "Authorization",
+                "type": "string"
+              },
+              {
+                "name": "Authorization_d",
+                "type": "dynamic"
+              },
+              {
+                "name": "Caller",
+                "type": "string"
+              },
+              {
+                "name": "CallerIpAddress",
+                "type": "string"
+              },
+              {
+                "name": "Category",
+                "type": "string"
+              },
+              {
+                "name": "CategoryValue",
+                "type": "string"
+              },
+              {
+                "name": "Claims",
+                "type": "string"
+              },
+              {
+                "name": "Claims_d",
+                "type": "dynamic"
+              },
+              {
+                "name": "CorrelationId",
+                "type": "string"
+              },
+              {
+                "name": "EventDataId",
+                "type": "string"
+              },
+              {
+                "name": "EventSubmissionTimestamp",
+                "type": "datetime"
+              },
+              {
+                "name": "Hierarchy",
+                "type": "string"
+              },
+              {
+                "name": "HTTPRequest",
+                "type": "string"
+              },
+              {
+                "name": "Level",
+                "type": "string"
+              },
+              {
+                "name": "OperationId",
+                "type": "string"
+              },
+              {
+                "name": "OperationName",
+                "type": "string"
+              },
+              {
+                "name": "OperationNameValue",
+                "type": "string"
+              },
+              {
+                "name": "Properties",
+                "type": "string"
+              },
+              {
+                "name": "Properties_d",
+                "type": "dynamic"
+              },
+              {
+                "name": "Resource",
+                "type": "string"
+              },
+              {
+                "name": "ResourceGroup",
+                "type": "string"
+              },
+              {
+                "name": "ResourceId",
+                "type": "string"
+              },
+              {
+                "name": "ResourceProvider",
+                "type": "string"
+              },
+              {
+                "name": "ResourceProviderValue",
+                "type": "string"
+              },
+              {
+                "name": "SourceSystem",
+                "type": "string"
+              },
+              {
+                "name": "SubscriptionId",
+                "type": "string"
+              },
+              {
+                "name": "TimeGenerated",
+                "type": "datetime"
+              }
+            ]
+          }
+        },
+        "destinations": {
+          "logAnalytics": [
+            {
+              "workspaceResourceId": "[parameters('workspaceResourceId')]",
+              "name": "logAnalyticsWorkspace"
+            }
+          ]
+        },
+        "dataFlows": [
+          {
+            "streams": [
+              "Custom-AzureActivity"
+            ],
+            "destinations": [
+              "logAnalyticsWorkspace"
+            ],
+            "transformKql": "source",
+            "outputStream": "Microsoft-AzureActivity"
+          }
+        ],
+        "dataCollectionEndpointId": "[parameters('endpointResourceId')]"
+      }
+    }
+  ],
+  "outputs": {
+    "dataCollectionRuleId": {
+      "type": "string",
+      "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+    }
+  }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/AzureAssessmentRecommendation.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/AzureAssessmentRecommendation.json
@@ -1,0 +1,158 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "dataCollectionRuleName": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the name of the Data Collection Rule to create."
+      }
+    },
+    "location": {
+      "defaultValue": "[resourceGroup().location]",
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the location in which to create the Data Collection Rule."
+      }
+    },
+    "workspaceResourceId": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+      }
+    },
+    "endpointResourceId": {
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Data Collection Endpoint to use."
+      },
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Insights/dataCollectionRules",
+      "apiVersion": "2023-03-11",
+      "name": "[parameters('dataCollectionRuleName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "streamDeclarations": {
+          "Custom-AzureAssessmentRecommendation": {
+            "columns": [
+              {
+                "name": "AADTenantDomain",
+                "type": "string"
+              },
+              {
+                "name": "AADTenantId",
+                "type": "string"
+              },
+              {
+                "name": "AADTenantName",
+                "type": "string"
+              },
+              {
+                "name": "ActionArea",
+                "type": "string"
+              },
+              {
+                "name": "ActionAreaId",
+                "type": "string"
+              },
+              {
+                "name": "AffectedObjectName",
+                "type": "string"
+              },
+              {
+                "name": "AffectedObjectType",
+                "type": "string"
+              },
+              {
+                "name": "AssessmentId",
+                "type": "string"
+              },
+              {
+                "name": "Computer",
+                "type": "string"
+              },
+              {
+                "name": "CustomData",
+                "type": "string"
+              },
+              {
+                "name": "Description",
+                "type": "string"
+              },
+              {
+                "name": "FocusArea",
+                "type": "string"
+              },
+              {
+                "name": "FocusAreaId",
+                "type": "string"
+              },
+              {
+                "name": "Recommendation",
+                "type": "string"
+              },
+              {
+                "name": "RecommendationId",
+                "type": "string"
+              },
+              {
+                "name": "RecommendationResult",
+                "type": "string"
+              },
+              {
+                "name": "RecommendationWeight",
+                "type": "real"
+              },
+              {
+                "name": "Resource",
+                "type": "string"
+              },
+              {
+                "name": "SourceSystem",
+                "type": "string"
+              },
+              {
+                "name": "Technology",
+                "type": "string"
+              },
+              {
+                "name": "TimeGenerated",
+                "type": "datetime"
+              }
+            ]
+          }
+        },
+        "destinations": {
+          "logAnalytics": [
+            {
+              "workspaceResourceId": "[parameters('workspaceResourceId')]",
+              "name": "logAnalyticsWorkspace"
+            }
+          ]
+        },
+        "dataFlows": [
+          {
+            "streams": [
+              "Custom-AzureAssessmentRecommendation"
+            ],
+            "destinations": [
+              "logAnalyticsWorkspace"
+            ],
+            "transformKql": "source",
+            "outputStream": "Microsoft-AzureAssessmentRecommendation"
+          }
+        ],
+        "dataCollectionEndpointId": "[parameters('endpointResourceId')]"
+      }
+    }
+  ],
+  "outputs": {
+    "dataCollectionRuleId": {
+      "type": "string",
+      "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+    }
+  }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/AzureDiagnostics.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/AzureDiagnostics.json
@@ -1,0 +1,162 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "dataCollectionRuleName": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the name of the Data Collection Rule to create."
+      }
+    },
+    "location": {
+      "defaultValue": "[resourceGroup().location]",
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the location in which to create the Data Collection Rule."
+      }
+    },
+    "workspaceResourceId": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+      }
+    },
+    "endpointResourceId": {
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Data Collection Endpoint to use."
+      },
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Insights/dataCollectionRules",
+      "apiVersion": "2023-03-11",
+      "name": "[parameters('dataCollectionRuleName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "streamDeclarations": {
+          "Custom-AzureDiagnostics": {
+            "columns": [
+              {
+                "name": "AdditionalFields",
+                "type": "dynamic"
+              },
+              {
+                "name": "CallerIPAddress",
+                "type": "string"
+              },
+              {
+                "name": "Category",
+                "type": "string"
+              },
+              {
+                "name": "CorrelationId",
+                "type": "string"
+              },
+              {
+                "name": "DurationMs",
+                "type": "long"
+              },
+              {
+                "name": "Level",
+                "type": "string"
+              },
+              {
+                "name": "Location",
+                "type": "string"
+              },
+              {
+                "name": "Message",
+                "type": "string"
+              },
+              {
+                "name": "OperationName",
+                "type": "string"
+              },
+              {
+                "name": "OperationVersion",
+                "type": "string"
+              },
+              {
+                "name": "Resource",
+                "type": "string"
+              },
+              {
+                "name": "ResourceGroup",
+                "type": "string"
+              },
+              {
+                "name": "ResourceProvider",
+                "type": "string"
+              },
+              {
+                "name": "ResourceType",
+                "type": "string"
+              },
+              {
+                "name": "ResultDescription",
+                "type": "string"
+              },
+              {
+                "name": "ResultSignature",
+                "type": "string"
+              },
+              {
+                "name": "ResultType",
+                "type": "string"
+              },
+              {
+                "name": "SourceSystem",
+                "type": "string"
+              },
+              {
+                "name": "SubscriptionId",
+                "type": "string"
+              },
+              {
+                "name": "TimeGenerated",
+                "type": "datetime"
+              },
+              {
+                "name": "TenantId",
+                "type": "string"
+              },
+              {
+                "name": "Type",
+                "type": "string"
+              }
+            ]
+          }
+        },
+        "destinations": {
+          "logAnalytics": [
+            {
+              "workspaceResourceId": "[parameters('workspaceResourceId')]",
+              "name": "logAnalyticsWorkspace"
+            }
+          ]
+        },
+        "dataFlows": [
+          {
+            "streams": [
+              "Custom-AzureDiagnostics"
+            ],
+            "destinations": [
+              "logAnalyticsWorkspace"
+            ],
+            "transformKql": "source",
+            "outputStream": "Microsoft-AzureDiagnostics"
+          }
+        ],
+        "dataCollectionEndpointId": "[parameters('endpointResourceId')]"
+      }
+    }
+  ],
+  "outputs": {
+    "dataCollectionRuleId": {
+      "type": "string",
+      "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+    }
+  }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/CommonSecurityLog.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/CommonSecurityLog.json
@@ -1,0 +1,702 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "dataCollectionRuleName": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the name of the Data Collection Rule to create."
+      }
+    },
+    "location": {
+      "defaultValue": "[resourceGroup().location]",
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the location in which to create the Data Collection Rule."
+      }
+    },
+    "workspaceResourceId": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+      }
+    },
+    "endpointResourceId": {
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Data Collection Endpoint to use."
+      },
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Insights/dataCollectionRules",
+      "apiVersion": "2023-03-11",
+      "name": "[parameters('dataCollectionRuleName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "streamDeclarations": {
+          "Custom-CommonSecurityLog": {
+            "columns": [
+              {
+                "name": "Activity",
+                "type": "string"
+              },
+              {
+                "name": "AdditionalExtensions",
+                "type": "string"
+              },
+              {
+                "name": "ApplicationProtocol",
+                "type": "string"
+              },
+              {
+                "name": "CollectorHostName",
+                "type": "string"
+              },
+              {
+                "name": "CommunicationDirection",
+                "type": "string"
+              },
+              {
+                "name": "Computer",
+                "type": "string"
+              },
+              {
+                "name": "DestinationDnsDomain",
+                "type": "string"
+              },
+              {
+                "name": "DestinationHostName",
+                "type": "string"
+              },
+              {
+                "name": "DestinationIP",
+                "type": "string"
+              },
+              {
+                "name": "DestinationMACAddress",
+                "type": "string"
+              },
+              {
+                "name": "DestinationNTDomain",
+                "type": "string"
+              },
+              {
+                "name": "DestinationPort",
+                "type": "int"
+              },
+              {
+                "name": "DestinationProcessId",
+                "type": "int"
+              },
+              {
+                "name": "DestinationProcessName",
+                "type": "string"
+              },
+              {
+                "name": "DestinationServiceName",
+                "type": "string"
+              },
+              {
+                "name": "DestinationTranslatedAddress",
+                "type": "string"
+              },
+              {
+                "name": "DestinationTranslatedPort",
+                "type": "int"
+              },
+              {
+                "name": "DestinationUserID",
+                "type": "string"
+              },
+              {
+                "name": "DestinationUserName",
+                "type": "string"
+              },
+              {
+                "name": "DestinationUserPrivileges",
+                "type": "string"
+              },
+              {
+                "name": "DeviceAction",
+                "type": "string"
+              },
+              {
+                "name": "DeviceAddress",
+                "type": "string"
+              },
+              {
+                "name": "DeviceCustomDate1",
+                "type": "string"
+              },
+              {
+                "name": "DeviceCustomDate1Label",
+                "type": "string"
+              },
+              {
+                "name": "DeviceCustomDate2",
+                "type": "string"
+              },
+              {
+                "name": "DeviceCustomDate2Label",
+                "type": "string"
+              },
+              {
+                "name": "DeviceCustomFloatingPoint1",
+                "type": "real"
+              },
+              {
+                "name": "DeviceCustomFloatingPoint1Label",
+                "type": "string"
+              },
+              {
+                "name": "DeviceCustomFloatingPoint2",
+                "type": "real"
+              },
+              {
+                "name": "DeviceCustomFloatingPoint2Label",
+                "type": "string"
+              },
+              {
+                "name": "DeviceCustomFloatingPoint3",
+                "type": "real"
+              },
+              {
+                "name": "DeviceCustomFloatingPoint3Label",
+                "type": "string"
+              },
+              {
+                "name": "DeviceCustomFloatingPoint4",
+                "type": "real"
+              },
+              {
+                "name": "DeviceCustomFloatingPoint4Label",
+                "type": "string"
+              },
+              {
+                "name": "DeviceCustomIPv6Address1",
+                "type": "string"
+              },
+              {
+                "name": "DeviceCustomIPv6Address1Label",
+                "type": "string"
+              },
+              {
+                "name": "DeviceCustomIPv6Address2",
+                "type": "string"
+              },
+              {
+                "name": "DeviceCustomIPv6Address2Label",
+                "type": "string"
+              },
+              {
+                "name": "DeviceCustomIPv6Address3",
+                "type": "string"
+              },
+              {
+                "name": "DeviceCustomIPv6Address3Label",
+                "type": "string"
+              },
+              {
+                "name": "DeviceCustomIPv6Address4",
+                "type": "string"
+              },
+              {
+                "name": "DeviceCustomIPv6Address4Label",
+                "type": "string"
+              },
+              {
+                "name": "DeviceCustomNumber1",
+                "type": "int"
+              },
+              {
+                "name": "DeviceCustomNumber1Label",
+                "type": "string"
+              },
+              {
+                "name": "DeviceCustomNumber2",
+                "type": "int"
+              },
+              {
+                "name": "DeviceCustomNumber2Label",
+                "type": "string"
+              },
+              {
+                "name": "DeviceCustomNumber3",
+                "type": "int"
+              },
+              {
+                "name": "DeviceCustomNumber3Label",
+                "type": "string"
+              },
+              {
+                "name": "DeviceCustomString1",
+                "type": "string"
+              },
+              {
+                "name": "DeviceCustomString1Label",
+                "type": "string"
+              },
+              {
+                "name": "DeviceCustomString2",
+                "type": "string"
+              },
+              {
+                "name": "DeviceCustomString2Label",
+                "type": "string"
+              },
+              {
+                "name": "DeviceCustomString3",
+                "type": "string"
+              },
+              {
+                "name": "DeviceCustomString3Label",
+                "type": "string"
+              },
+              {
+                "name": "DeviceCustomString4",
+                "type": "string"
+              },
+              {
+                "name": "DeviceCustomString4Label",
+                "type": "string"
+              },
+              {
+                "name": "DeviceCustomString5",
+                "type": "string"
+              },
+              {
+                "name": "DeviceCustomString5Label",
+                "type": "string"
+              },
+              {
+                "name": "DeviceCustomString6",
+                "type": "string"
+              },
+              {
+                "name": "DeviceCustomString6Label",
+                "type": "string"
+              },
+              {
+                "name": "DeviceDnsDomain",
+                "type": "string"
+              },
+              {
+                "name": "DeviceEventCategory",
+                "type": "string"
+              },
+              {
+                "name": "DeviceEventClassID",
+                "type": "string"
+              },
+              {
+                "name": "DeviceExternalID",
+                "type": "string"
+              },
+              {
+                "name": "DeviceFacility",
+                "type": "string"
+              },
+              {
+                "name": "DeviceInboundInterface",
+                "type": "string"
+              },
+              {
+                "name": "DeviceMacAddress",
+                "type": "string"
+              },
+              {
+                "name": "DeviceName",
+                "type": "string"
+              },
+              {
+                "name": "DeviceNtDomain",
+                "type": "string"
+              },
+              {
+                "name": "DeviceOutboundInterface",
+                "type": "string"
+              },
+              {
+                "name": "DevicePayloadId",
+                "type": "string"
+              },
+              {
+                "name": "DeviceProduct",
+                "type": "string"
+              },
+              {
+                "name": "DeviceTimeZone",
+                "type": "string"
+              },
+              {
+                "name": "DeviceTranslatedAddress",
+                "type": "string"
+              },
+              {
+                "name": "DeviceVendor",
+                "type": "string"
+              },
+              {
+                "name": "DeviceVersion",
+                "type": "string"
+              },
+              {
+                "name": "EndTime",
+                "type": "datetime"
+              },
+              {
+                "name": "EventCount",
+                "type": "int"
+              },
+              {
+                "name": "EventOutcome",
+                "type": "string"
+              },
+              {
+                "name": "EventType",
+                "type": "int"
+              },
+              {
+                "name": "ExternalID",
+                "type": "int"
+              },
+              {
+                "name": "ExtID",
+                "type": "string"
+              },
+              {
+                "name": "FieldDeviceCustomNumber1",
+                "type": "long"
+              },
+              {
+                "name": "FieldDeviceCustomNumber2",
+                "type": "long"
+              },
+              {
+                "name": "FieldDeviceCustomNumber3",
+                "type": "long"
+              },
+              {
+                "name": "FileCreateTime",
+                "type": "string"
+              },
+              {
+                "name": "FileHash",
+                "type": "string"
+              },
+              {
+                "name": "FileID",
+                "type": "string"
+              },
+              {
+                "name": "FileModificationTime",
+                "type": "string"
+              },
+              {
+                "name": "FileName",
+                "type": "string"
+              },
+              {
+                "name": "FilePath",
+                "type": "string"
+              },
+              {
+                "name": "FilePermission",
+                "type": "string"
+              },
+              {
+                "name": "FileSize",
+                "type": "int"
+              },
+              {
+                "name": "FileType",
+                "type": "string"
+              },
+              {
+                "name": "FlexDate1",
+                "type": "string"
+              },
+              {
+                "name": "FlexDate1Label",
+                "type": "string"
+              },
+              {
+                "name": "FlexNumber1",
+                "type": "int"
+              },
+              {
+                "name": "FlexNumber1Label",
+                "type": "string"
+              },
+              {
+                "name": "FlexNumber2",
+                "type": "int"
+              },
+              {
+                "name": "FlexNumber2Label",
+                "type": "string"
+              },
+              {
+                "name": "FlexString1",
+                "type": "string"
+              },
+              {
+                "name": "FlexString1Label",
+                "type": "string"
+              },
+              {
+                "name": "FlexString2",
+                "type": "string"
+              },
+              {
+                "name": "FlexString2Label",
+                "type": "string"
+              },
+              {
+                "name": "IndicatorThreatType",
+                "type": "string"
+              },
+              {
+                "name": "LogSeverity",
+                "type": "string"
+              },
+              {
+                "name": "MaliciousIP",
+                "type": "string"
+              },
+              {
+                "name": "MaliciousIPCountry",
+                "type": "string"
+              },
+              {
+                "name": "MaliciousIPLatitude",
+                "type": "real"
+              },
+              {
+                "name": "MaliciousIPLongitude",
+                "type": "real"
+              },
+              {
+                "name": "Message",
+                "type": "string"
+              },
+              {
+                "name": "OldFileCreateTime",
+                "type": "string"
+              },
+              {
+                "name": "OldFileHash",
+                "type": "string"
+              },
+              {
+                "name": "OldFileID",
+                "type": "string"
+              },
+              {
+                "name": "OldFileModificationTime",
+                "type": "string"
+              },
+              {
+                "name": "OldFileName",
+                "type": "string"
+              },
+              {
+                "name": "OldFilePath",
+                "type": "string"
+              },
+              {
+                "name": "OldFilePermission",
+                "type": "string"
+              },
+              {
+                "name": "OldFileSize",
+                "type": "int"
+              },
+              {
+                "name": "OldFileType",
+                "type": "string"
+              },
+              {
+                "name": "OriginalLogSeverity",
+                "type": "string"
+              },
+              {
+                "name": "ProcessID",
+                "type": "int"
+              },
+              {
+                "name": "ProcessName",
+                "type": "string"
+              },
+              {
+                "name": "Protocol",
+                "type": "string"
+              },
+              {
+                "name": "Reason",
+                "type": "string"
+              },
+              {
+                "name": "ReceiptTime",
+                "type": "string"
+              },
+              {
+                "name": "ReceivedBytes",
+                "type": "long"
+              },
+              {
+                "name": "RemoteIP",
+                "type": "string"
+              },
+              {
+                "name": "RemotePort",
+                "type": "string"
+              },
+              {
+                "name": "ReportReferenceLink",
+                "type": "string"
+              },
+              {
+                "name": "RequestClientApplication",
+                "type": "string"
+              },
+              {
+                "name": "RequestContext",
+                "type": "string"
+              },
+              {
+                "name": "RequestCookies",
+                "type": "string"
+              },
+              {
+                "name": "RequestMethod",
+                "type": "string"
+              },
+              {
+                "name": "RequestURL",
+                "type": "string"
+              },
+              {
+                "name": "SentBytes",
+                "type": "long"
+              },
+              {
+                "name": "SimplifiedDeviceAction",
+                "type": "string"
+              },
+              {
+                "name": "SourceDnsDomain",
+                "type": "string"
+              },
+              {
+                "name": "SourceHostName",
+                "type": "string"
+              },
+              {
+                "name": "SourceIP",
+                "type": "string"
+              },
+              {
+                "name": "SourceMACAddress",
+                "type": "string"
+              },
+              {
+                "name": "SourceNTDomain",
+                "type": "string"
+              },
+              {
+                "name": "SourcePort",
+                "type": "int"
+              },
+              {
+                "name": "SourceProcessId",
+                "type": "int"
+              },
+              {
+                "name": "SourceProcessName",
+                "type": "string"
+              },
+              {
+                "name": "SourceServiceName",
+                "type": "string"
+              },
+              {
+                "name": "SourceSystem",
+                "type": "string"
+              },
+              {
+                "name": "SourceTranslatedAddress",
+                "type": "string"
+              },
+              {
+                "name": "SourceTranslatedPort",
+                "type": "int"
+              },
+              {
+                "name": "SourceUserID",
+                "type": "string"
+              },
+              {
+                "name": "SourceUserName",
+                "type": "string"
+              },
+              {
+                "name": "SourceUserPrivileges",
+                "type": "string"
+              },
+              {
+                "name": "StartTime",
+                "type": "datetime"
+              },
+              {
+                "name": "ThreatConfidence",
+                "type": "string"
+              },
+              {
+                "name": "ThreatDescription",
+                "type": "string"
+              },
+              {
+                "name": "ThreatSeverity",
+                "type": "int"
+              },
+              {
+                "name": "TimeGenerated",
+                "type": "datetime"
+              }
+            ]
+          }
+        },
+        "destinations": {
+          "logAnalytics": [
+            {
+              "workspaceResourceId": "[parameters('workspaceResourceId')]",
+              "name": "logAnalyticsWorkspace"
+            }
+          ]
+        },
+        "dataFlows": [
+          {
+            "streams": [
+              "Custom-CommonSecurityLog"
+            ],
+            "destinations": [
+              "logAnalyticsWorkspace"
+            ],
+            "transformKql": "source",
+            "outputStream": "Microsoft-CommonSecurityLog"
+          }
+        ],
+        "dataCollectionEndpointId": "[parameters('endpointResourceId')]"
+      }
+    }
+  ],
+  "outputs": {
+    "dataCollectionRuleId": {
+      "type": "string",
+      "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+    }
+  }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/DeviceEvents.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/DeviceEvents.json
@@ -1,0 +1,342 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "dataCollectionRuleName": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the name of the Data Collection Rule to create."
+      }
+    },
+    "location": {
+      "defaultValue": "[resourceGroup().location]",
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the location in which to create the Data Collection Rule."
+      }
+    },
+    "workspaceResourceId": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+      }
+    },
+    "endpointResourceId": {
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Data Collection Endpoint to use."
+      },
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Insights/dataCollectionRules",
+      "apiVersion": "2023-03-11",
+      "name": "[parameters('dataCollectionRuleName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "streamDeclarations": {
+          "Custom-DeviceEvents": {
+            "columns": [
+              {
+                "name": "AccountDomain",
+                "type": "string"
+              },
+              {
+                "name": "AccountName",
+                "type": "string"
+              },
+              {
+                "name": "AccountSid",
+                "type": "string"
+              },
+              {
+                "name": "ActionType",
+                "type": "string"
+              },
+              {
+                "name": "AdditionalFields",
+                "type": "dynamic"
+              },
+              {
+                "name": "AppGuardContainerId",
+                "type": "string"
+              },
+              {
+                "name": "CreatedProcessSessionId",
+                "type": "long"
+              },
+              {
+                "name": "DeviceId",
+                "type": "string"
+              },
+              {
+                "name": "DeviceName",
+                "type": "string"
+              },
+              {
+                "name": "FileName",
+                "type": "string"
+              },
+              {
+                "name": "FileOriginIP",
+                "type": "string"
+              },
+              {
+                "name": "FileOriginUrl",
+                "type": "string"
+              },
+              {
+                "name": "FileSize",
+                "type": "long"
+              },
+              {
+                "name": "FolderPath",
+                "type": "string"
+              },
+              {
+                "name": "InitiatingProcessAccountDomain",
+                "type": "string"
+              },
+              {
+                "name": "InitiatingProcessAccountName",
+                "type": "string"
+              },
+              {
+                "name": "InitiatingProcessAccountObjectId",
+                "type": "string"
+              },
+              {
+                "name": "InitiatingProcessAccountSid",
+                "type": "string"
+              },
+              {
+                "name": "InitiatingProcessAccountUpn",
+                "type": "string"
+              },
+              {
+                "name": "InitiatingProcessCommandLine",
+                "type": "string"
+              },
+              {
+                "name": "InitiatingProcessCreationTime",
+                "type": "datetime"
+              },
+              {
+                "name": "InitiatingProcessFileName",
+                "type": "string"
+              },
+              {
+                "name": "InitiatingProcessFileSize",
+                "type": "long"
+              },
+              {
+                "name": "InitiatingProcessFolderPath",
+                "type": "string"
+              },
+              {
+                "name": "InitiatingProcessId",
+                "type": "long"
+              },
+              {
+                "name": "InitiatingProcessLogonId",
+                "type": "long"
+              },
+              {
+                "name": "InitiatingProcessMD5",
+                "type": "string"
+              },
+              {
+                "name": "InitiatingProcessParentCreationTime",
+                "type": "datetime"
+              },
+              {
+                "name": "InitiatingProcessParentFileName",
+                "type": "string"
+              },
+              {
+                "name": "InitiatingProcessParentId",
+                "type": "long"
+              },
+              {
+                "name": "InitiatingProcessRemoteSessionDeviceName",
+                "type": "string"
+              },
+              {
+                "name": "InitiatingProcessRemoteSessionIP",
+                "type": "string"
+              },
+              {
+                "name": "InitiatingProcessSessionId",
+                "type": "long"
+              },
+              {
+                "name": "InitiatingProcessSHA1",
+                "type": "string"
+              },
+              {
+                "name": "InitiatingProcessSHA256",
+                "type": "string"
+              },
+              {
+                "name": "InitiatingProcessUniqueId",
+                "type": "string"
+              },
+              {
+                "name": "InitiatingProcessVersionInfoCompanyName",
+                "type": "string"
+              },
+              {
+                "name": "InitiatingProcessVersionInfoFileDescription",
+                "type": "string"
+              },
+              {
+                "name": "InitiatingProcessVersionInfoInternalFileName",
+                "type": "string"
+              },
+              {
+                "name": "InitiatingProcessVersionInfoOriginalFileName",
+                "type": "string"
+              },
+              {
+                "name": "InitiatingProcessVersionInfoProductName",
+                "type": "string"
+              },
+              {
+                "name": "InitiatingProcessVersionInfoProductVersion",
+                "type": "string"
+              },
+              {
+                "name": "IsInitiatingProcessRemoteSession",
+                "type": "boolean"
+              },
+              {
+                "name": "IsProcessRemoteSession",
+                "type": "boolean"
+              },
+              {
+                "name": "LocalIP",
+                "type": "string"
+              },
+              {
+                "name": "LocalPort",
+                "type": "int"
+              },
+              {
+                "name": "LogonId",
+                "type": "long"
+              },
+              {
+                "name": "MachineGroup",
+                "type": "string"
+              },
+              {
+                "name": "MD5",
+                "type": "string"
+              },
+              {
+                "name": "ProcessCommandLine",
+                "type": "string"
+              },
+              {
+                "name": "ProcessCreationTime",
+                "type": "datetime"
+              },
+              {
+                "name": "ProcessId",
+                "type": "long"
+              },
+              {
+                "name": "ProcessRemoteSessionDeviceName",
+                "type": "string"
+              },
+              {
+                "name": "ProcessRemoteSessionIP",
+                "type": "string"
+              },
+              {
+                "name": "ProcessTokenElevation",
+                "type": "string"
+              },
+              {
+                "name": "RegistryKey",
+                "type": "string"
+              },
+              {
+                "name": "RegistryValueData",
+                "type": "string"
+              },
+              {
+                "name": "RegistryValueName",
+                "type": "string"
+              },
+              {
+                "name": "RemoteDeviceName",
+                "type": "string"
+              },
+              {
+                "name": "RemoteIP",
+                "type": "string"
+              },
+              {
+                "name": "RemotePort",
+                "type": "int"
+              },
+              {
+                "name": "RemoteUrl",
+                "type": "string"
+              },
+              {
+                "name": "ReportId",
+                "type": "long"
+              },
+              {
+                "name": "SHA1",
+                "type": "string"
+              },
+              {
+                "name": "SHA256",
+                "type": "string"
+              },
+              {
+                "name": "SourceSystem",
+                "type": "string"
+              },
+              {
+                "name": "TimeGenerated",
+                "type": "datetime"
+              }
+            ]
+          }
+        },
+        "destinations": {
+          "logAnalytics": [
+            {
+              "workspaceResourceId": "[parameters('workspaceResourceId')]",
+              "name": "logAnalyticsWorkspace"
+            }
+          ]
+        },
+        "dataFlows": [
+          {
+            "streams": [
+              "Custom-DeviceEvents"
+            ],
+            "destinations": [
+              "logAnalyticsWorkspace"
+            ],
+            "transformKql": "source",
+            "outputStream": "Microsoft-DeviceEvents"
+          }
+        ],
+        "dataCollectionEndpointId": "[parameters('endpointResourceId')]"
+      }
+    }
+  ],
+  "outputs": {
+    "dataCollectionRuleId": {
+      "type": "string",
+      "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+    }
+  }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/DeviceFileEvents.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/DeviceFileEvents.json
@@ -1,0 +1,314 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "dataCollectionRuleName": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the name of the Data Collection Rule to create."
+      }
+    },
+    "location": {
+      "defaultValue": "[resourceGroup().location]",
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the location in which to create the Data Collection Rule."
+      }
+    },
+    "workspaceResourceId": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+      }
+    },
+    "endpointResourceId": {
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Data Collection Endpoint to use."
+      },
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Insights/dataCollectionRules",
+      "apiVersion": "2023-03-11",
+      "name": "[parameters('dataCollectionRuleName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "streamDeclarations": {
+          "Custom-DeviceFileEvents": {
+            "columns": [
+              {
+                "name": "ActionType",
+                "type": "string"
+              },
+              {
+                "name": "AdditionalFields",
+                "type": "dynamic"
+              },
+              {
+                "name": "AppGuardContainerId",
+                "type": "string"
+              },
+              {
+                "name": "DeviceId",
+                "type": "string"
+              },
+              {
+                "name": "DeviceName",
+                "type": "string"
+              },
+              {
+                "name": "FileName",
+                "type": "string"
+              },
+              {
+                "name": "FileOriginIP",
+                "type": "string"
+              },
+              {
+                "name": "FileOriginReferrerUrl",
+                "type": "string"
+              },
+              {
+                "name": "FileOriginUrl",
+                "type": "string"
+              },
+              {
+                "name": "FileSize",
+                "type": "long"
+              },
+              {
+                "name": "FolderPath",
+                "type": "string"
+              },
+              {
+                "name": "InitiatingProcessAccountDomain",
+                "type": "string"
+              },
+              {
+                "name": "InitiatingProcessAccountName",
+                "type": "string"
+              },
+              {
+                "name": "InitiatingProcessAccountObjectId",
+                "type": "string"
+              },
+              {
+                "name": "InitiatingProcessAccountSid",
+                "type": "string"
+              },
+              {
+                "name": "InitiatingProcessAccountUpn",
+                "type": "string"
+              },
+              {
+                "name": "InitiatingProcessCommandLine",
+                "type": "string"
+              },
+              {
+                "name": "InitiatingProcessCreationTime",
+                "type": "datetime"
+              },
+              {
+                "name": "InitiatingProcessFileName",
+                "type": "string"
+              },
+              {
+                "name": "InitiatingProcessFileSize",
+                "type": "long"
+              },
+              {
+                "name": "InitiatingProcessFolderPath",
+                "type": "string"
+              },
+              {
+                "name": "InitiatingProcessId",
+                "type": "long"
+              },
+              {
+                "name": "InitiatingProcessIntegrityLevel",
+                "type": "string"
+              },
+              {
+                "name": "InitiatingProcessMD5",
+                "type": "string"
+              },
+              {
+                "name": "InitiatingProcessParentCreationTime",
+                "type": "datetime"
+              },
+              {
+                "name": "InitiatingProcessParentFileName",
+                "type": "string"
+              },
+              {
+                "name": "InitiatingProcessParentId",
+                "type": "long"
+              },
+              {
+                "name": "InitiatingProcessRemoteSessionDeviceName",
+                "type": "string"
+              },
+              {
+                "name": "InitiatingProcessRemoteSessionIP",
+                "type": "string"
+              },
+              {
+                "name": "InitiatingProcessSessionId",
+                "type": "long"
+              },
+              {
+                "name": "InitiatingProcessSHA1",
+                "type": "string"
+              },
+              {
+                "name": "InitiatingProcessSHA256",
+                "type": "string"
+              },
+              {
+                "name": "InitiatingProcessTokenElevation",
+                "type": "string"
+              },
+              {
+                "name": "InitiatingProcessUniqueId",
+                "type": "string"
+              },
+              {
+                "name": "InitiatingProcessVersionInfoCompanyName",
+                "type": "string"
+              },
+              {
+                "name": "InitiatingProcessVersionInfoFileDescription",
+                "type": "string"
+              },
+              {
+                "name": "InitiatingProcessVersionInfoInternalFileName",
+                "type": "string"
+              },
+              {
+                "name": "InitiatingProcessVersionInfoOriginalFileName",
+                "type": "string"
+              },
+              {
+                "name": "InitiatingProcessVersionInfoProductName",
+                "type": "string"
+              },
+              {
+                "name": "InitiatingProcessVersionInfoProductVersion",
+                "type": "string"
+              },
+              {
+                "name": "IsAzureInfoProtectionApplied",
+                "type": "boolean"
+              },
+              {
+                "name": "IsInitiatingProcessRemoteSession",
+                "type": "boolean"
+              },
+              {
+                "name": "MachineGroup",
+                "type": "string"
+              },
+              {
+                "name": "MD5",
+                "type": "string"
+              },
+              {
+                "name": "PreviousFileName",
+                "type": "string"
+              },
+              {
+                "name": "PreviousFolderPath",
+                "type": "string"
+              },
+              {
+                "name": "ReportId",
+                "type": "long"
+              },
+              {
+                "name": "RequestAccountDomain",
+                "type": "string"
+              },
+              {
+                "name": "RequestAccountName",
+                "type": "string"
+              },
+              {
+                "name": "RequestAccountSid",
+                "type": "string"
+              },
+              {
+                "name": "RequestProtocol",
+                "type": "string"
+              },
+              {
+                "name": "RequestSourceIP",
+                "type": "string"
+              },
+              {
+                "name": "RequestSourcePort",
+                "type": "int"
+              },
+              {
+                "name": "SensitivityLabel",
+                "type": "string"
+              },
+              {
+                "name": "SensitivitySubLabel",
+                "type": "string"
+              },
+              {
+                "name": "SHA1",
+                "type": "string"
+              },
+              {
+                "name": "SHA256",
+                "type": "string"
+              },
+              {
+                "name": "ShareName",
+                "type": "string"
+              },
+              {
+                "name": "SourceSystem",
+                "type": "string"
+              },
+              {
+                "name": "TimeGenerated",
+                "type": "datetime"
+              }
+            ]
+          }
+        },
+        "destinations": {
+          "logAnalytics": [
+            {
+              "workspaceResourceId": "[parameters('workspaceResourceId')]",
+              "name": "logAnalyticsWorkspace"
+            }
+          ]
+        },
+        "dataFlows": [
+          {
+            "streams": [
+              "Custom-DeviceFileEvents"
+            ],
+            "destinations": [
+              "logAnalyticsWorkspace"
+            ],
+            "transformKql": "source",
+            "outputStream": "Microsoft-DeviceFileEvents"
+          }
+        ],
+        "dataCollectionEndpointId": "[parameters('endpointResourceId')]"
+      }
+    }
+  ],
+  "outputs": {
+    "dataCollectionRuleId": {
+      "type": "string",
+      "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+    }
+  }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/DeviceTvmSecureConfigurationAssessmentKB.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/DeviceTvmSecureConfigurationAssessmentKB.json
@@ -1,0 +1,118 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "dataCollectionRuleName": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the name of the Data Collection Rule to create."
+      }
+    },
+    "location": {
+      "defaultValue": "[resourceGroup().location]",
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the location in which to create the Data Collection Rule."
+      }
+    },
+    "workspaceResourceId": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+      }
+    },
+    "endpointResourceId": {
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Data Collection Endpoint to use."
+      },
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Insights/dataCollectionRules",
+      "apiVersion": "2023-03-11",
+      "name": "[parameters('dataCollectionRuleName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "streamDeclarations": {
+          "Custom-DeviceTvmSecureConfigurationAssessmentKB": {
+            "columns": [
+              {
+                "name": "ConfigurationId",
+                "type": "string"
+              },
+              {
+                "name": "ConfigurationImpact",
+                "type": "real"
+              },
+              {
+                "name": "ConfigurationName",
+                "type": "string"
+              },
+              {
+                "name": "ConfigurationDescription",
+                "type": "string"
+              },
+              {
+                "name": "RiskDescription",
+                "type": "string"
+              },
+              {
+                "name": "ConfigurationCategory",
+                "type": "string"
+              },
+              {
+                "name": "ConfigurationSubcategory",
+                "type": "string"
+              },
+              {
+                "name": "ConfigurationBenchmarks",
+                "type": "dynamic"
+              },
+              {
+                "name": "Tags",
+                "type": "dynamic"
+              },
+              {
+                "name": "RemediationOptions",
+                "type": "string"
+              },
+              {
+                "name": "TimeGenerated",
+                "type": "datetime"
+              }
+            ]
+          }
+        },
+        "destinations": {
+          "logAnalytics": [
+            {
+              "workspaceResourceId": "[parameters('workspaceResourceId')]",
+              "name": "logAnalyticsWorkspace"
+            }
+          ]
+        },
+        "dataFlows": [
+          {
+            "streams": [
+              "Custom-DeviceTvmSecureConfigurationAssessmentKB"
+            ],
+            "destinations": [
+              "logAnalyticsWorkspace"
+            ],
+            "transformKql": "source",
+            "outputStream": "Microsoft-DeviceTvmSecureConfigurationAssessmentKB"
+          }
+        ],
+        "dataCollectionEndpointId": "[parameters('endpointResourceId')]"
+      }
+    }
+  ],
+  "outputs": {
+    "dataCollectionRuleId": {
+      "type": "string",
+      "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+    }
+  }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/DeviceTvmSoftwareVulnerabilitiesKB.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/DeviceTvmSoftwareVulnerabilitiesKB.json
@@ -1,0 +1,118 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "dataCollectionRuleName": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the name of the Data Collection Rule to create."
+      }
+    },
+    "location": {
+      "defaultValue": "[resourceGroup().location]",
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the location in which to create the Data Collection Rule."
+      }
+    },
+    "workspaceResourceId": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+      }
+    },
+    "endpointResourceId": {
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Data Collection Endpoint to use."
+      },
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Insights/dataCollectionRules",
+      "apiVersion": "2023-03-11",
+      "name": "[parameters('dataCollectionRuleName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "streamDeclarations": {
+          "Custom-DeviceTvmSoftwareVulnerabilitiesKB": {
+            "columns": [
+              {
+                "name": "AffectedSoftware",
+                "type": "dynamic"
+              },
+              {
+                "name": "CveId",
+                "type": "string"
+              },
+              {
+                "name": "CvssScore",
+                "type": "real"
+              },
+              {
+                "name": "IsExploitAvailable",
+                "type": "boolean"
+              },
+              {
+                "name": "LastModifiedTime",
+                "type": "datetime"
+              },
+              {
+                "name": "PublishedDate",
+                "type": "datetime"
+              },
+              {
+                "name": "SourceSystem",
+                "type": "string"
+              },
+              {
+                "name": "TimeGenerated",
+                "type": "datetime"
+              },
+              {
+                "name": "Timestamp",
+                "type": "datetime"
+              },
+              {
+                "name": "VulnerabilityDescription",
+                "type": "string"
+              },
+              {
+                "name": "VulnerabilitySeverityLevel",
+                "type": "string"
+              }
+            ]
+          }
+        },
+        "destinations": {
+          "logAnalytics": [
+            {
+              "workspaceResourceId": "[parameters('workspaceResourceId')]",
+              "name": "logAnalyticsWorkspace"
+            }
+          ]
+        },
+        "dataFlows": [
+          {
+            "streams": [
+              "Custom-DeviceTvmSoftwareVulnerabilitiesKB"
+            ],
+            "destinations": [
+              "logAnalyticsWorkspace"
+            ],
+            "transformKql": "source",
+            "outputStream": "Microsoft-DeviceTvmSoftwareVulnerabilitiesKB"
+          }
+        ],
+        "dataCollectionEndpointId": "[parameters('endpointResourceId')]"
+      }
+    }
+  ],
+  "outputs": {
+    "dataCollectionRuleId": {
+      "type": "string",
+      "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+    }
+  }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/Event.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/Event.json
@@ -1,0 +1,142 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "dataCollectionRuleName": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the name of the Data Collection Rule to create."
+      }
+    },
+    "location": {
+      "defaultValue": "[resourceGroup().location]",
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the location in which to create the Data Collection Rule."
+      }
+    },
+    "workspaceResourceId": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+      }
+    },
+    "endpointResourceId": {
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Data Collection Endpoint to use."
+      },
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Insights/dataCollectionRules",
+      "apiVersion": "2023-03-11",
+      "name": "[parameters('dataCollectionRuleName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "streamDeclarations": {
+          "Custom-Event": {
+            "columns": [
+              {
+                "name": "AzureDeploymentID",
+                "type": "string"
+              },
+              {
+                "name": "Computer",
+                "type": "string"
+              },
+              {
+                "name": "EventCategory",
+                "type": "int"
+              },
+              {
+                "name": "EventData",
+                "type": "string"
+              },
+              {
+                "name": "EventID",
+                "type": "int"
+              },
+              {
+                "name": "EventLevel",
+                "type": "int"
+              },
+              {
+                "name": "EventLevelName",
+                "type": "string"
+              },
+              {
+                "name": "EventLog",
+                "type": "string"
+              },
+              {
+                "name": "ManagementGroupName",
+                "type": "string"
+              },
+              {
+                "name": "Message",
+                "type": "string"
+              },
+              {
+                "name": "ParameterXml",
+                "type": "string"
+              },
+              {
+                "name": "RenderedDescription",
+                "type": "string"
+              },
+              {
+                "name": "Role",
+                "type": "string"
+              },
+              {
+                "name": "Source",
+                "type": "string"
+              },
+              {
+                "name": "SourceSystem",
+                "type": "string"
+              },
+              {
+                "name": "TimeGenerated",
+                "type": "datetime"
+              },
+              {
+                "name": "UserName",
+                "type": "string"
+              }
+            ]
+          }
+        },
+        "destinations": {
+          "logAnalytics": [
+            {
+              "workspaceResourceId": "[parameters('workspaceResourceId')]",
+              "name": "logAnalyticsWorkspace"
+            }
+          ]
+        },
+        "dataFlows": [
+          {
+            "streams": [
+              "Custom-Event"
+            ],
+            "destinations": [
+              "logAnalyticsWorkspace"
+            ],
+            "transformKql": "source",
+            "outputStream": "Microsoft-Event"
+          }
+        ],
+        "dataCollectionEndpointId": "[parameters('endpointResourceId')]"
+      }
+    }
+  ],
+  "outputs": {
+    "dataCollectionRuleId": {
+      "type": "string",
+      "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+    }
+  }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/ExchangeAssessmentRecommendation.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/ExchangeAssessmentRecommendation.json
@@ -1,0 +1,170 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "dataCollectionRuleName": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the name of the Data Collection Rule to create."
+      }
+    },
+    "location": {
+      "defaultValue": "[resourceGroup().location]",
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the location in which to create the Data Collection Rule."
+      }
+    },
+    "workspaceResourceId": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+      }
+    },
+    "endpointResourceId": {
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Data Collection Endpoint to use."
+      },
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Insights/dataCollectionRules",
+      "apiVersion": "2023-03-11",
+      "name": "[parameters('dataCollectionRuleName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "streamDeclarations": {
+          "Custom-ExchangeAssessmentRecommendation": {
+            "columns": [
+              {
+                "name": "ActionArea",
+                "type": "string"
+              },
+              {
+                "name": "ActionAreaId",
+                "type": "string"
+              },
+              {
+                "name": "ActiveDirectorySite",
+                "type": "string"
+              },
+              {
+                "name": "AffectedObjectName",
+                "type": "string"
+              },
+              {
+                "name": "AffectedObjectType",
+                "type": "string"
+              },
+              {
+                "name": "AssessmentId",
+                "type": "string"
+              },
+              {
+                "name": "Computer",
+                "type": "string"
+              },
+              {
+                "name": "CustomData",
+                "type": "string"
+              },
+              {
+                "name": "Description",
+                "type": "string"
+              },
+              {
+                "name": "ExchangeAdminGroup",
+                "type": "string"
+              },
+              {
+                "name": "ExchangeDAG",
+                "type": "string"
+              },
+              {
+                "name": "ExchangeMailboxDatabase",
+                "type": "string"
+              },
+              {
+                "name": "ExchangeOrganization",
+                "type": "string"
+              },
+              {
+                "name": "ExchangePublicFolderDatabase",
+                "type": "string"
+              },
+              {
+                "name": "ExchangeServer",
+                "type": "string"
+              },
+              {
+                "name": "FocusArea",
+                "type": "string"
+              },
+              {
+                "name": "FocusAreaId",
+                "type": "string"
+              },
+              {
+                "name": "Recommendation",
+                "type": "string"
+              },
+              {
+                "name": "RecommendationId",
+                "type": "string"
+              },
+              {
+                "name": "RecommendationResult",
+                "type": "string"
+              },
+              {
+                "name": "RecommendationWeight",
+                "type": "real"
+              },
+              {
+                "name": "SourceSystem",
+                "type": "string"
+              },
+              {
+                "name": "Technology",
+                "type": "string"
+              },
+              {
+                "name": "TimeGenerated",
+                "type": "datetime"
+              }
+            ]
+          }
+        },
+        "destinations": {
+          "logAnalytics": [
+            {
+              "workspaceResourceId": "[parameters('workspaceResourceId')]",
+              "name": "logAnalyticsWorkspace"
+            }
+          ]
+        },
+        "dataFlows": [
+          {
+            "streams": [
+              "Custom-ExchangeAssessmentRecommendation"
+            ],
+            "destinations": [
+              "logAnalyticsWorkspace"
+            ],
+            "transformKql": "source",
+            "outputStream": "Microsoft-ExchangeAssessmentRecommendation"
+          }
+        ],
+        "dataCollectionEndpointId": "[parameters('endpointResourceId')]"
+      }
+    }
+  ],
+  "outputs": {
+    "dataCollectionRuleId": {
+      "type": "string",
+      "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+    }
+  }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/ExchangeOnlineAssessmentRecommendation.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/ExchangeOnlineAssessmentRecommendation.json
@@ -1,0 +1,146 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "dataCollectionRuleName": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the name of the Data Collection Rule to create."
+      }
+    },
+    "location": {
+      "defaultValue": "[resourceGroup().location]",
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the location in which to create the Data Collection Rule."
+      }
+    },
+    "workspaceResourceId": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+      }
+    },
+    "endpointResourceId": {
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Data Collection Endpoint to use."
+      },
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Insights/dataCollectionRules",
+      "apiVersion": "2023-03-11",
+      "name": "[parameters('dataCollectionRuleName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "streamDeclarations": {
+          "Custom-ExchangeOnlineAssessmentRecommendation": {
+            "columns": [
+              {
+                "name": "ActionArea",
+                "type": "string"
+              },
+              {
+                "name": "ActionAreaId",
+                "type": "string"
+              },
+              {
+                "name": "AffectedObjectName",
+                "type": "string"
+              },
+              {
+                "name": "AffectedObjectType",
+                "type": "string"
+              },
+              {
+                "name": "AssessmentId",
+                "type": "string"
+              },
+              {
+                "name": "Computer",
+                "type": "string"
+              },
+              {
+                "name": "CustomData",
+                "type": "string"
+              },
+              {
+                "name": "Description",
+                "type": "string"
+              },
+              {
+                "name": "ExchangeOnlineOrganization",
+                "type": "string"
+              },
+              {
+                "name": "FocusArea",
+                "type": "string"
+              },
+              {
+                "name": "FocusAreaId",
+                "type": "string"
+              },
+              {
+                "name": "Recommendation",
+                "type": "string"
+              },
+              {
+                "name": "RecommendationId",
+                "type": "string"
+              },
+              {
+                "name": "RecommendationResult",
+                "type": "string"
+              },
+              {
+                "name": "RecommendationWeight",
+                "type": "real"
+              },
+              {
+                "name": "SourceSystem",
+                "type": "string"
+              },
+              {
+                "name": "Technology",
+                "type": "string"
+              },
+              {
+                "name": "TimeGenerated",
+                "type": "datetime"
+              }
+            ]
+          }
+        },
+        "destinations": {
+          "logAnalytics": [
+            {
+              "workspaceResourceId": "[parameters('workspaceResourceId')]",
+              "name": "logAnalyticsWorkspace"
+            }
+          ]
+        },
+        "dataFlows": [
+          {
+            "streams": [
+              "Custom-ExchangeOnlineAssessmentRecommendation"
+            ],
+            "destinations": [
+              "logAnalyticsWorkspace"
+            ],
+            "transformKql": "source",
+            "outputStream": "Microsoft-ExchangeOnlineAssessmentRecommendation"
+          }
+        ],
+        "dataCollectionEndpointId": "[parameters('endpointResourceId')]"
+      }
+    }
+  ],
+  "outputs": {
+    "dataCollectionRuleId": {
+      "type": "string",
+      "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+    }
+  }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/GCPAuditLogs.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/GCPAuditLogs.json
@@ -1,0 +1,174 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "dataCollectionRuleName": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the name of the Data Collection Rule to create."
+      }
+    },
+    "location": {
+      "defaultValue": "[resourceGroup().location]",
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the location in which to create the Data Collection Rule."
+      }
+    },
+    "workspaceResourceId": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+      }
+    },
+    "endpointResourceId": {
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Data Collection Endpoint to use."
+      },
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Insights/dataCollectionRules",
+      "apiVersion": "2023-03-11",
+      "name": "[parameters('dataCollectionRuleName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "streamDeclarations": {
+          "Custom-GCPAuditLogs": {
+            "columns": [
+              {
+                "name": "AuthenticationInfo",
+                "type": "dynamic"
+              },
+              {
+                "name": "AuthorizationInfo",
+                "type": "dynamic"
+              },
+              {
+                "name": "GCPResourceName",
+                "type": "string"
+              },
+              {
+                "name": "GCPResourceType",
+                "type": "string"
+              },
+              {
+                "name": "InsertId",
+                "type": "string"
+              },
+              {
+                "name": "LogName",
+                "type": "string"
+              },
+              {
+                "name": "Metadata",
+                "type": "dynamic"
+              },
+              {
+                "name": "MethodName",
+                "type": "string"
+              },
+              {
+                "name": "NumResponseItems",
+                "type": "string"
+              },
+              {
+                "name": "PrincipalEmail",
+                "type": "string"
+              },
+              {
+                "name": "ProjectId",
+                "type": "string"
+              },
+              {
+                "name": "Request",
+                "type": "dynamic"
+              },
+              {
+                "name": "RequestMetadata",
+                "type": "dynamic"
+              },
+              {
+                "name": "ResourceLocation",
+                "type": "dynamic"
+              },
+              {
+                "name": "ResourceOriginalState",
+                "type": "dynamic"
+              },
+              {
+                "name": "Response",
+                "type": "dynamic"
+              },
+              {
+                "name": "ServiceData",
+                "type": "dynamic"
+              },
+              {
+                "name": "ServiceName",
+                "type": "string"
+              },
+              {
+                "name": "Severity",
+                "type": "string"
+              },
+              {
+                "name": "SourceSystem",
+                "type": "string"
+              },
+              {
+                "name": "Status",
+                "type": "dynamic"
+              },
+              {
+                "name": "StatusMessage",
+                "type": "string"
+              },
+              {
+                "name": "Subscription",
+                "type": "string"
+              },
+              {
+                "name": "TimeGenerated",
+                "type": "datetime"
+              },
+              {
+                "name": "Timestamp",
+                "type": "datetime"
+              }
+            ]
+          }
+        },
+        "destinations": {
+          "logAnalytics": [
+            {
+              "workspaceResourceId": "[parameters('workspaceResourceId')]",
+              "name": "logAnalyticsWorkspace"
+            }
+          ]
+        },
+        "dataFlows": [
+          {
+            "streams": [
+              "Custom-GCPAuditLogs"
+            ],
+            "destinations": [
+              "logAnalyticsWorkspace"
+            ],
+            "transformKql": "source",
+            "outputStream": "Microsoft-GCPAuditLogs"
+          }
+        ],
+        "dataCollectionEndpointId": "[parameters('endpointResourceId')]"
+      }
+    }
+  ],
+  "outputs": {
+    "dataCollectionRuleId": {
+      "type": "string",
+      "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+    }
+  }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/GoogleCloudSCC.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/GoogleCloudSCC.json
@@ -1,0 +1,94 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "dataCollectionRuleName": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the name of the Data Collection Rule to create."
+      }
+    },
+    "location": {
+      "defaultValue": "[resourceGroup().location]",
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the location in which to create the Data Collection Rule."
+      }
+    },
+    "workspaceResourceId": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+      }
+    },
+    "endpointResourceId": {
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Data Collection Endpoint to use."
+      },
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Insights/dataCollectionRules",
+      "apiVersion": "2023-03-11",
+      "name": "[parameters('dataCollectionRuleName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "streamDeclarations": {
+          "Custom-GoogleCloudSCC": {
+            "columns": [
+              {
+                "name": "Findings",
+                "type": "dynamic"
+              },
+              {
+                "name": "FindingsResource",
+                "type": "dynamic"
+              },
+              {
+                "name": "SourceProperties",
+                "type": "dynamic"
+              },
+              {
+                "name": "SourceSystem",
+                "type": "string"
+              },
+              {
+                "name": "TimeGenerated",
+                "type": "datetime"
+              }
+            ]
+          }
+        },
+        "destinations": {
+          "logAnalytics": [
+            {
+              "workspaceResourceId": "[parameters('workspaceResourceId')]",
+              "name": "logAnalyticsWorkspace"
+            }
+          ]
+        },
+        "dataFlows": [
+          {
+            "streams": [
+              "Custom-GoogleCloudSCC"
+            ],
+            "destinations": [
+              "logAnalyticsWorkspace"
+            ],
+            "transformKql": "source",
+            "outputStream": "Microsoft-GoogleCloudSCC"
+          }
+        ],
+        "dataCollectionEndpointId": "[parameters('endpointResourceId')]"
+      }
+    }
+  ],
+  "outputs": {
+    "dataCollectionRuleId": {
+      "type": "string",
+      "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+    }
+  }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/SCCMAssessmentRecommendation.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/SCCMAssessmentRecommendation.json
@@ -1,0 +1,150 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "dataCollectionRuleName": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the name of the Data Collection Rule to create."
+      }
+    },
+    "location": {
+      "defaultValue": "[resourceGroup().location]",
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the location in which to create the Data Collection Rule."
+      }
+    },
+    "workspaceResourceId": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+      }
+    },
+    "endpointResourceId": {
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Data Collection Endpoint to use."
+      },
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Insights/dataCollectionRules",
+      "apiVersion": "2023-03-11",
+      "name": "[parameters('dataCollectionRuleName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "streamDeclarations": {
+          "Custom-SCCMAssessmentRecommendation": {
+            "columns": [
+              {
+                "name": "ActionArea",
+                "type": "string"
+              },
+              {
+                "name": "ActionAreaId",
+                "type": "string"
+              },
+              {
+                "name": "AffectedObjectName",
+                "type": "string"
+              },
+              {
+                "name": "AffectedObjectType",
+                "type": "string"
+              },
+              {
+                "name": "AssessmentId",
+                "type": "string"
+              },
+              {
+                "name": "Computer",
+                "type": "string"
+              },
+              {
+                "name": "CustomData",
+                "type": "string"
+              },
+              {
+                "name": "Description",
+                "type": "string"
+              },
+              {
+                "name": "FocusArea",
+                "type": "string"
+              },
+              {
+                "name": "FocusAreaId",
+                "type": "string"
+              },
+              {
+                "name": "Recommendation",
+                "type": "string"
+              },
+              {
+                "name": "RecommendationId",
+                "type": "string"
+              },
+              {
+                "name": "RecommendationResult",
+                "type": "string"
+              },
+              {
+                "name": "RecommendationWeight",
+                "type": "real"
+              },
+              {
+                "name": "SiteCode",
+                "type": "string"
+              },
+              {
+                "name": "SiteServer",
+                "type": "string"
+              },
+              {
+                "name": "SourceSystem",
+                "type": "string"
+              },
+              {
+                "name": "Technology",
+                "type": "string"
+              },
+              {
+                "name": "TimeGenerated",
+                "type": "datetime"
+              }
+            ]
+          }
+        },
+        "destinations": {
+          "logAnalytics": [
+            {
+              "workspaceResourceId": "[parameters('workspaceResourceId')]",
+              "name": "logAnalyticsWorkspace"
+            }
+          ]
+        },
+        "dataFlows": [
+          {
+            "streams": [
+              "Custom-SCCMAssessmentRecommendation"
+            ],
+            "destinations": [
+              "logAnalyticsWorkspace"
+            ],
+            "transformKql": "source",
+            "outputStream": "Microsoft-SCCMAssessmentRecommendation"
+          }
+        ],
+        "dataCollectionEndpointId": "[parameters('endpointResourceId')]"
+      }
+    }
+  ],
+  "outputs": {
+    "dataCollectionRuleId": {
+      "type": "string",
+      "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+    }
+  }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/SCOMAssessmentRecommendation.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/SCOMAssessmentRecommendation.json
@@ -1,0 +1,150 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "dataCollectionRuleName": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the name of the Data Collection Rule to create."
+      }
+    },
+    "location": {
+      "defaultValue": "[resourceGroup().location]",
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the location in which to create the Data Collection Rule."
+      }
+    },
+    "workspaceResourceId": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+      }
+    },
+    "endpointResourceId": {
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Data Collection Endpoint to use."
+      },
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Insights/dataCollectionRules",
+      "apiVersion": "2023-03-11",
+      "name": "[parameters('dataCollectionRuleName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "streamDeclarations": {
+          "Custom-SCOMAssessmentRecommendation": {
+            "columns": [
+              {
+                "name": "ActionArea",
+                "type": "string"
+              },
+              {
+                "name": "ActionAreaId",
+                "type": "string"
+              },
+              {
+                "name": "AffectedObjectName",
+                "type": "string"
+              },
+              {
+                "name": "AffectedObjectType",
+                "type": "string"
+              },
+              {
+                "name": "AssessmentId",
+                "type": "string"
+              },
+              {
+                "name": "Computer",
+                "type": "string"
+              },
+              {
+                "name": "CustomData",
+                "type": "string"
+              },
+              {
+                "name": "Description",
+                "type": "string"
+              },
+              {
+                "name": "FocusArea",
+                "type": "string"
+              },
+              {
+                "name": "FocusAreaId",
+                "type": "string"
+              },
+              {
+                "name": "ManagementGroup",
+                "type": "string"
+              },
+              {
+                "name": "ManagementServer",
+                "type": "string"
+              },
+              {
+                "name": "Recommendation",
+                "type": "string"
+              },
+              {
+                "name": "RecommendationId",
+                "type": "string"
+              },
+              {
+                "name": "RecommendationResult",
+                "type": "string"
+              },
+              {
+                "name": "RecommendationWeight",
+                "type": "real"
+              },
+              {
+                "name": "SourceSystem",
+                "type": "string"
+              },
+              {
+                "name": "Technology",
+                "type": "string"
+              },
+              {
+                "name": "TimeGenerated",
+                "type": "datetime"
+              }
+            ]
+          }
+        },
+        "destinations": {
+          "logAnalytics": [
+            {
+              "workspaceResourceId": "[parameters('workspaceResourceId')]",
+              "name": "logAnalyticsWorkspace"
+            }
+          ]
+        },
+        "dataFlows": [
+          {
+            "streams": [
+              "Custom-SCOMAssessmentRecommendation"
+            ],
+            "destinations": [
+              "logAnalyticsWorkspace"
+            ],
+            "transformKql": "source",
+            "outputStream": "Microsoft-SCOMAssessmentRecommendation"
+          }
+        ],
+        "dataCollectionEndpointId": "[parameters('endpointResourceId')]"
+      }
+    }
+  ],
+  "outputs": {
+    "dataCollectionRuleId": {
+      "type": "string",
+      "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+    }
+  }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/SPAssessmentRecommendation.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/SPAssessmentRecommendation.json
@@ -1,0 +1,154 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "dataCollectionRuleName": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the name of the Data Collection Rule to create."
+      }
+    },
+    "location": {
+      "defaultValue": "[resourceGroup().location]",
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the location in which to create the Data Collection Rule."
+      }
+    },
+    "workspaceResourceId": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+      }
+    },
+    "endpointResourceId": {
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Data Collection Endpoint to use."
+      },
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Insights/dataCollectionRules",
+      "apiVersion": "2023-03-11",
+      "name": "[parameters('dataCollectionRuleName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "streamDeclarations": {
+          "Custom-SPAssessmentRecommendation": {
+            "columns": [
+              {
+                "name": "ActionArea",
+                "type": "string"
+              },
+              {
+                "name": "ActionAreaId",
+                "type": "string"
+              },
+              {
+                "name": "AffectedObjectName",
+                "type": "string"
+              },
+              {
+                "name": "AffectedObjectType",
+                "type": "string"
+              },
+              {
+                "name": "AssessmentId",
+                "type": "string"
+              },
+              {
+                "name": "Computer",
+                "type": "string"
+              },
+              {
+                "name": "CustomData",
+                "type": "string"
+              },
+              {
+                "name": "Description",
+                "type": "string"
+              },
+              {
+                "name": "FocusArea",
+                "type": "string"
+              },
+              {
+                "name": "FocusAreaId",
+                "type": "string"
+              },
+              {
+                "name": "Recommendation",
+                "type": "string"
+              },
+              {
+                "name": "RecommendationId",
+                "type": "string"
+              },
+              {
+                "name": "RecommendationResult",
+                "type": "string"
+              },
+              {
+                "name": "RecommendationWeight",
+                "type": "real"
+              },
+              {
+                "name": "SharePointFarm",
+                "type": "string"
+              },
+              {
+                "name": "SharePointServer",
+                "type": "string"
+              },
+              {
+                "name": "SourceSystem",
+                "type": "string"
+              },
+              {
+                "name": "Technology",
+                "type": "string"
+              },
+              {
+                "name": "TimeGenerated",
+                "type": "datetime"
+              },
+              {
+                "name": "WebApplication",
+                "type": "string"
+              }
+            ]
+          }
+        },
+        "destinations": {
+          "logAnalytics": [
+            {
+              "workspaceResourceId": "[parameters('workspaceResourceId')]",
+              "name": "logAnalyticsWorkspace"
+            }
+          ]
+        },
+        "dataFlows": [
+          {
+            "streams": [
+              "Custom-SPAssessmentRecommendation"
+            ],
+            "destinations": [
+              "logAnalyticsWorkspace"
+            ],
+            "transformKql": "source",
+            "outputStream": "Microsoft-SPAssessmentRecommendation"
+          }
+        ],
+        "dataCollectionEndpointId": "[parameters('endpointResourceId')]"
+      }
+    }
+  ],
+  "outputs": {
+    "dataCollectionRuleId": {
+      "type": "string",
+      "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+    }
+  }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/SQLAssessmentRecommendation.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/SQLAssessmentRecommendation.json
@@ -1,0 +1,150 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "dataCollectionRuleName": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the name of the Data Collection Rule to create."
+      }
+    },
+    "location": {
+      "defaultValue": "[resourceGroup().location]",
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the location in which to create the Data Collection Rule."
+      }
+    },
+    "workspaceResourceId": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+      }
+    },
+    "endpointResourceId": {
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Data Collection Endpoint to use."
+      },
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Insights/dataCollectionRules",
+      "apiVersion": "2023-03-11",
+      "name": "[parameters('dataCollectionRuleName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "streamDeclarations": {
+          "Custom-SQLAssessmentRecommendation": {
+            "columns": [
+              {
+                "name": "ActionArea",
+                "type": "string"
+              },
+              {
+                "name": "ActionAreaId",
+                "type": "string"
+              },
+              {
+                "name": "AffectedObjectName",
+                "type": "string"
+              },
+              {
+                "name": "AffectedObjectType",
+                "type": "string"
+              },
+              {
+                "name": "AssessmentId",
+                "type": "string"
+              },
+              {
+                "name": "Computer",
+                "type": "string"
+              },
+              {
+                "name": "CustomData",
+                "type": "string"
+              },
+              {
+                "name": "DatabaseName",
+                "type": "string"
+              },
+              {
+                "name": "Description",
+                "type": "string"
+              },
+              {
+                "name": "FocusArea",
+                "type": "string"
+              },
+              {
+                "name": "FocusAreaId",
+                "type": "string"
+              },
+              {
+                "name": "Recommendation",
+                "type": "string"
+              },
+              {
+                "name": "RecommendationId",
+                "type": "string"
+              },
+              {
+                "name": "RecommendationResult",
+                "type": "string"
+              },
+              {
+                "name": "RecommendationWeight",
+                "type": "real"
+              },
+              {
+                "name": "SourceSystem",
+                "type": "string"
+              },
+              {
+                "name": "SqlInstanceName",
+                "type": "string"
+              },
+              {
+                "name": "Technology",
+                "type": "string"
+              },
+              {
+                "name": "TimeGenerated",
+                "type": "datetime"
+              }
+            ]
+          }
+        },
+        "destinations": {
+          "logAnalytics": [
+            {
+              "workspaceResourceId": "[parameters('workspaceResourceId')]",
+              "name": "logAnalyticsWorkspace"
+            }
+          ]
+        },
+        "dataFlows": [
+          {
+            "streams": [
+              "Custom-SQLAssessmentRecommendation"
+            ],
+            "destinations": [
+              "logAnalyticsWorkspace"
+            ],
+            "transformKql": "source",
+            "outputStream": "Microsoft-SQLAssessmentRecommendation"
+          }
+        ],
+        "dataCollectionEndpointId": "[parameters('endpointResourceId')]"
+      }
+    }
+  ],
+  "outputs": {
+    "dataCollectionRuleId": {
+      "type": "string",
+      "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+    }
+  }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/SecurityEvent.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/SecurityEvent.json
@@ -1,0 +1,946 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "dataCollectionRuleName": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the name of the Data Collection Rule to create."
+      }
+    },
+    "location": {
+      "defaultValue": "[resourceGroup().location]",
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the location in which to create the Data Collection Rule."
+      }
+    },
+    "workspaceResourceId": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+      }
+    },
+    "endpointResourceId": {
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Data Collection Endpoint to use."
+      },
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Insights/dataCollectionRules",
+      "apiVersion": "2023-03-11",
+      "name": "[parameters('dataCollectionRuleName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "streamDeclarations": {
+          "Custom-SecurityEvent": {
+            "columns": [
+              {
+                "name": "AccessMask",
+                "type": "string"
+              },
+              {
+                "name": "Account",
+                "type": "string"
+              },
+              {
+                "name": "AccountDomain",
+                "type": "string"
+              },
+              {
+                "name": "AccountExpires",
+                "type": "string"
+              },
+              {
+                "name": "AccountName",
+                "type": "string"
+              },
+              {
+                "name": "AccountSessionIdentifier",
+                "type": "string"
+              },
+              {
+                "name": "AccountType",
+                "type": "string"
+              },
+              {
+                "name": "Activity",
+                "type": "string"
+              },
+              {
+                "name": "AdditionalInfo",
+                "type": "string"
+              },
+              {
+                "name": "AdditionalInfo2",
+                "type": "string"
+              },
+              {
+                "name": "AllowedToDelegateTo",
+                "type": "string"
+              },
+              {
+                "name": "Attributes",
+                "type": "string"
+              },
+              {
+                "name": "AuditPolicyChanges",
+                "type": "string"
+              },
+              {
+                "name": "AuditsDiscarded",
+                "type": "int"
+              },
+              {
+                "name": "AuthenticationLevel",
+                "type": "int"
+              },
+              {
+                "name": "AuthenticationPackageName",
+                "type": "string"
+              },
+              {
+                "name": "AuthenticationProvider",
+                "type": "string"
+              },
+              {
+                "name": "AuthenticationServer",
+                "type": "string"
+              },
+              {
+                "name": "AuthenticationService",
+                "type": "int"
+              },
+              {
+                "name": "AuthenticationType",
+                "type": "string"
+              },
+              {
+                "name": "AzureDeploymentID",
+                "type": "string"
+              },
+              {
+                "name": "CACertificateHash",
+                "type": "string"
+              },
+              {
+                "name": "CalledStationID",
+                "type": "string"
+              },
+              {
+                "name": "CallerProcessId",
+                "type": "string"
+              },
+              {
+                "name": "CallerProcessName",
+                "type": "string"
+              },
+              {
+                "name": "CallingStationID",
+                "type": "string"
+              },
+              {
+                "name": "CAPublicKeyHash",
+                "type": "string"
+              },
+              {
+                "name": "CategoryId",
+                "type": "string"
+              },
+              {
+                "name": "CertificateDatabaseHash",
+                "type": "string"
+              },
+              {
+                "name": "Channel",
+                "type": "string"
+              },
+              {
+                "name": "ClassId",
+                "type": "string"
+              },
+              {
+                "name": "ClassName",
+                "type": "string"
+              },
+              {
+                "name": "ClientAddress",
+                "type": "string"
+              },
+              {
+                "name": "ClientIPAddress",
+                "type": "string"
+              },
+              {
+                "name": "ClientName",
+                "type": "string"
+              },
+              {
+                "name": "CommandLine",
+                "type": "string"
+              },
+              {
+                "name": "CompatibleIds",
+                "type": "string"
+              },
+              {
+                "name": "Computer",
+                "type": "string"
+              },
+              {
+                "name": "Correlation",
+                "type": "string"
+              },
+              {
+                "name": "DCDNSName",
+                "type": "string"
+              },
+              {
+                "name": "DeviceDescription",
+                "type": "string"
+              },
+              {
+                "name": "DeviceId",
+                "type": "string"
+              },
+              {
+                "name": "DisplayName",
+                "type": "string"
+              },
+              {
+                "name": "Disposition",
+                "type": "string"
+              },
+              {
+                "name": "DomainBehaviorVersion",
+                "type": "string"
+              },
+              {
+                "name": "DomainName",
+                "type": "string"
+              },
+              {
+                "name": "DomainPolicyChanged",
+                "type": "string"
+              },
+              {
+                "name": "DomainSid",
+                "type": "string"
+              },
+              {
+                "name": "EAPType",
+                "type": "string"
+              },
+              {
+                "name": "ElevatedToken",
+                "type": "string"
+              },
+              {
+                "name": "ErrorCode",
+                "type": "int"
+              },
+              {
+                "name": "EventData",
+                "type": "string"
+              },
+              {
+                "name": "EventID",
+                "type": "int"
+              },
+              {
+                "name": "EventLevelName",
+                "type": "string"
+              },
+              {
+                "name": "EventRecordId",
+                "type": "string"
+              },
+              {
+                "name": "EventSourceName",
+                "type": "string"
+              },
+              {
+                "name": "ExtendedQuarantineState",
+                "type": "string"
+              },
+              {
+                "name": "FailureReason",
+                "type": "string"
+              },
+              {
+                "name": "FileHash",
+                "type": "string"
+              },
+              {
+                "name": "FilePath",
+                "type": "string"
+              },
+              {
+                "name": "FilePathNoUser",
+                "type": "string"
+              },
+              {
+                "name": "Filter",
+                "type": "string"
+              },
+              {
+                "name": "ForceLogoff",
+                "type": "string"
+              },
+              {
+                "name": "Fqbn",
+                "type": "string"
+              },
+              {
+                "name": "FullyQualifiedSubjectMachineName",
+                "type": "string"
+              },
+              {
+                "name": "FullyQualifiedSubjectUserName",
+                "type": "string"
+              },
+              {
+                "name": "GroupMembership",
+                "type": "string"
+              },
+              {
+                "name": "HandleId",
+                "type": "string"
+              },
+              {
+                "name": "HardwareIds",
+                "type": "string"
+              },
+              {
+                "name": "HomeDirectory",
+                "type": "string"
+              },
+              {
+                "name": "HomePath",
+                "type": "string"
+              },
+              {
+                "name": "IpAddress",
+                "type": "string"
+              },
+              {
+                "name": "IpPort",
+                "type": "string"
+              },
+              {
+                "name": "KeyLength",
+                "type": "int"
+              },
+              {
+                "name": "Keywords",
+                "type": "string"
+              },
+              {
+                "name": "Level",
+                "type": "string"
+              },
+              {
+                "name": "LmPackageName",
+                "type": "string"
+              },
+              {
+                "name": "LocationInformation",
+                "type": "string"
+              },
+              {
+                "name": "LockoutDuration",
+                "type": "string"
+              },
+              {
+                "name": "LockoutObservationWindow",
+                "type": "string"
+              },
+              {
+                "name": "LockoutThreshold",
+                "type": "string"
+              },
+              {
+                "name": "LoggingResult",
+                "type": "string"
+              },
+              {
+                "name": "LogonHours",
+                "type": "string"
+              },
+              {
+                "name": "LogonID",
+                "type": "string"
+              },
+              {
+                "name": "LogonProcessName",
+                "type": "string"
+              },
+              {
+                "name": "LogonType",
+                "type": "int"
+              },
+              {
+                "name": "LogonTypeName",
+                "type": "string"
+              },
+              {
+                "name": "MachineAccountQuota",
+                "type": "string"
+              },
+              {
+                "name": "MachineInventory",
+                "type": "string"
+              },
+              {
+                "name": "MachineLogon",
+                "type": "string"
+              },
+              {
+                "name": "ManagementGroupName",
+                "type": "string"
+              },
+              {
+                "name": "MandatoryLabel",
+                "type": "string"
+              },
+              {
+                "name": "MaxPasswordAge",
+                "type": "string"
+              },
+              {
+                "name": "MemberName",
+                "type": "string"
+              },
+              {
+                "name": "MemberSid",
+                "type": "string"
+              },
+              {
+                "name": "MinPasswordAge",
+                "type": "string"
+              },
+              {
+                "name": "MinPasswordLength",
+                "type": "string"
+              },
+              {
+                "name": "MixedDomainMode",
+                "type": "string"
+              },
+              {
+                "name": "NASIdentifier",
+                "type": "string"
+              },
+              {
+                "name": "NASIPv4Address",
+                "type": "string"
+              },
+              {
+                "name": "NASIPv6Address",
+                "type": "string"
+              },
+              {
+                "name": "NASPort",
+                "type": "string"
+              },
+              {
+                "name": "NASPortType",
+                "type": "string"
+              },
+              {
+                "name": "NetworkPolicyName",
+                "type": "string"
+              },
+              {
+                "name": "NewDate",
+                "type": "string"
+              },
+              {
+                "name": "NewMaxUsers",
+                "type": "string"
+              },
+              {
+                "name": "NewProcessId",
+                "type": "string"
+              },
+              {
+                "name": "NewProcessName",
+                "type": "string"
+              },
+              {
+                "name": "NewRemark",
+                "type": "string"
+              },
+              {
+                "name": "NewShareFlags",
+                "type": "string"
+              },
+              {
+                "name": "NewTime",
+                "type": "string"
+              },
+              {
+                "name": "NewUacValue",
+                "type": "string"
+              },
+              {
+                "name": "NewValue",
+                "type": "string"
+              },
+              {
+                "name": "NewValueType",
+                "type": "string"
+              },
+              {
+                "name": "ObjectName",
+                "type": "string"
+              },
+              {
+                "name": "ObjectServer",
+                "type": "string"
+              },
+              {
+                "name": "ObjectType",
+                "type": "string"
+              },
+              {
+                "name": "ObjectValueName",
+                "type": "string"
+              },
+              {
+                "name": "OemInformation",
+                "type": "string"
+              },
+              {
+                "name": "OldMaxUsers",
+                "type": "string"
+              },
+              {
+                "name": "OldRemark",
+                "type": "string"
+              },
+              {
+                "name": "OldShareFlags",
+                "type": "string"
+              },
+              {
+                "name": "OldUacValue",
+                "type": "string"
+              },
+              {
+                "name": "OldValue",
+                "type": "string"
+              },
+              {
+                "name": "OldValueType",
+                "type": "string"
+              },
+              {
+                "name": "Opcode",
+                "type": "string"
+              },
+              {
+                "name": "OperationType",
+                "type": "string"
+              },
+              {
+                "name": "PackageName",
+                "type": "string"
+              },
+              {
+                "name": "ParentProcessName",
+                "type": "string"
+              },
+              {
+                "name": "PasswordHistoryLength",
+                "type": "string"
+              },
+              {
+                "name": "PasswordLastSet",
+                "type": "string"
+              },
+              {
+                "name": "PasswordProperties",
+                "type": "string"
+              },
+              {
+                "name": "PreviousDate",
+                "type": "string"
+              },
+              {
+                "name": "PreviousTime",
+                "type": "string"
+              },
+              {
+                "name": "PrimaryGroupId",
+                "type": "string"
+              },
+              {
+                "name": "PrivateKeyUsageCount",
+                "type": "string"
+              },
+              {
+                "name": "PrivilegeList",
+                "type": "string"
+              },
+              {
+                "name": "Process",
+                "type": "string"
+              },
+              {
+                "name": "ProcessId",
+                "type": "string"
+              },
+              {
+                "name": "ProcessName",
+                "type": "string"
+              },
+              {
+                "name": "ProfilePath",
+                "type": "string"
+              },
+              {
+                "name": "Properties",
+                "type": "string"
+              },
+              {
+                "name": "ProtocolSequence",
+                "type": "string"
+              },
+              {
+                "name": "ProxyPolicyName",
+                "type": "string"
+              },
+              {
+                "name": "QuarantineHelpURL",
+                "type": "string"
+              },
+              {
+                "name": "QuarantineSessionID",
+                "type": "string"
+              },
+              {
+                "name": "QuarantineSessionIdentifier",
+                "type": "string"
+              },
+              {
+                "name": "QuarantineState",
+                "type": "string"
+              },
+              {
+                "name": "QuarantineSystemHealthResult",
+                "type": "string"
+              },
+              {
+                "name": "RelativeTargetName",
+                "type": "string"
+              },
+              {
+                "name": "RemoteIpAddress",
+                "type": "string"
+              },
+              {
+                "name": "RemotePort",
+                "type": "string"
+              },
+              {
+                "name": "Requester",
+                "type": "string"
+              },
+              {
+                "name": "RequestId",
+                "type": "string"
+              },
+              {
+                "name": "RestrictedAdminMode",
+                "type": "string"
+              },
+              {
+                "name": "RowsDeleted",
+                "type": "string"
+              },
+              {
+                "name": "SamAccountName",
+                "type": "string"
+              },
+              {
+                "name": "ScriptPath",
+                "type": "string"
+              },
+              {
+                "name": "SecurityDescriptor",
+                "type": "string"
+              },
+              {
+                "name": "ServiceAccount",
+                "type": "string"
+              },
+              {
+                "name": "ServiceFileName",
+                "type": "string"
+              },
+              {
+                "name": "ServiceName",
+                "type": "string"
+              },
+              {
+                "name": "ServiceStartType",
+                "type": "int"
+              },
+              {
+                "name": "ServiceType",
+                "type": "string"
+              },
+              {
+                "name": "SessionName",
+                "type": "string"
+              },
+              {
+                "name": "ShareLocalPath",
+                "type": "string"
+              },
+              {
+                "name": "ShareName",
+                "type": "string"
+              },
+              {
+                "name": "SidHistory",
+                "type": "string"
+              },
+              {
+                "name": "SourceSystem",
+                "type": "string"
+              },
+              {
+                "name": "Status",
+                "type": "string"
+              },
+              {
+                "name": "StorageAccount",
+                "type": "string"
+              },
+              {
+                "name": "SubcategoryId",
+                "type": "string"
+              },
+              {
+                "name": "Subject",
+                "type": "string"
+              },
+              {
+                "name": "SubjectAccount",
+                "type": "string"
+              },
+              {
+                "name": "SubjectDomainName",
+                "type": "string"
+              },
+              {
+                "name": "SubjectKeyIdentifier",
+                "type": "string"
+              },
+              {
+                "name": "SubjectLogonId",
+                "type": "string"
+              },
+              {
+                "name": "SubjectMachineName",
+                "type": "string"
+              },
+              {
+                "name": "SubjectMachineSID",
+                "type": "string"
+              },
+              {
+                "name": "SubjectUserName",
+                "type": "string"
+              },
+              {
+                "name": "SubjectUserSid",
+                "type": "string"
+              },
+              {
+                "name": "SubStatus",
+                "type": "string"
+              },
+              {
+                "name": "SystemProcessId",
+                "type": "int"
+              },
+              {
+                "name": "SystemThreadId",
+                "type": "int"
+              },
+              {
+                "name": "SystemUserId",
+                "type": "string"
+              },
+              {
+                "name": "TableId",
+                "type": "string"
+              },
+              {
+                "name": "TargetAccount",
+                "type": "string"
+              },
+              {
+                "name": "TargetDomainName",
+                "type": "string"
+              },
+              {
+                "name": "TargetInfo",
+                "type": "string"
+              },
+              {
+                "name": "TargetLinkedLogonId",
+                "type": "string"
+              },
+              {
+                "name": "TargetLogonId",
+                "type": "string"
+              },
+              {
+                "name": "TargetOutboundDomainName",
+                "type": "string"
+              },
+              {
+                "name": "TargetOutboundUserName",
+                "type": "string"
+              },
+              {
+                "name": "TargetServerName",
+                "type": "string"
+              },
+              {
+                "name": "TargetSid",
+                "type": "string"
+              },
+              {
+                "name": "TargetUser",
+                "type": "string"
+              },
+              {
+                "name": "TargetUserName",
+                "type": "string"
+              },
+              {
+                "name": "TargetUserSid",
+                "type": "string"
+              },
+              {
+                "name": "Task",
+                "type": "int"
+              },
+              {
+                "name": "TemplateContent",
+                "type": "string"
+              },
+              {
+                "name": "TemplateDSObjectFQDN",
+                "type": "string"
+              },
+              {
+                "name": "TemplateInternalName",
+                "type": "string"
+              },
+              {
+                "name": "TemplateOID",
+                "type": "string"
+              },
+              {
+                "name": "TemplateSchemaVersion",
+                "type": "string"
+              },
+              {
+                "name": "TemplateVersion",
+                "type": "string"
+              },
+              {
+                "name": "TimeGenerated",
+                "type": "datetime"
+              },
+              {
+                "name": "TokenElevationType",
+                "type": "string"
+              },
+              {
+                "name": "TransmittedServices",
+                "type": "string"
+              },
+              {
+                "name": "Type",
+                "type": "string"
+              },
+              {
+                "name": "UserAccountControl",
+                "type": "string"
+              },
+              {
+                "name": "UserParameters",
+                "type": "string"
+              },
+              {
+                "name": "UserPrincipalName",
+                "type": "string"
+              },
+              {
+                "name": "UserWorkstations",
+                "type": "string"
+              },
+              {
+                "name": "VendorIds",
+                "type": "string"
+              },
+              {
+                "name": "Version",
+                "type": "int"
+              },
+              {
+                "name": "VirtualAccount",
+                "type": "string"
+              },
+              {
+                "name": "Workstation",
+                "type": "string"
+              },
+              {
+                "name": "WorkstationName",
+                "type": "string"
+              }
+            ]
+          }
+        },
+        "destinations": {
+          "logAnalytics": [
+            {
+              "workspaceResourceId": "[parameters('workspaceResourceId')]",
+              "name": "logAnalyticsWorkspace"
+            }
+          ]
+        },
+        "dataFlows": [
+          {
+            "streams": [
+              "Custom-SecurityEvent"
+            ],
+            "destinations": [
+              "logAnalyticsWorkspace"
+            ],
+            "transformKql": "source",
+            "outputStream": "Microsoft-SecurityEvent"
+          }
+        ],
+        "dataCollectionEndpointId": "[parameters('endpointResourceId')]"
+      }
+    }
+  ],
+  "outputs": {
+    "dataCollectionRuleId": {
+      "type": "string",
+      "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+    }
+  }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/SfBAssessmentRecommendation.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/SfBAssessmentRecommendation.json
@@ -1,0 +1,150 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "dataCollectionRuleName": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the name of the Data Collection Rule to create."
+      }
+    },
+    "location": {
+      "defaultValue": "[resourceGroup().location]",
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the location in which to create the Data Collection Rule."
+      }
+    },
+    "workspaceResourceId": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+      }
+    },
+    "endpointResourceId": {
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Data Collection Endpoint to use."
+      },
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Insights/dataCollectionRules",
+      "apiVersion": "2023-03-11",
+      "name": "[parameters('dataCollectionRuleName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "streamDeclarations": {
+          "Custom-SfBAssessmentRecommendation": {
+            "columns": [
+              {
+                "name": "ActionArea",
+                "type": "string"
+              },
+              {
+                "name": "ActionAreaId",
+                "type": "string"
+              },
+              {
+                "name": "AffectedObjectName",
+                "type": "string"
+              },
+              {
+                "name": "AffectedObjectType",
+                "type": "string"
+              },
+              {
+                "name": "AssessmentId",
+                "type": "string"
+              },
+              {
+                "name": "Computer",
+                "type": "string"
+              },
+              {
+                "name": "CustomData",
+                "type": "string"
+              },
+              {
+                "name": "Description",
+                "type": "string"
+              },
+              {
+                "name": "FocusArea",
+                "type": "string"
+              },
+              {
+                "name": "FocusAreaId",
+                "type": "string"
+              },
+              {
+                "name": "Recommendation",
+                "type": "string"
+              },
+              {
+                "name": "RecommendationId",
+                "type": "string"
+              },
+              {
+                "name": "RecommendationResult",
+                "type": "string"
+              },
+              {
+                "name": "RecommendationWeight",
+                "type": "real"
+              },
+              {
+                "name": "SfBPool",
+                "type": "string"
+              },
+              {
+                "name": "SfBServer",
+                "type": "string"
+              },
+              {
+                "name": "SourceSystem",
+                "type": "string"
+              },
+              {
+                "name": "Technology",
+                "type": "string"
+              },
+              {
+                "name": "TimeGenerated",
+                "type": "datetime"
+              }
+            ]
+          }
+        },
+        "destinations": {
+          "logAnalytics": [
+            {
+              "workspaceResourceId": "[parameters('workspaceResourceId')]",
+              "name": "logAnalyticsWorkspace"
+            }
+          ]
+        },
+        "dataFlows": [
+          {
+            "streams": [
+              "Custom-SfBAssessmentRecommendation"
+            ],
+            "destinations": [
+              "logAnalyticsWorkspace"
+            ],
+            "transformKql": "source",
+            "outputStream": "Microsoft-SfBAssessmentRecommendation"
+          }
+        ],
+        "dataCollectionEndpointId": "[parameters('endpointResourceId')]"
+      }
+    }
+  ],
+  "outputs": {
+    "dataCollectionRuleId": {
+      "type": "string",
+      "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+    }
+  }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/SfBOnlineAssessmentRecommendation.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/SfBOnlineAssessmentRecommendation.json
@@ -1,0 +1,146 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "dataCollectionRuleName": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the name of the Data Collection Rule to create."
+      }
+    },
+    "location": {
+      "defaultValue": "[resourceGroup().location]",
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the location in which to create the Data Collection Rule."
+      }
+    },
+    "workspaceResourceId": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+      }
+    },
+    "endpointResourceId": {
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Data Collection Endpoint to use."
+      },
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Insights/dataCollectionRules",
+      "apiVersion": "2023-03-11",
+      "name": "[parameters('dataCollectionRuleName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "streamDeclarations": {
+          "Custom-SfBOnlineAssessmentRecommendation": {
+            "columns": [
+              {
+                "name": "ActionArea",
+                "type": "string"
+              },
+              {
+                "name": "ActionAreaId",
+                "type": "string"
+              },
+              {
+                "name": "AffectedObjectName",
+                "type": "string"
+              },
+              {
+                "name": "AffectedObjectType",
+                "type": "string"
+              },
+              {
+                "name": "AssessmentId",
+                "type": "string"
+              },
+              {
+                "name": "Computer",
+                "type": "string"
+              },
+              {
+                "name": "CustomData",
+                "type": "string"
+              },
+              {
+                "name": "Description",
+                "type": "string"
+              },
+              {
+                "name": "FocusArea",
+                "type": "string"
+              },
+              {
+                "name": "FocusAreaId",
+                "type": "string"
+              },
+              {
+                "name": "Recommendation",
+                "type": "string"
+              },
+              {
+                "name": "RecommendationId",
+                "type": "string"
+              },
+              {
+                "name": "RecommendationResult",
+                "type": "string"
+              },
+              {
+                "name": "RecommendationWeight",
+                "type": "real"
+              },
+              {
+                "name": "SfBOnlineOrganization",
+                "type": "string"
+              },
+              {
+                "name": "SourceSystem",
+                "type": "string"
+              },
+              {
+                "name": "Technology",
+                "type": "string"
+              },
+              {
+                "name": "TimeGenerated",
+                "type": "datetime"
+              }
+            ]
+          }
+        },
+        "destinations": {
+          "logAnalytics": [
+            {
+              "workspaceResourceId": "[parameters('workspaceResourceId')]",
+              "name": "logAnalyticsWorkspace"
+            }
+          ]
+        },
+        "dataFlows": [
+          {
+            "streams": [
+              "Custom-SfBOnlineAssessmentRecommendation"
+            ],
+            "destinations": [
+              "logAnalyticsWorkspace"
+            ],
+            "transformKql": "source",
+            "outputStream": "Microsoft-SfBOnlineAssessmentRecommendation"
+          }
+        ],
+        "dataCollectionEndpointId": "[parameters('endpointResourceId')]"
+      }
+    }
+  ],
+  "outputs": {
+    "dataCollectionRuleId": {
+      "type": "string",
+      "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+    }
+  }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/SharePointOnlineAssessmentRecommendation.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/SharePointOnlineAssessmentRecommendation.json
@@ -1,0 +1,146 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "dataCollectionRuleName": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the name of the Data Collection Rule to create."
+      }
+    },
+    "location": {
+      "defaultValue": "[resourceGroup().location]",
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the location in which to create the Data Collection Rule."
+      }
+    },
+    "workspaceResourceId": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+      }
+    },
+    "endpointResourceId": {
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Data Collection Endpoint to use."
+      },
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Insights/dataCollectionRules",
+      "apiVersion": "2023-03-11",
+      "name": "[parameters('dataCollectionRuleName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "streamDeclarations": {
+          "Custom-SharePointOnlineAssessmentRecommendation": {
+            "columns": [
+              {
+                "name": "ActionArea",
+                "type": "string"
+              },
+              {
+                "name": "ActionAreaId",
+                "type": "string"
+              },
+              {
+                "name": "AffectedObjectName",
+                "type": "string"
+              },
+              {
+                "name": "AffectedObjectType",
+                "type": "string"
+              },
+              {
+                "name": "AssessmentId",
+                "type": "string"
+              },
+              {
+                "name": "Computer",
+                "type": "string"
+              },
+              {
+                "name": "CustomData",
+                "type": "string"
+              },
+              {
+                "name": "Description",
+                "type": "string"
+              },
+              {
+                "name": "FocusArea",
+                "type": "string"
+              },
+              {
+                "name": "FocusAreaId",
+                "type": "string"
+              },
+              {
+                "name": "Recommendation",
+                "type": "string"
+              },
+              {
+                "name": "RecommendationId",
+                "type": "string"
+              },
+              {
+                "name": "RecommendationResult",
+                "type": "string"
+              },
+              {
+                "name": "RecommendationWeight",
+                "type": "real"
+              },
+              {
+                "name": "SharePointOnlineOrganization",
+                "type": "string"
+              },
+              {
+                "name": "SourceSystem",
+                "type": "string"
+              },
+              {
+                "name": "Technology",
+                "type": "string"
+              },
+              {
+                "name": "TimeGenerated",
+                "type": "datetime"
+              }
+            ]
+          }
+        },
+        "destinations": {
+          "logAnalytics": [
+            {
+              "workspaceResourceId": "[parameters('workspaceResourceId')]",
+              "name": "logAnalyticsWorkspace"
+            }
+          ]
+        },
+        "dataFlows": [
+          {
+            "streams": [
+              "Custom-SharePointOnlineAssessmentRecommendation"
+            ],
+            "destinations": [
+              "logAnalyticsWorkspace"
+            ],
+            "transformKql": "source",
+            "outputStream": "Microsoft-SharePointOnlineAssessmentRecommendation"
+          }
+        ],
+        "dataCollectionEndpointId": "[parameters('endpointResourceId')]"
+      }
+    }
+  ],
+  "outputs": {
+    "dataCollectionRuleId": {
+      "type": "string",
+      "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+    }
+  }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/Syslog.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/Syslog.json
@@ -1,0 +1,122 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "dataCollectionRuleName": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the name of the Data Collection Rule to create."
+      }
+    },
+    "location": {
+      "defaultValue": "[resourceGroup().location]",
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the location in which to create the Data Collection Rule."
+      }
+    },
+    "workspaceResourceId": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+      }
+    },
+    "endpointResourceId": {
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Data Collection Endpoint to use."
+      },
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Insights/dataCollectionRules",
+      "apiVersion": "2023-03-11",
+      "name": "[parameters('dataCollectionRuleName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "streamDeclarations": {
+          "Custom-Syslog": {
+            "columns": [
+              {
+                "name": "CollectorHostName",
+                "type": "string"
+              },
+              {
+                "name": "Computer",
+                "type": "string"
+              },
+              {
+                "name": "EventTime",
+                "type": "datetime"
+              },
+              {
+                "name": "Facility",
+                "type": "string"
+              },
+              {
+                "name": "HostIP",
+                "type": "string"
+              },
+              {
+                "name": "HostName",
+                "type": "string"
+              },
+              {
+                "name": "ProcessID",
+                "type": "int"
+              },
+              {
+                "name": "ProcessName",
+                "type": "string"
+              },
+              {
+                "name": "SeverityLevel",
+                "type": "string"
+              },
+              {
+                "name": "SourceSystem",
+                "type": "string"
+              },
+              {
+                "name": "SyslogMessage",
+                "type": "string"
+              },
+              {
+                "name": "TimeGenerated",
+                "type": "datetime"
+              }
+            ]
+          }
+        },
+        "destinations": {
+          "logAnalytics": [
+            {
+              "workspaceResourceId": "[parameters('workspaceResourceId')]",
+              "name": "logAnalyticsWorkspace"
+            }
+          ]
+        },
+        "dataFlows": [
+          {
+            "streams": [
+              "Custom-Syslog"
+            ],
+            "destinations": [
+              "logAnalyticsWorkspace"
+            ],
+            "transformKql": "source",
+            "outputStream": "Microsoft-Syslog"
+          }
+        ],
+        "dataCollectionEndpointId": "[parameters('endpointResourceId')]"
+      }
+    }
+  ],
+  "outputs": {
+    "dataCollectionRuleId": {
+      "type": "string",
+      "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+    }
+  }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/UCClient.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/UCClient.json
@@ -1,0 +1,126 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "dataCollectionRuleName": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the name of the Data Collection Rule to create."
+      }
+    },
+    "location": {
+      "defaultValue": "[resourceGroup().location]",
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the location in which to create the Data Collection Rule."
+      }
+    },
+    "workspaceResourceId": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+      }
+    },
+    "endpointResourceId": {
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Data Collection Endpoint to use."
+      },
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Insights/dataCollectionRules",
+      "apiVersion": "2023-03-11",
+      "name": "[parameters('dataCollectionRuleName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "streamDeclarations": {
+          "Custom-UCClient": {
+            "columns": [
+              {
+                "name": "AzureADDeviceId",
+                "type": "string"
+              },
+              {
+                "name": "AzureADTenantId",
+                "type": "string"
+              },
+              {
+                "name": "Computer",
+                "type": "string"
+              },
+              {
+                "name": "ComputerID",
+                "type": "string"
+              },
+              {
+                "name": "GlobalDeviceID",
+                "type": "string"
+              },
+              {
+                "name": "OSArchitecture",
+                "type": "string"
+              },
+              {
+                "name": "OSBuild",
+                "type": "string"
+              },
+              {
+                "name": "OSFamily",
+                "type": "string"
+              },
+              {
+                "name": "OSName",
+                "type": "string"
+              },
+              {
+                "name": "OSServicingBranch",
+                "type": "string"
+              },
+              {
+                "name": "OSVersion",
+                "type": "string"
+              },
+              {
+                "name": "SourceSystem",
+                "type": "string"
+              },
+              {
+                "name": "TimeGenerated",
+                "type": "datetime"
+              }
+            ]
+          }
+        },
+        "destinations": {
+          "logAnalytics": [
+            {
+              "workspaceResourceId": "[parameters('workspaceResourceId')]",
+              "name": "logAnalyticsWorkspace"
+            }
+          ]
+        },
+        "dataFlows": [
+          {
+            "streams": [
+              "Custom-UCClient"
+            ],
+            "destinations": [
+              "logAnalyticsWorkspace"
+            ],
+            "transformKql": "source",
+            "outputStream": "Microsoft-UCClient"
+          }
+        ],
+        "dataCollectionEndpointId": "[parameters('endpointResourceId')]"
+      }
+    }
+  ],
+  "outputs": {
+    "dataCollectionRuleId": {
+      "type": "string",
+      "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+    }
+  }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/UCClientReadinessStatus.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/UCClientReadinessStatus.json
@@ -1,0 +1,118 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "dataCollectionRuleName": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the name of the Data Collection Rule to create."
+      }
+    },
+    "location": {
+      "defaultValue": "[resourceGroup().location]",
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the location in which to create the Data Collection Rule."
+      }
+    },
+    "workspaceResourceId": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+      }
+    },
+    "endpointResourceId": {
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Data Collection Endpoint to use."
+      },
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Insights/dataCollectionRules",
+      "apiVersion": "2023-03-11",
+      "name": "[parameters('dataCollectionRuleName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "streamDeclarations": {
+          "Custom-UCClientReadinessStatus": {
+            "columns": [
+              {
+                "name": "AzureADDeviceId",
+                "type": "string"
+              },
+              {
+                "name": "AzureADTenantId",
+                "type": "string"
+              },
+              {
+                "name": "Computer",
+                "type": "string"
+              },
+              {
+                "name": "ComputerID",
+                "type": "string"
+              },
+              {
+                "name": "GlobalDeviceID",
+                "type": "string"
+              },
+              {
+                "name": "OSVersion",
+                "type": "string"
+              },
+              {
+                "name": "ReadinessReason",
+                "type": "string"
+              },
+              {
+                "name": "ReadinessStatus",
+                "type": "string"
+              },
+              {
+                "name": "SourceSystem",
+                "type": "string"
+              },
+              {
+                "name": "TargetVersion",
+                "type": "string"
+              },
+              {
+                "name": "TimeGenerated",
+                "type": "datetime"
+              }
+            ]
+          }
+        },
+        "destinations": {
+          "logAnalytics": [
+            {
+              "workspaceResourceId": "[parameters('workspaceResourceId')]",
+              "name": "logAnalyticsWorkspace"
+            }
+          ]
+        },
+        "dataFlows": [
+          {
+            "streams": [
+              "Custom-UCClientReadinessStatus"
+            ],
+            "destinations": [
+              "logAnalyticsWorkspace"
+            ],
+            "transformKql": "source",
+            "outputStream": "Microsoft-UCClientReadinessStatus"
+          }
+        ],
+        "dataCollectionEndpointId": "[parameters('endpointResourceId')]"
+      }
+    }
+  ],
+  "outputs": {
+    "dataCollectionRuleId": {
+      "type": "string",
+      "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+    }
+  }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/UCClientUpdateStatus.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/UCClientUpdateStatus.json
@@ -1,0 +1,130 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "dataCollectionRuleName": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the name of the Data Collection Rule to create."
+      }
+    },
+    "location": {
+      "defaultValue": "[resourceGroup().location]",
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the location in which to create the Data Collection Rule."
+      }
+    },
+    "workspaceResourceId": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+      }
+    },
+    "endpointResourceId": {
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Data Collection Endpoint to use."
+      },
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Insights/dataCollectionRules",
+      "apiVersion": "2023-03-11",
+      "name": "[parameters('dataCollectionRuleName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "streamDeclarations": {
+          "Custom-UCClientUpdateStatus": {
+            "columns": [
+              {
+                "name": "AzureADDeviceId",
+                "type": "string"
+              },
+              {
+                "name": "AzureADTenantId",
+                "type": "string"
+              },
+              {
+                "name": "Computer",
+                "type": "string"
+              },
+              {
+                "name": "ComputerID",
+                "type": "string"
+              },
+              {
+                "name": "EventData",
+                "type": "string"
+              },
+              {
+                "name": "EventID",
+                "type": "int"
+              },
+              {
+                "name": "GlobalDeviceID",
+                "type": "string"
+              },
+              {
+                "name": "OSVersion",
+                "type": "string"
+              },
+              {
+                "name": "SourceSystem",
+                "type": "string"
+              },
+              {
+                "name": "TimeGenerated",
+                "type": "datetime"
+              },
+              {
+                "name": "UpdateCategory",
+                "type": "string"
+              },
+              {
+                "name": "UpdateClassification",
+                "type": "string"
+              },
+              {
+                "name": "UpdateID",
+                "type": "string"
+              },
+              {
+                "name": "UpdateTitle",
+                "type": "string"
+              }
+            ]
+          }
+        },
+        "destinations": {
+          "logAnalytics": [
+            {
+              "workspaceResourceId": "[parameters('workspaceResourceId')]",
+              "name": "logAnalyticsWorkspace"
+            }
+          ]
+        },
+        "dataFlows": [
+          {
+            "streams": [
+              "Custom-UCClientUpdateStatus"
+            ],
+            "destinations": [
+              "logAnalyticsWorkspace"
+            ],
+            "transformKql": "source",
+            "outputStream": "Microsoft-UCClientUpdateStatus"
+          }
+        ],
+        "dataCollectionEndpointId": "[parameters('endpointResourceId')]"
+      }
+    }
+  ],
+  "outputs": {
+    "dataCollectionRuleId": {
+      "type": "string",
+      "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+    }
+  }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/UCDOAggregatedStatus.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/UCDOAggregatedStatus.json
@@ -1,0 +1,110 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "dataCollectionRuleName": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the name of the Data Collection Rule to create."
+      }
+    },
+    "location": {
+      "defaultValue": "[resourceGroup().location]",
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the location in which to create the Data Collection Rule."
+      }
+    },
+    "workspaceResourceId": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+      }
+    },
+    "endpointResourceId": {
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Data Collection Endpoint to use."
+      },
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Insights/dataCollectionRules",
+      "apiVersion": "2023-03-11",
+      "name": "[parameters('dataCollectionRuleName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "streamDeclarations": {
+          "Custom-UCDOAggregatedStatus": {
+            "columns": [
+              {
+                "name": "AzureADTenantId",
+                "type": "string"
+              },
+              {
+                "name": "BytesFromGroupPeers",
+                "type": "long"
+              },
+              {
+                "name": "BytesFromHttp",
+                "type": "long"
+              },
+              {
+                "name": "BytesFromInternetPeers",
+                "type": "long"
+              },
+              {
+                "name": "GlobalDeviceID",
+                "type": "string"
+              },
+              {
+                "name": "NoPeersForDownload",
+                "type": "int"
+              },
+              {
+                "name": "SourceSystem",
+                "type": "string"
+              },
+              {
+                "name": "TimeGenerated",
+                "type": "datetime"
+              },
+              {
+                "name": "TotalTimeForDownload",
+                "type": "long"
+              }
+            ]
+          }
+        },
+        "destinations": {
+          "logAnalytics": [
+            {
+              "workspaceResourceId": "[parameters('workspaceResourceId')]",
+              "name": "logAnalyticsWorkspace"
+            }
+          ]
+        },
+        "dataFlows": [
+          {
+            "streams": [
+              "Custom-UCDOAggregatedStatus"
+            ],
+            "destinations": [
+              "logAnalyticsWorkspace"
+            ],
+            "transformKql": "source",
+            "outputStream": "Microsoft-UCDOAggregatedStatus"
+          }
+        ],
+        "dataCollectionEndpointId": "[parameters('endpointResourceId')]"
+      }
+    }
+  ],
+  "outputs": {
+    "dataCollectionRuleId": {
+      "type": "string",
+      "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+    }
+  }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/UCDOStatus.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/UCDOStatus.json
@@ -1,0 +1,122 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "dataCollectionRuleName": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the name of the Data Collection Rule to create."
+      }
+    },
+    "location": {
+      "defaultValue": "[resourceGroup().location]",
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the location in which to create the Data Collection Rule."
+      }
+    },
+    "workspaceResourceId": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+      }
+    },
+    "endpointResourceId": {
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Data Collection Endpoint to use."
+      },
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Insights/dataCollectionRules",
+      "apiVersion": "2023-03-11",
+      "name": "[parameters('dataCollectionRuleName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "streamDeclarations": {
+          "Custom-UCDOStatus": {
+            "columns": [
+              {
+                "name": "AzureADTenantId",
+                "type": "string"
+              },
+              {
+                "name": "BytesFromGroupPeers",
+                "type": "long"
+              },
+              {
+                "name": "BytesFromHttp",
+                "type": "long"
+              },
+              {
+                "name": "BytesFromInternetPeers",
+                "type": "long"
+              },
+              {
+                "name": "Computer",
+                "type": "string"
+              },
+              {
+                "name": "ComputerID",
+                "type": "string"
+              },
+              {
+                "name": "ContentID",
+                "type": "string"
+              },
+              {
+                "name": "GlobalDeviceID",
+                "type": "string"
+              },
+              {
+                "name": "NoPeersForDownload",
+                "type": "int"
+              },
+              {
+                "name": "SourceSystem",
+                "type": "string"
+              },
+              {
+                "name": "TimeGenerated",
+                "type": "datetime"
+              },
+              {
+                "name": "TotalTimeForDownload",
+                "type": "long"
+              }
+            ]
+          }
+        },
+        "destinations": {
+          "logAnalytics": [
+            {
+              "workspaceResourceId": "[parameters('workspaceResourceId')]",
+              "name": "logAnalyticsWorkspace"
+            }
+          ]
+        },
+        "dataFlows": [
+          {
+            "streams": [
+              "Custom-UCDOStatus"
+            ],
+            "destinations": [
+              "logAnalyticsWorkspace"
+            ],
+            "transformKql": "source",
+            "outputStream": "Microsoft-UCDOStatus"
+          }
+        ],
+        "dataCollectionEndpointId": "[parameters('endpointResourceId')]"
+      }
+    }
+  ],
+  "outputs": {
+    "dataCollectionRuleId": {
+      "type": "string",
+      "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+    }
+  }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/UCDeviceAlert.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/UCDeviceAlert.json
@@ -1,0 +1,138 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "dataCollectionRuleName": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the name of the Data Collection Rule to create."
+      }
+    },
+    "location": {
+      "defaultValue": "[resourceGroup().location]",
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the location in which to create the Data Collection Rule."
+      }
+    },
+    "workspaceResourceId": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+      }
+    },
+    "endpointResourceId": {
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Data Collection Endpoint to use."
+      },
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Insights/dataCollectionRules",
+      "apiVersion": "2023-03-11",
+      "name": "[parameters('dataCollectionRuleName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "streamDeclarations": {
+          "Custom-UCDeviceAlert": {
+            "columns": [
+              {
+                "name": "AlertClassification",
+                "type": "string"
+              },
+              {
+                "name": "AlertData",
+                "type": "string"
+              },
+              {
+                "name": "AlertID",
+                "type": "string"
+              },
+              {
+                "name": "AlertRank",
+                "type": "int"
+              },
+              {
+                "name": "AlertStatus",
+                "type": "string"
+              },
+              {
+                "name": "AlertSubtype",
+                "type": "string"
+              },
+              {
+                "name": "AlertType",
+                "type": "string"
+              },
+              {
+                "name": "AzureADDeviceId",
+                "type": "string"
+              },
+              {
+                "name": "AzureADTenantId",
+                "type": "string"
+              },
+              {
+                "name": "Computer",
+                "type": "string"
+              },
+              {
+                "name": "ComputerID",
+                "type": "string"
+              },
+              {
+                "name": "Description",
+                "type": "string"
+              },
+              {
+                "name": "GlobalDeviceID",
+                "type": "string"
+              },
+              {
+                "name": "ResolvedTime",
+                "type": "datetime"
+              },
+              {
+                "name": "SourceSystem",
+                "type": "string"
+              },
+              {
+                "name": "TimeGenerated",
+                "type": "datetime"
+              }
+            ]
+          }
+        },
+        "destinations": {
+          "logAnalytics": [
+            {
+              "workspaceResourceId": "[parameters('workspaceResourceId')]",
+              "name": "logAnalyticsWorkspace"
+            }
+          ]
+        },
+        "dataFlows": [
+          {
+            "streams": [
+              "Custom-UCDeviceAlert"
+            ],
+            "destinations": [
+              "logAnalyticsWorkspace"
+            ],
+            "transformKql": "source",
+            "outputStream": "Microsoft-UCDeviceAlert"
+          }
+        ],
+        "dataCollectionEndpointId": "[parameters('endpointResourceId')]"
+      }
+    }
+  ],
+  "outputs": {
+    "dataCollectionRuleId": {
+      "type": "string",
+      "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+    }
+  }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/UCServiceUpdateStatus.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/UCServiceUpdateStatus.json
@@ -1,0 +1,114 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "dataCollectionRuleName": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the name of the Data Collection Rule to create."
+      }
+    },
+    "location": {
+      "defaultValue": "[resourceGroup().location]",
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the location in which to create the Data Collection Rule."
+      }
+    },
+    "workspaceResourceId": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+      }
+    },
+    "endpointResourceId": {
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Data Collection Endpoint to use."
+      },
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Insights/dataCollectionRules",
+      "apiVersion": "2023-03-11",
+      "name": "[parameters('dataCollectionRuleName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "streamDeclarations": {
+          "Custom-UCServiceUpdateStatus": {
+            "columns": [
+              {
+                "name": "AzureADTenantId",
+                "type": "string"
+              },
+              {
+                "name": "EventData",
+                "type": "string"
+              },
+              {
+                "name": "EventID",
+                "type": "int"
+              },
+              {
+                "name": "ServiceName",
+                "type": "string"
+              },
+              {
+                "name": "SourceSystem",
+                "type": "string"
+              },
+              {
+                "name": "TimeGenerated",
+                "type": "datetime"
+              },
+              {
+                "name": "UpdateCategory",
+                "type": "string"
+              },
+              {
+                "name": "UpdateClassification",
+                "type": "string"
+              },
+              {
+                "name": "UpdateID",
+                "type": "string"
+              },
+              {
+                "name": "UpdateTitle",
+                "type": "string"
+              }
+            ]
+          }
+        },
+        "destinations": {
+          "logAnalytics": [
+            {
+              "workspaceResourceId": "[parameters('workspaceResourceId')]",
+              "name": "logAnalyticsWorkspace"
+            }
+          ]
+        },
+        "dataFlows": [
+          {
+            "streams": [
+              "Custom-UCServiceUpdateStatus"
+            ],
+            "destinations": [
+              "logAnalyticsWorkspace"
+            ],
+            "transformKql": "source",
+            "outputStream": "Microsoft-UCServiceUpdateStatus"
+          }
+        ],
+        "dataCollectionEndpointId": "[parameters('endpointResourceId')]"
+      }
+    }
+  ],
+  "outputs": {
+    "dataCollectionRuleId": {
+      "type": "string",
+      "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+    }
+  }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/UCUpdateAlert.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/UCUpdateAlert.json
@@ -1,0 +1,138 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "dataCollectionRuleName": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the name of the Data Collection Rule to create."
+      }
+    },
+    "location": {
+      "defaultValue": "[resourceGroup().location]",
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the location in which to create the Data Collection Rule."
+      }
+    },
+    "workspaceResourceId": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+      }
+    },
+    "endpointResourceId": {
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Data Collection Endpoint to use."
+      },
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Insights/dataCollectionRules",
+      "apiVersion": "2023-03-11",
+      "name": "[parameters('dataCollectionRuleName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "streamDeclarations": {
+          "Custom-UCUpdateAlert": {
+            "columns": [
+              {
+                "name": "AlertClassification",
+                "type": "string"
+              },
+              {
+                "name": "AlertData",
+                "type": "string"
+              },
+              {
+                "name": "AlertID",
+                "type": "string"
+              },
+              {
+                "name": "AlertRank",
+                "type": "int"
+              },
+              {
+                "name": "AlertStatus",
+                "type": "string"
+              },
+              {
+                "name": "AlertSubtype",
+                "type": "string"
+              },
+              {
+                "name": "AlertType",
+                "type": "string"
+              },
+              {
+                "name": "AzureADTenantId",
+                "type": "string"
+              },
+              {
+                "name": "Description",
+                "type": "string"
+              },
+              {
+                "name": "ResolvedTime",
+                "type": "datetime"
+              },
+              {
+                "name": "SourceSystem",
+                "type": "string"
+              },
+              {
+                "name": "TimeGenerated",
+                "type": "datetime"
+              },
+              {
+                "name": "UpdateCategory",
+                "type": "string"
+              },
+              {
+                "name": "UpdateClassification",
+                "type": "string"
+              },
+              {
+                "name": "UpdateID",
+                "type": "string"
+              },
+              {
+                "name": "UpdateTitle",
+                "type": "string"
+              }
+            ]
+          }
+        },
+        "destinations": {
+          "logAnalytics": [
+            {
+              "workspaceResourceId": "[parameters('workspaceResourceId')]",
+              "name": "logAnalyticsWorkspace"
+            }
+          ]
+        },
+        "dataFlows": [
+          {
+            "streams": [
+              "Custom-UCUpdateAlert"
+            ],
+            "destinations": [
+              "logAnalyticsWorkspace"
+            ],
+            "transformKql": "source",
+            "outputStream": "Microsoft-UCUpdateAlert"
+          }
+        ],
+        "dataCollectionEndpointId": "[parameters('endpointResourceId')]"
+      }
+    }
+  ],
+  "outputs": {
+    "dataCollectionRuleId": {
+      "type": "string",
+      "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+    }
+  }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/WindowsClientAssessmentRecommendation.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/WindowsClientAssessmentRecommendation.json
@@ -1,0 +1,142 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "dataCollectionRuleName": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the name of the Data Collection Rule to create."
+      }
+    },
+    "location": {
+      "defaultValue": "[resourceGroup().location]",
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the location in which to create the Data Collection Rule."
+      }
+    },
+    "workspaceResourceId": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+      }
+    },
+    "endpointResourceId": {
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Data Collection Endpoint to use."
+      },
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Insights/dataCollectionRules",
+      "apiVersion": "2023-03-11",
+      "name": "[parameters('dataCollectionRuleName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "streamDeclarations": {
+          "Custom-WindowsClientAssessmentRecommendation": {
+            "columns": [
+              {
+                "name": "ActionArea",
+                "type": "string"
+              },
+              {
+                "name": "ActionAreaId",
+                "type": "string"
+              },
+              {
+                "name": "AffectedObjectName",
+                "type": "string"
+              },
+              {
+                "name": "AffectedObjectType",
+                "type": "string"
+              },
+              {
+                "name": "AssessmentId",
+                "type": "string"
+              },
+              {
+                "name": "Computer",
+                "type": "string"
+              },
+              {
+                "name": "CustomData",
+                "type": "string"
+              },
+              {
+                "name": "Description",
+                "type": "string"
+              },
+              {
+                "name": "FocusArea",
+                "type": "string"
+              },
+              {
+                "name": "FocusAreaId",
+                "type": "string"
+              },
+              {
+                "name": "Recommendation",
+                "type": "string"
+              },
+              {
+                "name": "RecommendationId",
+                "type": "string"
+              },
+              {
+                "name": "RecommendationResult",
+                "type": "string"
+              },
+              {
+                "name": "RecommendationWeight",
+                "type": "real"
+              },
+              {
+                "name": "SourceSystem",
+                "type": "string"
+              },
+              {
+                "name": "Technology",
+                "type": "string"
+              },
+              {
+                "name": "TimeGenerated",
+                "type": "datetime"
+              }
+            ]
+          }
+        },
+        "destinations": {
+          "logAnalytics": [
+            {
+              "workspaceResourceId": "[parameters('workspaceResourceId')]",
+              "name": "logAnalyticsWorkspace"
+            }
+          ]
+        },
+        "dataFlows": [
+          {
+            "streams": [
+              "Custom-WindowsClientAssessmentRecommendation"
+            ],
+            "destinations": [
+              "logAnalyticsWorkspace"
+            ],
+            "transformKql": "source",
+            "outputStream": "Microsoft-WindowsClientAssessmentRecommendation"
+          }
+        ],
+        "dataCollectionEndpointId": "[parameters('endpointResourceId')]"
+      }
+    }
+  ],
+  "outputs": {
+    "dataCollectionRuleId": {
+      "type": "string",
+      "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+    }
+  }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/WindowsEvent.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/WindowsEvent.json
@@ -1,0 +1,154 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "dataCollectionRuleName": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the name of the Data Collection Rule to create."
+      }
+    },
+    "location": {
+      "defaultValue": "[resourceGroup().location]",
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the location in which to create the Data Collection Rule."
+      }
+    },
+    "workspaceResourceId": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+      }
+    },
+    "endpointResourceId": {
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Data Collection Endpoint to use."
+      },
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Insights/dataCollectionRules",
+      "apiVersion": "2023-03-11",
+      "name": "[parameters('dataCollectionRuleName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "streamDeclarations": {
+          "Custom-WindowsEvent": {
+            "columns": [
+              {
+                "name": "Channel",
+                "type": "string"
+              },
+              {
+                "name": "Computer",
+                "type": "string"
+              },
+              {
+                "name": "Correlation",
+                "type": "string"
+              },
+              {
+                "name": "EventData",
+                "type": "dynamic"
+              },
+              {
+                "name": "EventID",
+                "type": "int"
+              },
+              {
+                "name": "EventLevel",
+                "type": "int"
+              },
+              {
+                "name": "EventLevelName",
+                "type": "string"
+              },
+              {
+                "name": "EventOriginId",
+                "type": "string"
+              },
+              {
+                "name": "EventRecordId",
+                "type": "string"
+              },
+              {
+                "name": "Keywords",
+                "type": "string"
+              },
+              {
+                "name": "ManagementGroupName",
+                "type": "string"
+              },
+              {
+                "name": "Opcode",
+                "type": "string"
+              },
+              {
+                "name": "Provider",
+                "type": "string"
+              },
+              {
+                "name": "RawEventData",
+                "type": "string"
+              },
+              {
+                "name": "SystemProcessId",
+                "type": "int"
+              },
+              {
+                "name": "SystemThreadId",
+                "type": "int"
+              },
+              {
+                "name": "SystemUserId",
+                "type": "string"
+              },
+              {
+                "name": "Task",
+                "type": "int"
+              },
+              {
+                "name": "TimeGenerated",
+                "type": "datetime"
+              },
+              {
+                "name": "Version",
+                "type": "int"
+              }
+            ]
+          }
+        },
+        "destinations": {
+          "logAnalytics": [
+            {
+              "workspaceResourceId": "[parameters('workspaceResourceId')]",
+              "name": "logAnalyticsWorkspace"
+            }
+          ]
+        },
+        "dataFlows": [
+          {
+            "streams": [
+              "Custom-WindowsEvent"
+            ],
+            "destinations": [
+              "logAnalyticsWorkspace"
+            ],
+            "transformKql": "source",
+            "outputStream": "Microsoft-WindowsEvent"
+          }
+        ],
+        "dataCollectionEndpointId": "[parameters('endpointResourceId')]"
+      }
+    }
+  ],
+  "outputs": {
+    "dataCollectionRuleId": {
+      "type": "string",
+      "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+    }
+  }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/WindowsServerAssessmentRecommendation.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(DCE)/WindowsServerAssessmentRecommendation.json
@@ -1,0 +1,142 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "dataCollectionRuleName": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the name of the Data Collection Rule to create."
+      }
+    },
+    "location": {
+      "defaultValue": "[resourceGroup().location]",
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the location in which to create the Data Collection Rule."
+      }
+    },
+    "workspaceResourceId": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+      }
+    },
+    "endpointResourceId": {
+      "metadata": {
+        "description": "Specifies the Azure resource ID of the Data Collection Endpoint to use."
+      },
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Insights/dataCollectionRules",
+      "apiVersion": "2023-03-11",
+      "name": "[parameters('dataCollectionRuleName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "streamDeclarations": {
+          "Custom-WindowsServerAssessmentRecommendation": {
+            "columns": [
+              {
+                "name": "ActionArea",
+                "type": "string"
+              },
+              {
+                "name": "ActionAreaId",
+                "type": "string"
+              },
+              {
+                "name": "AffectedObjectName",
+                "type": "string"
+              },
+              {
+                "name": "AffectedObjectType",
+                "type": "string"
+              },
+              {
+                "name": "AssessmentId",
+                "type": "string"
+              },
+              {
+                "name": "Computer",
+                "type": "string"
+              },
+              {
+                "name": "CustomData",
+                "type": "string"
+              },
+              {
+                "name": "Description",
+                "type": "string"
+              },
+              {
+                "name": "FocusArea",
+                "type": "string"
+              },
+              {
+                "name": "FocusAreaId",
+                "type": "string"
+              },
+              {
+                "name": "Recommendation",
+                "type": "string"
+              },
+              {
+                "name": "RecommendationId",
+                "type": "string"
+              },
+              {
+                "name": "RecommendationResult",
+                "type": "string"
+              },
+              {
+                "name": "RecommendationWeight",
+                "type": "real"
+              },
+              {
+                "name": "SourceSystem",
+                "type": "string"
+              },
+              {
+                "name": "Technology",
+                "type": "string"
+              },
+              {
+                "name": "TimeGenerated",
+                "type": "datetime"
+              }
+            ]
+          }
+        },
+        "destinations": {
+          "logAnalytics": [
+            {
+              "workspaceResourceId": "[parameters('workspaceResourceId')]",
+              "name": "logAnalyticsWorkspace"
+            }
+          ]
+        },
+        "dataFlows": [
+          {
+            "streams": [
+              "Custom-WindowsServerAssessmentRecommendation"
+            ],
+            "destinations": [
+              "logAnalyticsWorkspace"
+            ],
+            "transformKql": "source",
+            "outputStream": "Microsoft-WindowsServerAssessmentRecommendation"
+          }
+        ],
+        "dataCollectionEndpointId": "[parameters('endpointResourceId')]"
+      }
+    }
+  ],
+  "outputs": {
+    "dataCollectionRuleId": {
+      "type": "string",
+      "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+    }
+  }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/ADAssessmentRecommendation.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/ADAssessmentRecommendation.json
@@ -1,0 +1,142 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "dataCollectionRuleName": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the name of the Data Collection Rule to create."
+            }
+        },
+        "location": {
+            "defaultValue": "[resourceGroup().location]",
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the location in which to create the Data Collection Rule."
+            }
+        },
+        "workspaceResourceId": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+            }
+        }
+    },
+    "resources": [{
+        "type": "Microsoft.Insights/dataCollectionRules",
+        "apiVersion": "2023-03-11",
+        "name": "[parameters('dataCollectionRuleName')]",
+        "location": "[parameters('location')]",
+        "kind": "Direct",
+        "properties": {
+            "streamDeclarations": {
+                "Custom-ADAssessmentRecommendation": {
+                    "columns": [{
+                            "name": "ActionArea",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActionAreaId",
+                            "type": "guid"
+                        },
+                        {
+                            "name": "AffectedObjectName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AffectedObjectType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AssessmentId",
+                            "type": "guid"
+                        },
+                        {
+                            "name": "Computer",
+                            "type": "string"
+                        },
+                        {
+                            "name": "CustomData",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Description",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Domain",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DomainController",
+                            "type": "string"
+                        },
+                        {
+                            "name": "FocusArea",
+                            "type": "string"
+                        },
+                        {
+                            "name": "FocusAreaId",
+                            "type": "guid"
+                        },
+                        {
+                            "name": "Forest",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Recommendation",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RecommendationId",
+                            "type": "guid"
+                        },
+                        {
+                            "name": "RecommendationResult",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RecommendationWeight",
+                            "type": "real"
+                        },
+                        {
+                            "name": "SourceSystem",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Technology",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TimeGenerated",
+                            "type": "datetime"
+                        }
+                    ]
+                }
+            },
+            "destinations": {
+                "logAnalytics": [{
+                    "workspaceResourceId": "[parameters('workspaceResourceId')]",
+                    "name": "logAnalyticsWorkspace"
+                }]
+            },
+            "dataFlows": [{
+                    "streams": [
+                        "Custom-ADAssessmentRecommendation"
+                    ],
+                    "destinations": [
+                        "logAnalyticsWorkspace"
+                    ],
+                    "transformKql": "source",
+                    "outputStream": "Microsoft-ADAssessmentRecommendation"
+                }
+            ]
+        }
+    }],
+    "outputs": {
+        "dataCollectionRuleId": {
+            "type": "string",
+            "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+        }
+    }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/ADSecurityAssessmentRecommendation.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/ADSecurityAssessmentRecommendation.json
@@ -1,0 +1,158 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "dataCollectionRuleName": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the name of the Data Collection Rule to create."
+            }
+        },
+        "location": {
+            "defaultValue": "[resourceGroup().location]",
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the location in which to create the Data Collection Rule."
+            }
+        },
+        "workspaceResourceId": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+            }
+        }
+    },
+    "resources": [{
+        "type": "Microsoft.Insights/dataCollectionRules",
+        "apiVersion": "2023-03-11",
+        "name": "[parameters('dataCollectionRuleName')]",
+        "location": "[parameters('location')]",
+        "kind": "Direct",
+        "properties": {
+            "streamDeclarations": {
+                "Custom-ADSecurityAssessmentRecommendation": {
+                    "columns": [{
+                            "name": "ActionArea",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActionAreaId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AffectedObjectName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AffectedObjectType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AssessmentId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Computer",
+                            "type": "string"
+                        },
+                        {
+                            "name": "CustomData",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Description",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DNSServer",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DNSZone",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Domain",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DomainController",
+                            "type": "string"
+                        },
+                        {
+                            "name": "FocusArea",
+                            "type": "string"
+                        },
+                        {
+                            "name": "FocusAreaId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Forest",
+                            "type": "string"
+                        },
+                        {
+                            "name": "GroupPolicyObject",
+                            "type": "string"
+                        },
+                        {
+                            "name": "NamingContext",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Recommendation",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RecommendationId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RecommendationResult",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RecommendationWeight",
+                            "type": "real"
+                        },
+                        {
+                            "name": "SourceSystem",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Technology",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TimeGenerated",
+                            "type": "datetime"
+                        }
+                    ]
+                }
+            },
+            "destinations": {
+                "logAnalytics": [{
+                    "workspaceResourceId": "[parameters('workspaceResourceId')]",
+                    "name": "logAnalyticsWorkspace"
+                }]
+            },
+            "dataFlows": [{
+                    "streams": [
+                        "Custom-ADSecurityAssessmentRecommendation"
+                    ],
+                    "destinations": [
+                        "logAnalyticsWorkspace"
+                    ],
+                    "transformKql": "source",
+                    "outputStream": "Microsoft-ADSecurityAssessmentRecommendation"
+                }
+            ]
+        }
+    }],
+    "outputs": {
+        "dataCollectionRuleId": {
+            "type": "string",
+            "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+        }
+    }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/ASimAuditEventLogs.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/ASimAuditEventLogs.json
@@ -1,0 +1,550 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "dataCollectionRuleName": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the name of the Data Collection Rule to create."
+            }
+        },
+        "location": {
+            "defaultValue": "[resourceGroup().location]",
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the location in which to create the Data Collection Rule."
+            }
+        },
+        "workspaceResourceId": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+            }
+        }
+    },
+    "resources": [{
+        "type": "Microsoft.Insights/dataCollectionRules",
+        "apiVersion": "2023-03-11",
+        "name": "[parameters('dataCollectionRuleName')]",
+        "location": "[parameters('location')]",
+        "kind": "Direct",
+        "properties": {
+            "streamDeclarations": {
+                "Custom-ASimAuditEventLogs": {
+                    "columns": [{
+                            "name": "ActingAppId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActingAppName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActingAppType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActingOriginalAppType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActorOriginalUserType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActorScope",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActorScopeId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActorSessionId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActorUserAadId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActorUserId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActorUserIdType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActorUsername",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActorUsernameType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActorUserSid",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActorUserType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AdditionalFields",
+                            "type": "dynamic"
+                        },
+                        {
+                            "name": "DvcAction",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcDescription",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcDomain",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcDomainType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcFQDN",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcHostname",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcIdType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcInterface",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcIpAddr",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcMacAddr",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcOriginalAction",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcOs",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcOsVersion",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcScope",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcScopeId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcZone",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventCount",
+                            "type": "int"
+                        },
+                        {
+                            "name": "EventEndTime",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "EventMessage",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventOriginalResultDetails",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventOriginalSeverity",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventOriginalSubType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventOriginalType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventOriginalUid",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventOwner",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventProduct",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventProductVersion",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventReportUrl",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventResult",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventResultDetails",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventSchemaVersion",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventSeverity",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventStartTime",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "EventSubType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventVendor",
+                            "type": "string"
+                        },
+                        {
+                            "name": "HttpUserAgent",
+                            "type": "string"
+                        },
+                        {
+                            "name": "NewValue",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Object",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ObjectId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ObjectType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "OldValue",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Operation",
+                            "type": "string"
+                        },
+                        {
+                            "name": "OriginalObjectType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RuleName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RuleNumber",
+                            "type": "int"
+                        },
+                        {
+                            "name": "SourceSystem",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcDescription",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcDeviceType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcDomain",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcDomainType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcDvcId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcDvcIdType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcDvcScope",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcDvcScopeId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcFQDN",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcGeoCity",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcGeoCountry",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcGeoLatitude",
+                            "type": "real"
+                        },
+                        {
+                            "name": "SrcGeoLongitude",
+                            "type": "real"
+                        },
+                        {
+                            "name": "SrcGeoRegion",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcHostname",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcIpAddr",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcOriginalRiskLevel",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcPortNumber",
+                            "type": "int"
+                        },
+                        {
+                            "name": "SrcRiskLevel",
+                            "type": "int"
+                        },
+                        {
+                            "name": "TargetAppId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetAppName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetAppType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetDescription",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetDeviceType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetDomain",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetDomainType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetDvcId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetDvcIdType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetDvcOs",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetDvcScope",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetDvcScopeId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetFQDN",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetGeoCity",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetGeoCountry",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetGeoLatitude",
+                            "type": "real"
+                        },
+                        {
+                            "name": "TargetGeoLongitude",
+                            "type": "real"
+                        },
+                        {
+                            "name": "TargetGeoRegion",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetHostname",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetIpAddr",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetOriginalAppType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetOriginalRiskLevel",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetPortNumber",
+                            "type": "int"
+                        },
+                        {
+                            "name": "TargetRiskLevel",
+                            "type": "int"
+                        },
+                        {
+                            "name": "TargetUrl",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ThreatCategory",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ThreatConfidence",
+                            "type": "int"
+                        },
+                        {
+                            "name": "ThreatField",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ThreatFirstReportedTime",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "ThreatId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ThreatIpAddr",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ThreatIsActive",
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "ThreatLastReportedTime",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "ThreatName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ThreatOriginalConfidence",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ThreatOriginalRiskLevel",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ThreatRiskLevel",
+                            "type": "int"
+                        },
+                        {
+                            "name": "TimeGenerated",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "ValueType",
+                            "type": "string"
+                        }
+                    ]
+                }
+            },
+            "destinations": {
+                "logAnalytics": [{
+                    "workspaceResourceId": "[parameters('workspaceResourceId')]",
+                    "name": "logAnalyticsWorkspace"
+                }]
+            },
+            "dataFlows": [{
+                    "streams": [
+                        "Custom-ASimAuditEventLogs"
+                    ],
+                    "destinations": [
+                        "logAnalyticsWorkspace"
+                    ],
+                    "transformKql": "source",
+                    "outputStream": "Microsoft-ASimAuditEventLogs"
+                }
+            ]
+        }
+    }],
+    "outputs": {
+        "dataCollectionRuleId": {
+            "type": "string",
+            "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+        }
+    }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/ASimAuthenticationEventLogs.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/ASimAuthenticationEventLogs.json
@@ -1,0 +1,562 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "dataCollectionRuleName": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the name of the Data Collection Rule to create."
+            }
+        },
+        "location": {
+            "defaultValue": "[resourceGroup().location]",
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the location in which to create the Data Collection Rule."
+            }
+        },
+        "workspaceResourceId": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+            }
+        }
+    },
+    "resources": [{
+        "type": "Microsoft.Insights/dataCollectionRules",
+        "apiVersion": "2023-03-11",
+        "name": "[parameters('dataCollectionRuleName')]",
+        "location": "[parameters('location')]",
+        "kind": "Direct",
+        "properties": {
+            "streamDeclarations": {
+                "Custom-ASimAuthenticationEventLogs": {
+                    "columns": [{
+                            "name": "ActingAppId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActingAppName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActingAppType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActingOriginalAppType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActorOriginalUserType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActorScope",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActorScopeId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActorSessionId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActorUserId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActorUserIdType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActorUsername",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActorUsernameType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActorUserType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AdditionalFields",
+                            "type": "dynamic"
+                        },
+                        {
+                            "name": "DvcAction",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcDescription",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcDomain",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcDomainType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcFQDN",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcHostname",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcIdType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcInterface",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcIpAddr",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcMacAddr",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcOriginalAction",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcOs",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcOsVersion",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcScope",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcScopeId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcZone",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventCount",
+                            "type": "int"
+                        },
+                        {
+                            "name": "EventEndTime",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "EventMessage",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventOriginalResultDetails",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventOriginalSeverity",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventOriginalSubType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventOriginalType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventOriginalUid",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventOwner",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventProduct",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventProductVersion",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventReportUrl",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventResult",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventResultDetails",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventSchemaVersion",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventSeverity",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventStartTime",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "EventSubType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventVendor",
+                            "type": "string"
+                        },
+                        {
+                            "name": "HttpUserAgent",
+                            "type": "string"
+                        },
+                        {
+                            "name": "LogonMethod",
+                            "type": "string"
+                        },
+                        {
+                            "name": "LogonProtocol",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RuleName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RuleNumber",
+                            "type": "int"
+                        },
+                        {
+                            "name": "SourceSystem",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcDescription",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcDeviceType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcDomain",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcDomainType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcDvcId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcDvcIdType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcDvcOs",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcDvcScope",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcDvcScopeId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcFQDN",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcGeoCity",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcGeoCountry",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcGeoLatitude",
+                            "type": "real"
+                        },
+                        {
+                            "name": "SrcGeoLongitude",
+                            "type": "real"
+                        },
+                        {
+                            "name": "SrcGeoRegion",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcHostname",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcIpAddr",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcIsp",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcOriginalRiskLevel",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcPortNumber",
+                            "type": "int"
+                        },
+                        {
+                            "name": "SrcRiskLevel",
+                            "type": "int"
+                        },
+                        {
+                            "name": "TargetAppId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetAppName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetAppType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetDescription",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetDeviceType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetDomain",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetDomainType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetDvcId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetDvcIdType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetDvcOs",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetDvcScope",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetDvcScopeId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetFQDN",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetGeoCity",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetGeoCountry",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetGeoLatitude",
+                            "type": "real"
+                        },
+                        {
+                            "name": "TargetGeoLongitude",
+                            "type": "real"
+                        },
+                        {
+                            "name": "TargetGeoRegion",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetHostname",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetIpAddr",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetOriginalAppType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetOriginalRiskLevel",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetOriginalUserType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetPortNumber",
+                            "type": "int"
+                        },
+                        {
+                            "name": "TargetRiskLevel",
+                            "type": "int"
+                        },
+                        {
+                            "name": "TargetSessionId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetUrl",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetUserId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetUserIdType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetUsername",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetUsernameType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetUserScope",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetUserScopeId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetUserType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ThreatCategory",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ThreatConfidence",
+                            "type": "int"
+                        },
+                        {
+                            "name": "ThreatField",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ThreatFirstReportedTime",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "ThreatId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ThreatIpAddr",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ThreatIsActive",
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "ThreatLastReportedTime",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "ThreatName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ThreatOriginalConfidence",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ThreatOriginalRiskLevel",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ThreatRiskLevel",
+                            "type": "int"
+                        },
+                        {
+                            "name": "TimeGenerated",
+                            "type": "datetime"
+                        }
+                    ]
+                }
+            },
+            "destinations": {
+                "logAnalytics": [{
+                    "workspaceResourceId": "[parameters('workspaceResourceId')]",
+                    "name": "logAnalyticsWorkspace"
+                }]
+            },
+            "dataFlows": [{
+                    "streams": [
+                        "Custom-ASimAuthenticationEventLogs"
+                    ],
+                    "destinations": [
+                        "logAnalyticsWorkspace"
+                    ],
+                    "transformKql": "source",
+                    "outputStream": "Microsoft-ASimAuthenticationEventLogs"
+                }
+            ]
+        }
+    }],
+    "outputs": {
+        "dataCollectionRuleId": {
+            "type": "string",
+            "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+        }
+    }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/ASimDhcpEventLogs.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/ASimDhcpEventLogs.json
@@ -1,0 +1,442 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "dataCollectionRuleName": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the name of the Data Collection Rule to create."
+            }
+        },
+        "location": {
+            "defaultValue": "[resourceGroup().location]",
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the location in which to create the Data Collection Rule."
+            }
+        },
+        "workspaceResourceId": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+            }
+        }
+    },
+    "resources": [{
+        "type": "Microsoft.Insights/dataCollectionRules",
+        "apiVersion": "2023-03-11",
+        "name": "[parameters('dataCollectionRuleName')]",
+        "location": "[parameters('location')]",
+        "kind": "Direct",
+        "properties": {
+            "streamDeclarations": {
+                "Custom-ASimDhcpEventLogs": {
+                    "columns": [{
+                            "name": "AdditionalFields",
+                            "type": "dynamic"
+                        },
+                        {
+                            "name": "DhcpCircuitId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DhcpLeaseDuration",
+                            "type": "int"
+                        },
+                        {
+                            "name": "DhcpSessionDuration",
+                            "type": "int"
+                        },
+                        {
+                            "name": "DhcpSessionId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DhcpSrcDHCId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DhcpSubscriberId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DhcpUserClass",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DhcpUserClassId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DhcpVendorClass",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DhcpVendorClassId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcAction",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcDescription",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcDomain",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcDomainType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcFQDN",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcHostname",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcIdType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcInterface",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcIpAddr",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcMacAddr",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcOriginalAction",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcOs",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcOsVersion",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcScope",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcScopeId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcZone",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventCount",
+                            "type": "int"
+                        },
+                        {
+                            "name": "EventEndTime",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "EventMessage",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventOriginalResultDetails",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventOriginalSeverity",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventOriginalSubType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventOriginalType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventOriginalUid",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventOwner",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventProduct",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventProductVersion",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventReportUrl",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventResult",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventResultDetails",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventSchema",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventSchemaVersion",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventSeverity",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventStartTime",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "EventSubType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventVendor",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RequestedIpAddr",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RuleName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RuleNumber",
+                            "type": "int"
+                        },
+                        {
+                            "name": "SourceSystem",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcDescription",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcDeviceType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcDomain",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcDomainType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcDvcId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcDvcIdType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcDvcScope",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcDvcScopeId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcFQDN",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcGeoCity",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcGeoCountry",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcGeoLatitude",
+                            "type": "real"
+                        },
+                        {
+                            "name": "SrcGeoLongitude",
+                            "type": "real"
+                        },
+                        {
+                            "name": "SrcGeoRegion",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcHostname",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcIpAddr",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcMacAddr",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcOriginalRiskLevel",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcOriginalUserType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcPortNumber",
+                            "type": "int"
+                        },
+                        {
+                            "name": "SrcRiskLevel",
+                            "type": "int"
+                        },
+                        {
+                            "name": "SrcUserId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcUserIdType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcUsername",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcUsernameType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcUserScope",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcUserScopeId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcUserSessionId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcUserType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcUserUid",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ThreatCategory",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ThreatConfidence",
+                            "type": "int"
+                        },
+                        {
+                            "name": "ThreatField",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ThreatFirstReportedTime",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "ThreatId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ThreatIsActive",
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "ThreatLastReportedTime",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "ThreatName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ThreatOriginalConfidence",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ThreatOriginalRiskLevel",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ThreatRiskLevel",
+                            "type": "int"
+                        },
+                        {
+                            "name": "TimeGenerated",
+                            "type": "datetime"
+                        }
+                    ]
+                }
+            },
+            "destinations": {
+                "logAnalytics": [{
+                    "workspaceResourceId": "[parameters('workspaceResourceId')]",
+                    "name": "logAnalyticsWorkspace"
+                }]
+            },
+            "dataFlows": [{
+                    "streams": [
+                        "Custom-ASimDhcpEventLogs"
+                    ],
+                    "destinations": [
+                        "logAnalyticsWorkspace"
+                    ],
+                    "transformKql": "source",
+                    "outputStream": "Microsoft-ASimDhcpEventLogs"
+                }
+            ]
+        }
+    }],
+    "outputs": {
+        "dataCollectionRuleId": {
+            "type": "string",
+            "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+        }
+    }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/ASimDnsActivityLogs.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/ASimDnsActivityLogs.json
@@ -1,0 +1,586 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "dataCollectionRuleName": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the name of the Data Collection Rule to create."
+            }
+        },
+        "location": {
+            "defaultValue": "[resourceGroup().location]",
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the location in which to create the Data Collection Rule."
+            }
+        },
+        "workspaceResourceId": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+            }
+        }
+    },
+    "resources": [{
+        "type": "Microsoft.Insights/dataCollectionRules",
+        "apiVersion": "2023-03-11",
+        "name": "[parameters('dataCollectionRuleName')]",
+        "location": "[parameters('location')]",
+        "kind": "Direct",
+        "properties": {
+            "streamDeclarations": {
+                "Custom-ASimDnsActivityLogs": {
+                    "columns": [{
+                            "name": "AdditionalFields",
+                            "type": "dynamic"
+                        },
+                        {
+                            "name": "DnsFlags",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DnsFlagsAuthenticated",
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "DnsFlagsAuthoritative",
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "DnsFlagsCheckingDisabled",
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "DnsFlagsRecursionAvailable",
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "DnsFlagsRecursionDesired",
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "DnsFlagsTruncated",
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "DnsFlagsZ",
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "DnsNetworkDuration",
+                            "type": "int"
+                        },
+                        {
+                            "name": "DnsQuery",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DnsQueryClass",
+                            "type": "int"
+                        },
+                        {
+                            "name": "DnsQueryClassName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DnsQueryType",
+                            "type": "int"
+                        },
+                        {
+                            "name": "DnsQueryTypeName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DnsResponseCode",
+                            "type": "int"
+                        },
+                        {
+                            "name": "DnsResponseIpCity",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DnsResponseIpCountry",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DnsResponseIpLatitude",
+                            "type": "real"
+                        },
+                        {
+                            "name": "DnsResponseIpLongitude",
+                            "type": "real"
+                        },
+                        {
+                            "name": "DnsResponseIpRegion",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DnsResponseName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DnsSessionId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Dst",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DstDescription",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DstDeviceType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DstDomain",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DstDomainType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DstDvcId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DstDvcIdType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DstDvcScope",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DstDvcScopeId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DstFQDN",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DstGeoCity",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DstGeoCountry",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DstGeoLatitude",
+                            "type": "real"
+                        },
+                        {
+                            "name": "DstGeoLongitude",
+                            "type": "real"
+                        },
+                        {
+                            "name": "DstGeoRegion",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DstHostname",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DstIpAddr",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DstOriginalRiskLevel",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DstPortNumber",
+                            "type": "int"
+                        },
+                        {
+                            "name": "DstRiskLevel",
+                            "type": "int"
+                        },
+                        {
+                            "name": "Dvc",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcAction",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcDescription",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcDomain",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcDomainType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcFQDN",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcHostname",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcIdType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcInterface",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcIpAddr",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcMacAddr",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcOriginalAction",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcOs",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcOsVersion",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcScope",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcScopeId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcZone",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventCount",
+                            "type": "int"
+                        },
+                        {
+                            "name": "EventEndTime",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "EventMessage",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventOriginalSeverity",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventOriginalType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventOriginalUid",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventOwner",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventProduct",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventProductVersion",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventReportUrl",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventResult",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventResultDetails",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventSchemaVersion",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventSeverity",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventStartTime",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "EventSubType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventVendor",
+                            "type": "string"
+                        },
+                        {
+                            "name": "NetworkProtocol",
+                            "type": "string"
+                        },
+                        {
+                            "name": "NetworkProtocolVersion",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RuleName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RuleNumber",
+                            "type": "int"
+                        },
+                        {
+                            "name": "SourceSystem",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Src",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcDescription",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcDeviceType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcDomain",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcDomainType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcDvcId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcDvcIdType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcDvcScope",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcDvcScopeId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcFQDN",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcGeoCity",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcGeoCountry",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcGeoLatitude",
+                            "type": "real"
+                        },
+                        {
+                            "name": "SrcGeoLongitude",
+                            "type": "real"
+                        },
+                        {
+                            "name": "SrcGeoRegion",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcHostname",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcIpAddr",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcOriginalRiskLevel",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcOriginalUserType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcPortNumber",
+                            "type": "int"
+                        },
+                        {
+                            "name": "SrcProcessGuid",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcProcessId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcProcessName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcRiskLevel",
+                            "type": "int"
+                        },
+                        {
+                            "name": "SrcUserId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcUserIdType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcUsername",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcUsernameType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcUserScope",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcUserScopeId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcUserSessionId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcUserType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ThreatCategory",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ThreatConfidence",
+                            "type": "int"
+                        },
+                        {
+                            "name": "ThreatField",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ThreatFirstReportedTime",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "ThreatId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ThreatIpAddr",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ThreatIsActive",
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "ThreatLastReportedTime",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "ThreatName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ThreatOriginalConfidence",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ThreatOriginalRiskLevel",
+                            "type": "int"
+                        },
+                        {
+                            "name": "ThreatRiskLevel",
+                            "type": "int"
+                        },
+                        {
+                            "name": "TimeGenerated",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "TransactionIdHex",
+                            "type": "string"
+                        },
+                        {
+                            "name": "UrlCategory",
+                            "type": "string"
+                        }
+                    ]
+                }
+            },
+            "destinations": {
+                "logAnalytics": [{
+                    "workspaceResourceId": "[parameters('workspaceResourceId')]",
+                    "name": "logAnalyticsWorkspace"
+                }]
+            },
+            "dataFlows": [{
+                    "streams": [
+                        "Custom-ASimDnsActivityLogs"
+                    ],
+                    "destinations": [
+                        "logAnalyticsWorkspace"
+                    ],
+                    "transformKql": "source",
+                    "outputStream": "Microsoft-ASimDnsActivityLogs"
+                }
+            ]
+        }
+    }],
+    "outputs": {
+        "dataCollectionRuleId": {
+            "type": "string",
+            "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+        }
+    }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/ASimFileEventLogs.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/ASimFileEventLogs.json
@@ -1,0 +1,550 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "dataCollectionRuleName": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the name of the Data Collection Rule to create."
+            }
+        },
+        "location": {
+            "defaultValue": "[resourceGroup().location]",
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the location in which to create the Data Collection Rule."
+            }
+        },
+        "workspaceResourceId": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+            }
+        }
+    },
+    "resources": [{
+        "type": "Microsoft.Insights/dataCollectionRules",
+        "apiVersion": "2023-03-11",
+        "name": "[parameters('dataCollectionRuleName')]",
+        "location": "[parameters('location')]",
+        "kind": "Direct",
+        "properties": {
+            "streamDeclarations": {
+                "Custom-ASimFileEventLogs": {
+                    "columns": [{
+                            "name": "ActingProcessCommandLine",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActingProcessGuid",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActingProcessId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActingProcessName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActorOriginalUserType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActorScope",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActorScopeId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActorSessionId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActorUserAadId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActorUserId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActorUserIdType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActorUsername",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActorUsernameType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActorUserSid",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActorUserType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AdditionalFields",
+                            "type": "dynamic"
+                        },
+                        {
+                            "name": "DvcAction",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcDescription",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcDomain",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcDomainType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcFQDN",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcHostname",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcIdType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcInterface",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcIpAddr",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcMacAddr",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcOriginalAction",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcOs",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcOsVersion",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcScope",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcScopeId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcZone",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventCount",
+                            "type": "int"
+                        },
+                        {
+                            "name": "EventEndTime",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "EventMessage",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventOriginalResultDetails",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventOriginalSeverity",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventOriginalSubType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventOriginalType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventOriginalUid",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventOwner",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventProduct",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventProductVersion",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventReportUrl",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventResult",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventResultDetails",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventSchema",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventSchemaVersion",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventSeverity",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventStartTime",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "EventSubType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventVendor",
+                            "type": "string"
+                        },
+                        {
+                            "name": "HashType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "HttpUserAgent",
+                            "type": "string"
+                        },
+                        {
+                            "name": "NetworkApplicationProtocol",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RuleName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RuleNumber",
+                            "type": "int"
+                        },
+                        {
+                            "name": "SourceSystem",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcDescription",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcDeviceType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcDomain",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcDomainType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcDvcId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcDvcIdType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcDvcScope",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcDvcScopeId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcFileCreationTime",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "SrcFileDirectory",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcFileExtension",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcFileMD5",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcFileMimeType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcFileName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcFilePath",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcFilePathType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcFileSHA1",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcFileSHA256",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcFileSHA512",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcFileSize",
+                            "type": "long"
+                        },
+                        {
+                            "name": "SrcFQDN",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcGeoCity",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcGeoCountry",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcGeoLatitude",
+                            "type": "real"
+                        },
+                        {
+                            "name": "SrcGeoLongitude",
+                            "type": "real"
+                        },
+                        {
+                            "name": "SrcGeoRegion",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcHostname",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcIpAddr",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcMacAddr",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcOriginalRiskLevel",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcPortNumber",
+                            "type": "int"
+                        },
+                        {
+                            "name": "SrcRiskLevel",
+                            "type": "int"
+                        },
+                        {
+                            "name": "TargetAppId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetAppName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetAppType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetFileCreationTime",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "TargetFileDirectory",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetFileExtension",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetFileMD5",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetFileMimeType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetFileName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetFilePath",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetFilePathType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetFileSHA1",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetFileSHA256",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetFileSHA512",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetFileSize",
+                            "type": "long"
+                        },
+                        {
+                            "name": "TargetOriginalAppType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetUrl",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ThreatCategory",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ThreatConfidence",
+                            "type": "int"
+                        },
+                        {
+                            "name": "ThreatField",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ThreatFilePath",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ThreatFirstReportedTime",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "ThreatId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ThreatIsActive",
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "ThreatLastReportedTime",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "ThreatName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ThreatOriginalConfidence",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ThreatOriginalRiskLevel",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ThreatRiskLevel",
+                            "type": "int"
+                        },
+                        {
+                            "name": "TimeGenerated",
+                            "type": "datetime"
+                        }
+                    ]
+                }
+            },
+            "destinations": {
+                "logAnalytics": [{
+                    "workspaceResourceId": "[parameters('workspaceResourceId')]",
+                    "name": "logAnalyticsWorkspace"
+                }]
+            },
+            "dataFlows": [{
+                    "streams": [
+                        "Custom-ASimFileEventLogs"
+                    ],
+                    "destinations": [
+                        "logAnalyticsWorkspace"
+                    ],
+                    "transformKql": "source",
+                    "outputStream": "Microsoft-ASimFileEventLogs"
+                }
+            ]
+        }
+    }],
+    "outputs": {
+        "dataCollectionRuleId": {
+            "type": "string",
+            "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+        }
+    }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/ASimNetworkSessionLogs.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/ASimNetworkSessionLogs.json
@@ -1,0 +1,622 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "dataCollectionRuleName": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the name of the Data Collection Rule to create."
+            }
+        },
+        "location": {
+            "defaultValue": "[resourceGroup().location]",
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the location in which to create the Data Collection Rule."
+            }
+        },
+        "workspaceResourceId": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+            }
+        }
+    },
+    "resources": [{
+        "type": "Microsoft.Insights/dataCollectionRules",
+        "apiVersion": "2023-03-11",
+        "name": "[parameters('dataCollectionRuleName')]",
+        "location": "[parameters('location')]",
+        "kind": "Direct",
+        "properties": {
+            "streamDeclarations": {
+                "Custom-ASimNetworkSessionLogs": {
+                    "columns": [{
+                            "name": "AdditionalFields",
+                            "type": "dynamic"
+                        },
+                        {
+                            "name": "DstAppId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DstAppName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DstAppType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DstBytes",
+                            "type": "long"
+                        },
+                        {
+                            "name": "DstDescription",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DstDeviceType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DstDomain",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DstDomainType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DstDvcId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DstDvcIdType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DstFQDN",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DstGeoCity",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DstGeoCountry",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DstGeoLatitude",
+                            "type": "real"
+                        },
+                        {
+                            "name": "DstGeoLongitude",
+                            "type": "real"
+                        },
+                        {
+                            "name": "DstGeoRegion",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DstHostname",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DstInterfaceGuid",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DstInterfaceName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DstIpAddr",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DstMacAddr",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DstNatIpAddr",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DstNatPortNumber",
+                            "type": "int"
+                        },
+                        {
+                            "name": "DstOriginalUserType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DstPackets",
+                            "type": "long"
+                        },
+                        {
+                            "name": "DstPortNumber",
+                            "type": "int"
+                        },
+                        {
+                            "name": "DstSubscriptionId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DstUserId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DstUserIdType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DstUsername",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DstUsernameType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DstUserType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DstVlanId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DstZone",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Dvc",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcAction",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcDescription",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcDomain",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcDomainType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcFQDN",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcHostname",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcIdType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcInboundInterface",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcInterface",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcIpAddr",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcMacAddr",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcOriginalAction",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcOs",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcOsVersion",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcOutboundInterface",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcSubscriptionId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcZone",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventCount",
+                            "type": "int"
+                        },
+                        {
+                            "name": "EventEndTime",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "EventMessage",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventOriginalResultDetails",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventOriginalSeverity",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventOriginalSubType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventOriginalType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventOriginalUid",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventProduct",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventProductVersion",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventReportUrl",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventResult",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventResultDetails",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventSchemaVersion",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventSeverity",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventStartTime",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "EventSubType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventVendor",
+                            "type": "string"
+                        },
+                        {
+                            "name": "NetworkApplicationProtocol",
+                            "type": "string"
+                        },
+                        {
+                            "name": "NetworkBytes",
+                            "type": "long"
+                        },
+                        {
+                            "name": "NetworkConnectionHistory",
+                            "type": "string"
+                        },
+                        {
+                            "name": "NetworkDirection",
+                            "type": "string"
+                        },
+                        {
+                            "name": "NetworkDuration",
+                            "type": "int"
+                        },
+                        {
+                            "name": "NetworkIcmpCode",
+                            "type": "int"
+                        },
+                        {
+                            "name": "NetworkIcmpType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "NetworkPackets",
+                            "type": "long"
+                        },
+                        {
+                            "name": "NetworkProtocol",
+                            "type": "string"
+                        },
+                        {
+                            "name": "NetworkProtocolVersion",
+                            "type": "string"
+                        },
+                        {
+                            "name": "NetworkRuleName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "NetworkRuleNumber",
+                            "type": "int"
+                        },
+                        {
+                            "name": "NetworkSessionId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SourceSystem",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcAppId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcAppName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcAppType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcBytes",
+                            "type": "long"
+                        },
+                        {
+                            "name": "SrcDescription",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcDeviceType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcDomain",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcDomainType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcDvcId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcDvcIdType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcFQDN",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcGeoCity",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcGeoCountry",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcGeoLatitude",
+                            "type": "real"
+                        },
+                        {
+                            "name": "SrcGeoLongitude",
+                            "type": "real"
+                        },
+                        {
+                            "name": "SrcGeoRegion",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcHostname",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcInterfaceGuid",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcInterfaceName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcIpAddr",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcMacAddr",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcNatIpAddr",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcNatPortNumber",
+                            "type": "int"
+                        },
+                        {
+                            "name": "SrcOriginalUserType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcPackets",
+                            "type": "long"
+                        },
+                        {
+                            "name": "SrcPortNumber",
+                            "type": "int"
+                        },
+                        {
+                            "name": "SrcSubscriptionId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcUserId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcUserIdType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcUsername",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcUsernameType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcUserType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcVlanId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcZone",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TcpFlagsAck",
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "TcpFlagsFin",
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "TcpFlagsPsh",
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "TcpFlagsRst",
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "TcpFlagsSyn",
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "TcpFlagsUrg",
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "ThreatCategory",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ThreatConfidence",
+                            "type": "int"
+                        },
+                        {
+                            "name": "ThreatField",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ThreatFirstReportedTime",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "ThreatId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ThreatIpAddr",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ThreatIsActive",
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "ThreatLastReportedTime",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "ThreatName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ThreatOriginalConfidence",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ThreatOriginalRiskLevel",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ThreatRiskLevel",
+                            "type": "int"
+                        },
+                        {
+                            "name": "TimeGenerated",
+                            "type": "datetime"
+                        }
+                    ]
+                }
+            },
+            "destinations": {
+                "logAnalytics": [{
+                    "workspaceResourceId": "[parameters('workspaceResourceId')]",
+                    "name": "logAnalyticsWorkspace"
+                }]
+            },
+            "dataFlows": [{
+                    "streams": [
+                        "Custom-ASimNetworkSessionLogs"
+                    ],
+                    "destinations": [
+                        "logAnalyticsWorkspace"
+                    ],
+                    "transformKql": "source",
+                    "outputStream": "Microsoft-ASimNetworkSessionLogs"
+                }
+            ]
+        }
+    }],
+    "outputs": {
+        "dataCollectionRuleId": {
+            "type": "string",
+            "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+        }
+    }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/ASimProcessEventLogs.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/ASimProcessEventLogs.json
@@ -1,0 +1,602 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "dataCollectionRuleName": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the name of the Data Collection Rule to create."
+            }
+        },
+        "location": {
+            "defaultValue": "[resourceGroup().location]",
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the location in which to create the Data Collection Rule."
+            }
+        },
+        "workspaceResourceId": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+            }
+        }
+    },
+    "resources": [{
+        "type": "Microsoft.Insights/dataCollectionRules",
+        "apiVersion": "2023-03-11",
+        "name": "[parameters('dataCollectionRuleName')]",
+        "location": "[parameters('location')]",
+        "kind": "Direct",
+        "properties": {
+            "streamDeclarations": {
+                "Custom-ASimProcessEventLogs": {
+                    "columns": [{
+                            "name": "ActingProcessCommandLine",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActingProcessCreationTime",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "ActingProcessFileCompany",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActingProcessFileDescription",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActingProcessFileInternalName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActingProcessFilename",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActingProcessFileOriginalName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActingProcessFileProduct",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActingProcessFileSize",
+                            "type": "long"
+                        },
+                        {
+                            "name": "ActingProcessFileVersion",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActingProcessGuid",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActingProcessId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActingProcessIMPHASH",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActingProcessInjectedAddress",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActingProcessIntegrityLevel",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActingProcessIsHidden",
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "ActingProcessMD5",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActingProcessName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActingProcessSHA1",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActingProcessSHA256",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActingProcessSHA512",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActingProcessTokenElevation",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActorOriginalUserType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActorScope",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActorScopeId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActorSessionId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActorUserId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActorUserIdType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActorUsername",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActorUsernameType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActorUserType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AdditionalFields",
+                            "type": "dynamic"
+                        },
+                        {
+                            "name": "DvcAction",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcDescription",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcDomain",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcDomainType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcFQDN",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcHostname",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcIdType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcInterface",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcIpAddr",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcMacAddr",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcOriginalAction",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcOs",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcOsVersion",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcScope",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcScopeId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcZone",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventCount",
+                            "type": "int"
+                        },
+                        {
+                            "name": "EventEndTime",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "EventMessage",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventOriginalResultDetails",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventOriginalSeverity",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventOriginalSubType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventOriginalType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventOriginalUid",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventOwner",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventProduct",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventProductVersion",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventReportUrl",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventResult",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventResultDetails",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventSchemaVersion",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventSeverity",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventStartTime",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "EventSubType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventVendor",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ParentProcessCreationTime",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "ParentProcessFileCompany",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ParentProcessFileDescription",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ParentProcessFileProduct",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ParentProcessFileVersion",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ParentProcessGuid",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ParentProcessId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ParentProcessIMPHASH",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ParentProcessInjectedAddress",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ParentProcessIntegrityLevel",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ParentProcessIsHidden",
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "ParentProcessMD5",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ParentProcessName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ParentProcessSHA1",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ParentProcessSHA256",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ParentProcessSHA512",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ParentProcessTokenElevation",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RuleName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RuleNumber",
+                            "type": "int"
+                        },
+                        {
+                            "name": "SourceSystem",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetOriginalUserType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetProcessCommandLine",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetProcessCreationTime",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "TargetProcessCurrentDirectory",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetProcessFileCompany",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetProcessFileDescription",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetProcessFileInternalName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetProcessFilename",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetProcessFileOriginalName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetProcessFileProduct",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetProcessFileSize",
+                            "type": "long"
+                        },
+                        {
+                            "name": "TargetProcessFileVersion",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetProcessGuid",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetProcessId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetProcessIMPHASH",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetProcessInjectedAddress",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetProcessIntegrityLevel",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetProcessIsHidden",
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "TargetProcessMD5",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetProcessName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetProcessSHA1",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetProcessSHA256",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetProcessSHA512",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetProcessStatusCode",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetProcessTokenElevation",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetScope",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetScopeId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetUserId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetUserIdType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetUsername",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetUsernameType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetUserSessionGuid",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetUserSessionId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetUserType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ThreatCategory",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ThreatConfidence",
+                            "type": "int"
+                        },
+                        {
+                            "name": "ThreatField",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ThreatFirstReportedTime",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "ThreatId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ThreatIsActive",
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "ThreatLastReportedTime",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "ThreatName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ThreatOriginalConfidence",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ThreatOriginalRiskLevel",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ThreatRiskLevel",
+                            "type": "int"
+                        },
+                        {
+                            "name": "TimeGenerated",
+                            "type": "datetime"
+                        }
+                    ]
+                }
+            },
+            "destinations": {
+                "logAnalytics": [{
+                    "workspaceResourceId": "[parameters('workspaceResourceId')]",
+                    "name": "logAnalyticsWorkspace"
+                }]
+            },
+            "dataFlows": [{
+                    "streams": [
+                        "Custom-ASimProcessEventLogs"
+                    ],
+                    "destinations": [
+                        "logAnalyticsWorkspace"
+                    ],
+                    "transformKql": "source",
+                    "outputStream": "Microsoft-ASimProcessEventLogs"
+                }
+            ]
+        }
+    }],
+    "outputs": {
+        "dataCollectionRuleId": {
+            "type": "string",
+            "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+        }
+    }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/ASimRegistryEventLogs.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/ASimRegistryEventLogs.json
@@ -1,0 +1,386 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "dataCollectionRuleName": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the name of the Data Collection Rule to create."
+            }
+        },
+        "location": {
+            "defaultValue": "[resourceGroup().location]",
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the location in which to create the Data Collection Rule."
+            }
+        },
+        "workspaceResourceId": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+            }
+        }
+    },
+    "resources": [{
+        "type": "Microsoft.Insights/dataCollectionRules",
+        "apiVersion": "2023-03-11",
+        "name": "[parameters('dataCollectionRuleName')]",
+        "location": "[parameters('location')]",
+        "kind": "Direct",
+        "properties": {
+            "streamDeclarations": {
+                "Custom-ASimRegistryEventLogs": {
+                    "columns": [{
+                            "name": "ActingProcessCommandLine",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActingProcessGuid",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActingProcessId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActingProcessName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActorOriginalUserType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActorScope",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActorScopeId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActorSessionId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActorUserAadId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActorUserId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActorUserIdType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActorUsername",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActorUsernameType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActorUserSid",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActorUserType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AdditionalFields",
+                            "type": "dynamic"
+                        },
+                        {
+                            "name": "DvcAction",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcDescription",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcDomain",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcDomainType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcFQDN",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcHostname",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcIdType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcInterface",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcIpAddr",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcMacAddr",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcOriginalAction",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcOs",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcOsVersion",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcScope",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcScopeId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcZone",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventCount",
+                            "type": "int"
+                        },
+                        {
+                            "name": "EventEndTime",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "EventMessage",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventOriginalResultDetails",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventOriginalSeverity",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventOriginalSubType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventOriginalType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventOriginalUid",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventOwner",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventProduct",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventProductVersion",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventReportUrl",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventResult",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventResultDetails",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventSchema",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventSchemaVersion",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventSeverity",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventStartTime",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "EventSubType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventVendor",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ParentProcessCommandLine",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ParentProcessGuid",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ParentProcessId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ParentProcessName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RegistryKey",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RegistryPreviousKey",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RegistryPreviousValue",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RegistryPreviousValueData",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RegistryPreviousValueType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RegistryValue",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RegistryValueData",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RegistryValueType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RuleName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RuleNumber",
+                            "type": "int"
+                        },
+                        {
+                            "name": "SourceSystem",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ThreatCategory",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ThreatConfidence",
+                            "type": "int"
+                        },
+                        {
+                            "name": "ThreatField",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ThreatFirstReportedTime",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "ThreatId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ThreatIsActive",
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "ThreatLastReportedTime",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "ThreatName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ThreatOriginalConfidence",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ThreatOriginalRiskLevel",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ThreatRiskLevel",
+                            "type": "int"
+                        },
+                        {
+                            "name": "TimeGenerated",
+                            "type": "datetime"
+                        }
+                    ]
+                }
+            },
+            "destinations": {
+                "logAnalytics": [{
+                    "workspaceResourceId": "[parameters('workspaceResourceId')]",
+                    "name": "logAnalyticsWorkspace"
+                }]
+            },
+            "dataFlows": [{
+                    "streams": [
+                        "Custom-ASimRegistryEventLogs"
+                    ],
+                    "destinations": [
+                        "logAnalyticsWorkspace"
+                    ],
+                    "transformKql": "source",
+                    "outputStream": "Microsoft-ASimRegistryEventLogs"
+                }
+            ]
+        }
+    }],
+    "outputs": {
+        "dataCollectionRuleId": {
+            "type": "string",
+            "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+        }
+    }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/ASimUserManagementActivityLogs.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/ASimUserManagementActivityLogs.json
@@ -1,0 +1,494 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "dataCollectionRuleName": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the name of the Data Collection Rule to create."
+            }
+        },
+        "location": {
+            "defaultValue": "[resourceGroup().location]",
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the location in which to create the Data Collection Rule."
+            }
+        },
+        "workspaceResourceId": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+            }
+        }
+    },
+    "resources": [{
+        "type": "Microsoft.Insights/dataCollectionRules",
+        "apiVersion": "2023-03-11",
+        "name": "[parameters('dataCollectionRuleName')]",
+        "location": "[parameters('location')]",
+        "kind": "Direct",
+        "properties": {
+            "streamDeclarations": {
+                "Custom-ASimUserManagementActivityLogs": {
+                    "columns": [{
+                            "name": "ActingAppId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActingAppName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActingAppType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActingOriginalAppType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActorOriginalUserType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActorScope",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActorScopeId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActorSessionId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActorUserAadId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActorUserId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActorUserIdType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActorUsername",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActorUsernameType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActorUserSid",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActorUserType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AdditionalFields",
+                            "type": "dynamic"
+                        },
+                        {
+                            "name": "DvcAction",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcDescription",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcDomain",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcDomainType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcFQDN",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcHostname",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcIdType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcInterface",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcIpAddr",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcMacAddr",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcOriginalAction",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcOs",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcOsVersion",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcScope",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcScopeId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcZone",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventCount",
+                            "type": "int"
+                        },
+                        {
+                            "name": "EventEndTime",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "EventMessage",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventOriginalResultDetails",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventOriginalSeverity",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventOriginalSubType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventOriginalType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventOriginalUid",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventOwner",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventProduct",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventProductVersion",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventReportUrl",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventResult",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventResultDetails",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventSchema",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventSchemaVersion",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventSeverity",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventStartTime",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "EventSubType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventVendor",
+                            "type": "string"
+                        },
+                        {
+                            "name": "GroupId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "GroupIdType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "GroupName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "GroupNameType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "GroupOriginalType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "GroupType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "HttpUserAgent",
+                            "type": "string"
+                        },
+                        {
+                            "name": "NewPropertyValue",
+                            "type": "string"
+                        },
+                        {
+                            "name": "PreviousPropertyValue",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RuleName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RuleNumber",
+                            "type": "int"
+                        },
+                        {
+                            "name": "SourceSystem",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcDescription",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcDeviceType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcDomain",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcDomainType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcDvcId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcDvcIdType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcDvcScope",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcDvcScopeId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcFQDN",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcGeoCity",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcGeoCountry",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcGeoLatitude",
+                            "type": "real"
+                        },
+                        {
+                            "name": "SrcGeoLongitude",
+                            "type": "real"
+                        },
+                        {
+                            "name": "SrcGeoRegion",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcHostname",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcIpAddr",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcMacAddr",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcOriginalRiskLevel",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcPortNumber",
+                            "type": "int"
+                        },
+                        {
+                            "name": "SrcRiskLevel",
+                            "type": "int"
+                        },
+                        {
+                            "name": "TargetOriginalUserType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetUserId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetUserIdType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetUsername",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetUsernameType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetUserScope",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetUserScopeId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetUserSessionId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetUserType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetUserUid",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ThreatCategory",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ThreatConfidence",
+                            "type": "int"
+                        },
+                        {
+                            "name": "ThreatField",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ThreatFirstReportedTime",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "ThreatId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ThreatIsActive",
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "ThreatLastReportedTime",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "ThreatName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ThreatOriginalConfidence",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ThreatOriginalRiskLevel",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ThreatRiskLevel",
+                            "type": "int"
+                        },
+                        {
+                            "name": "TimeGenerated",
+                            "type": "datetime"
+                        }
+                    ]
+                }
+            },
+            "destinations": {
+                "logAnalytics": [{
+                    "workspaceResourceId": "[parameters('workspaceResourceId')]",
+                    "name": "logAnalyticsWorkspace"
+                }]
+            },
+            "dataFlows": [{
+                    "streams": [
+                        "Custom-ASimUserManagementActivityLogs"
+                    ],
+                    "destinations": [
+                        "logAnalyticsWorkspace"
+                    ],
+                    "transformKql": "source",
+                    "outputStream": "Microsoft-ASimUserManagementActivityLogs"
+                }
+            ]
+        }
+    }],
+    "outputs": {
+        "dataCollectionRuleId": {
+            "type": "string",
+            "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+        }
+    }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/ASimWebSessionLogs.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/ASimWebSessionLogs.json
@@ -1,0 +1,638 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "dataCollectionRuleName": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the name of the Data Collection Rule to create."
+            }
+        },
+        "location": {
+            "defaultValue": "[resourceGroup().location]",
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the location in which to create the Data Collection Rule."
+            }
+        },
+        "workspaceResourceId": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+            }
+        }
+    },
+    "resources": [{
+        "type": "Microsoft.Insights/dataCollectionRules",
+        "apiVersion": "2023-03-11",
+        "name": "[parameters('dataCollectionRuleName')]",
+        "location": "[parameters('location')]",
+        "kind": "Direct",
+        "properties": {
+            "streamDeclarations": {
+                "Custom-ASimWebSessionLogs": {
+                    "columns": [{
+                            "name": "AdditionalFields",
+                            "type": "dynamic"
+                        },
+                        {
+                            "name": "DstAppId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DstAppName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DstAppType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DstBytes",
+                            "type": "long"
+                        },
+                        {
+                            "name": "DstDeviceType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DstDomain",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DstDomainType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DstDvcId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DstDvcIdType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DstDvcScope",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DstDvcScopeId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DstFQDN",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DstGeoCity",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DstGeoCountry",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DstGeoLatitude",
+                            "type": "real"
+                        },
+                        {
+                            "name": "DstGeoLongitude",
+                            "type": "real"
+                        },
+                        {
+                            "name": "DstGeoRegion",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DstHostname",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DstIpAddr",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DstMacAddr",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DstNatIpAddr",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DstNatPortNumber",
+                            "type": "int"
+                        },
+                        {
+                            "name": "DstOriginalUserType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DstPackets",
+                            "type": "long"
+                        },
+                        {
+                            "name": "DstPortNumber",
+                            "type": "int"
+                        },
+                        {
+                            "name": "DstUserId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DstUserIdType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DstUsername",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DstUsernameType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DstUserType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Dvc",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcAction",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcDomain",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcDomainType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcFQDN",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcHostname",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcIdType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcIpAddr",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DvcOriginalAction",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventCount",
+                            "type": "int"
+                        },
+                        {
+                            "name": "EventEndTime",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "EventMessage",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventOriginalResultDetails",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventOriginalSeverity",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventOriginalSubType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventOriginalType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventOriginalUid",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventOwner",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventProduct",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventProductVersion",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventReportUrl",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventResult",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventResultDetails",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventSchemaVersion",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventSeverity",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventStartTime",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "EventSubType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventVendor",
+                            "type": "string"
+                        },
+                        {
+                            "name": "FileContentType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "FileMD5",
+                            "type": "string"
+                        },
+                        {
+                            "name": "FileName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "FileSHA1",
+                            "type": "string"
+                        },
+                        {
+                            "name": "FileSHA256",
+                            "type": "string"
+                        },
+                        {
+                            "name": "FileSHA512",
+                            "type": "string"
+                        },
+                        {
+                            "name": "FileSize",
+                            "type": "int"
+                        },
+                        {
+                            "name": "HttpContentFormat",
+                            "type": "string"
+                        },
+                        {
+                            "name": "HttpContentType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "HttpHost",
+                            "type": "string"
+                        },
+                        {
+                            "name": "HttpReferrer",
+                            "type": "string"
+                        },
+                        {
+                            "name": "HttpRequestMethod",
+                            "type": "string"
+                        },
+                        {
+                            "name": "HttpRequestTime",
+                            "type": "int"
+                        },
+                        {
+                            "name": "HttpRequestXff",
+                            "type": "string"
+                        },
+                        {
+                            "name": "HttpResponseTime",
+                            "type": "int"
+                        },
+                        {
+                            "name": "HttpUserAgent",
+                            "type": "string"
+                        },
+                        {
+                            "name": "HttpVersion",
+                            "type": "string"
+                        },
+                        {
+                            "name": "NetworkApplicationProtocol",
+                            "type": "string"
+                        },
+                        {
+                            "name": "NetworkBytes",
+                            "type": "long"
+                        },
+                        {
+                            "name": "NetworkConnectionHistory",
+                            "type": "string"
+                        },
+                        {
+                            "name": "NetworkDirection",
+                            "type": "string"
+                        },
+                        {
+                            "name": "NetworkDuration",
+                            "type": "int"
+                        },
+                        {
+                            "name": "NetworkIcmpCode",
+                            "type": "int"
+                        },
+                        {
+                            "name": "NetworkIcmpType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "NetworkPackets",
+                            "type": "long"
+                        },
+                        {
+                            "name": "NetworkProtocol",
+                            "type": "string"
+                        },
+                        {
+                            "name": "NetworkProtocolVersion",
+                            "type": "string"
+                        },
+                        {
+                            "name": "NetworkSessionId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Rule",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RuleName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RuleNumber",
+                            "type": "int"
+                        },
+                        {
+                            "name": "SourceSystem",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcAppId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcAppName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcAppType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcBytes",
+                            "type": "long"
+                        },
+                        {
+                            "name": "SrcDeviceType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcDomain",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcDomainType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcDvcId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcDvcIdType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcDvcScope",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcDvcScopeId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcFQDN",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcGeoCity",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcGeoCountry",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcGeoLatitude",
+                            "type": "real"
+                        },
+                        {
+                            "name": "SrcGeoLongitude",
+                            "type": "real"
+                        },
+                        {
+                            "name": "SrcGeoRegion",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcHostname",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcIpAddr",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcMacAddr",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcNatIpAddr",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcNatPortNumber",
+                            "type": "int"
+                        },
+                        {
+                            "name": "SrcOriginalUserType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcPackets",
+                            "type": "long"
+                        },
+                        {
+                            "name": "SrcPortNumber",
+                            "type": "int"
+                        },
+                        {
+                            "name": "SrcProcessGuid",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcProcessId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcProcessName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcUserId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcUserIdType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcUsername",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcUsernameType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcUserScope",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcUserScopeId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcUserType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ThreatCategory",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ThreatConfidence",
+                            "type": "int"
+                        },
+                        {
+                            "name": "ThreatField",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ThreatFirstReportedTime",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "ThreatId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ThreatIpAddr",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ThreatIsActive",
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "ThreatLastReportedTime",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "ThreatName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ThreatOriginalConfidence",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ThreatOriginalRiskLevel",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ThreatRiskLevel",
+                            "type": "int"
+                        },
+                        {
+                            "name": "TimeGenerated",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "Url",
+                            "type": "string"
+                        },
+                        {
+                            "name": "UrlCategory",
+                            "type": "string"
+                        },
+                        {
+                            "name": "UrlOriginal",
+                            "type": "string"
+                        }
+                    ]
+                }
+            },
+            "destinations": {
+                "logAnalytics": [{
+                    "workspaceResourceId": "[parameters('workspaceResourceId')]",
+                    "name": "logAnalyticsWorkspace"
+                }]
+            },
+            "dataFlows": [{
+                    "streams": [
+                        "Custom-ASimWebSessionLogs"
+                    ],
+                    "destinations": [
+                        "logAnalyticsWorkspace"
+                    ],
+                    "transformKql": "source",
+                    "outputStream": "Microsoft-ASimWebSessionLogs"
+                }
+            ]
+        }
+    }],
+    "outputs": {
+        "dataCollectionRuleId": {
+            "type": "string",
+            "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+        }
+    }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/AWSCloudTrail.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/AWSCloudTrail.json
@@ -1,0 +1,258 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "dataCollectionRuleName": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the name of the Data Collection Rule to create."
+            }
+        },
+        "location": {
+            "defaultValue": "[resourceGroup().location]",
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the location in which to create the Data Collection Rule."
+            }
+        },
+        "workspaceResourceId": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+            }
+        }
+    },
+    "resources": [{
+        "type": "Microsoft.Insights/dataCollectionRules",
+        "apiVersion": "2023-03-11",
+        "name": "[parameters('dataCollectionRuleName')]",
+        "location": "[parameters('location')]",
+        "kind": "Direct",
+        "properties": {
+            "streamDeclarations": {
+                "Custom-AWSCloudTrail": {
+                    "columns": [{
+                            "name": "AdditionalEventData",
+                            "type": "string"
+                        },
+                        {
+                            "name": "APIVersion",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AwsEventId",
+                            "type": "guid"
+                        },
+                        {
+                            "name": "AWSRegion",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AwsRequestId",
+                            "type": "guid"
+                        },
+                        {
+                            "name": "AwsRequestId_",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Category",
+                            "type": "string"
+                        },
+                        {
+                            "name": "CidrIp",
+                            "type": "string"
+                        },
+                        {
+                            "name": "CipherSuite",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ClientProvidedHostHeader",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DestinationPort",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EC2RoleDelivery",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ErrorCode",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ErrorMessage",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventSource",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventTypeName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventVersion",
+                            "type": "string"
+                        },
+                        {
+                            "name": "IpProtocol",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ManagementEvent",
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "OperationName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ReadOnly",
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "RecipientAccountId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RequestParameters",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Resources",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ResponseElements",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ServiceEventDetails",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SessionCreationDate",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "SessionIssuerAccountId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SessionIssuerArn",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SessionIssuerPrincipalId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SessionIssuerType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SessionIssuerUserName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SessionMfaAuthenticated",
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "SharedEventId",
+                            "type": "guid"
+                        },
+                        {
+                            "name": "SourceIpAddress",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SourcePort",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SourceSystem",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TimeGenerated",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "TlsVersion",
+                            "type": "string"
+                        },
+                        {
+                            "name": "UserAgent",
+                            "type": "string"
+                        },
+                        {
+                            "name": "UserIdentityAccessKeyId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "UserIdentityAccountId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "UserIdentityArn",
+                            "type": "string"
+                        },
+                        {
+                            "name": "UserIdentityInvokedBy",
+                            "type": "string"
+                        },
+                        {
+                            "name": "UserIdentityPrincipalid",
+                            "type": "string"
+                        },
+                        {
+                            "name": "UserIdentityType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "UserIdentityUserName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "VpcEndpointId",
+                            "type": "string"
+                        }
+                    ]
+                }
+            },
+            "destinations": {
+                "logAnalytics": [{
+                    "workspaceResourceId": "[parameters('workspaceResourceId')]",
+                    "name": "logAnalyticsWorkspace"
+                }]
+            },
+            "dataFlows": [{
+                    "streams": [
+                        "Custom-AWSCloudTrail"
+                    ],
+                    "destinations": [
+                        "logAnalyticsWorkspace"
+                    ],
+                    "transformKql": "source",
+                    "outputStream": "Microsoft-AWSCloudTrail"
+                }
+            ]
+        }
+    }],
+    "outputs": {
+        "dataCollectionRuleId": {
+            "type": "string",
+            "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+        }
+    }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/AWSCloudWatch.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/AWSCloudWatch.json
@@ -1,0 +1,78 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "dataCollectionRuleName": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the name of the Data Collection Rule to create."
+            }
+        },
+        "location": {
+            "defaultValue": "[resourceGroup().location]",
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the location in which to create the Data Collection Rule."
+            }
+        },
+        "workspaceResourceId": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+            }
+        }
+    },
+    "resources": [{
+        "type": "Microsoft.Insights/dataCollectionRules",
+        "apiVersion": "2023-03-11",
+        "name": "[parameters('dataCollectionRuleName')]",
+        "location": "[parameters('location')]",
+        "kind": "Direct",
+        "properties": {
+            "streamDeclarations": {
+                "Custom-AWSCloudWatch": {
+                    "columns": [{
+                            "name": "ExtractedTime",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "Message",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SourceSystem",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TimeGenerated",
+                            "type": "datetime"
+                        }
+                    ]
+                }
+            },
+            "destinations": {
+                "logAnalytics": [{
+                    "workspaceResourceId": "[parameters('workspaceResourceId')]",
+                    "name": "logAnalyticsWorkspace"
+                }]
+            },
+            "dataFlows": [{
+                    "streams": [
+                        "Custom-AWSCloudWatch"
+                    ],
+                    "destinations": [
+                        "logAnalyticsWorkspace"
+                    ],
+                    "transformKql": "source",
+                    "outputStream": "Microsoft-AWSCloudWatch"
+                }
+            ]
+        }
+    }],
+    "outputs": {
+        "dataCollectionRuleId": {
+            "type": "string",
+            "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+        }
+    }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/AWSGuardDuty.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/AWSGuardDuty.json
@@ -1,0 +1,122 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "dataCollectionRuleName": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the name of the Data Collection Rule to create."
+            }
+        },
+        "location": {
+            "defaultValue": "[resourceGroup().location]",
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the location in which to create the Data Collection Rule."
+            }
+        },
+        "workspaceResourceId": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+            }
+        }
+    },
+    "resources": [{
+        "type": "Microsoft.Insights/dataCollectionRules",
+        "apiVersion": "2023-03-11",
+        "name": "[parameters('dataCollectionRuleName')]",
+        "location": "[parameters('location')]",
+        "kind": "Direct",
+        "properties": {
+            "streamDeclarations": {
+                "Custom-AWSGuardDuty": {
+                    "columns": [{
+                            "name": "AccountId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActivityType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Arn",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Description",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Id",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Partition",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Region",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ResourceDetails",
+                            "type": "dynamic"
+                        },
+                        {
+                            "name": "SchemaVersion",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ServiceDetails",
+                            "type": "dynamic"
+                        },
+                        {
+                            "name": "Severity",
+                            "type": "int"
+                        },
+                        {
+                            "name": "SourceSystem",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TimeCreated",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "TimeGenerated",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "Title",
+                            "type": "string"
+                        }
+                    ]
+                }
+            },
+            "destinations": {
+                "logAnalytics": [{
+                    "workspaceResourceId": "[parameters('workspaceResourceId')]",
+                    "name": "logAnalyticsWorkspace"
+                }]
+            },
+            "dataFlows": [{
+                    "streams": [
+                        "Custom-AWSGuardDuty"
+                    ],
+                    "destinations": [
+                        "logAnalyticsWorkspace"
+                    ],
+                    "transformKql": "source",
+                    "outputStream": "Microsoft-AWSGuardDuty"
+                }
+            ]
+        }
+    }],
+    "outputs": {
+        "dataCollectionRuleId": {
+            "type": "string",
+            "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+        }
+    }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/AWSVPCFlow.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/AWSVPCFlow.json
@@ -1,0 +1,226 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "dataCollectionRuleName": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the name of the Data Collection Rule to create."
+            }
+        },
+        "location": {
+            "defaultValue": "[resourceGroup().location]",
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the location in which to create the Data Collection Rule."
+            }
+        },
+        "workspaceResourceId": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+            }
+        }
+    },
+    "resources": [{
+        "type": "Microsoft.Insights/dataCollectionRules",
+        "apiVersion": "2023-03-11",
+        "name": "[parameters('dataCollectionRuleName')]",
+        "location": "[parameters('location')]",
+        "kind": "Direct",
+        "properties": {
+            "streamDeclarations": {
+                "Custom-AWSVPCFlow": {
+                    "columns": [{
+                            "name": "AccountId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Action",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AzId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Bytes",
+                            "type": "long"
+                        },
+                        {
+                            "name": "DstAddr",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DstPort",
+                            "type": "int"
+                        },
+                        {
+                            "name": "EcsClusterArn",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EcsClusterName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EcsContainerId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EcsContainerInstanceArn",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EcsContainerInstanceId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EcsSecondContainerId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EcsServiceName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EcsTaskArn",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EcsTaskDefinitionArn",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EcsTaskId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "End",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "FlowDirection",
+                            "type": "string"
+                        },
+                        {
+                            "name": "InstanceId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "InterfaceId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "LogStatus",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Packets",
+                            "type": "int"
+                        },
+                        {
+                            "name": "PktDstAddr",
+                            "type": "string"
+                        },
+                        {
+                            "name": "PktDstAwsService",
+                            "type": "string"
+                        },
+                        {
+                            "name": "PktSrcAddr",
+                            "type": "string"
+                        },
+                        {
+                            "name": "PktSrcAwsService",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Protocol",
+                            "type": "int"
+                        },
+                        {
+                            "name": "Region",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SourceSystem",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcAddr",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SrcPort",
+                            "type": "int"
+                        },
+                        {
+                            "name": "Start",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "SublocationId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SublocationType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SubnetId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TcpFlags",
+                            "type": "int"
+                        },
+                        {
+                            "name": "TimeGenerated",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "TrafficPath",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TrafficType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Version",
+                            "type": "int"
+                        },
+                        {
+                            "name": "VpcId",
+                            "type": "string"
+                        }
+                    ]
+                }
+            },
+            "destinations": {
+                "logAnalytics": [{
+                    "workspaceResourceId": "[parameters('workspaceResourceId')]",
+                    "name": "logAnalyticsWorkspace"
+                }]
+            },
+            "dataFlows": [{
+                    "streams": [
+                        "Custom-AWSVPCFlow"
+                    ],
+                    "destinations": [
+                        "logAnalyticsWorkspace"
+                    ],
+                    "transformKql": "source",
+                    "outputStream": "Microsoft-AWSVPCFlow"
+                }
+            ]
+        }
+    }],
+    "outputs": {
+        "dataCollectionRuleId": {
+            "type": "string",
+            "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+        }
+    }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/Anomalies.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/Anomalies.json
@@ -1,0 +1,198 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "dataCollectionRuleName": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the name of the Data Collection Rule to create."
+            }
+        },
+        "location": {
+            "defaultValue": "[resourceGroup().location]",
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the location in which to create the Data Collection Rule."
+            }
+        },
+        "workspaceResourceId": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+            }
+        }
+    },
+    "resources": [{
+        "type": "Microsoft.Insights/dataCollectionRules",
+        "apiVersion": "2023-03-11",
+        "name": "[parameters('dataCollectionRuleName')]",
+        "location": "[parameters('location')]",
+        "kind": "Direct",
+        "properties": {
+            "streamDeclarations": {
+                "Custom-Anomalies": {
+                    "columns": [{
+                            "name": "ActivityInsights",
+                            "type": "dynamic"
+                        },
+                        {
+                            "name": "AnomalyDetails",
+                            "type": "dynamic"
+                        },
+                        {
+                            "name": "AnomalyReasons",
+                            "type": "dynamic"
+                        },
+                        {
+                            "name": "AnomalyTemplateId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AnomalyTemplateName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AnomalyTemplateVersion",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Description",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DestinationDevice",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DestinationIpAddress",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DestinationLocation",
+                            "type": "dynamic"
+                        },
+                        {
+                            "name": "DeviceInsights",
+                            "type": "dynamic"
+                        },
+                        {
+                            "name": "EndTime",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "Entities",
+                            "type": "dynamic"
+                        },
+                        {
+                            "name": "ExtendedLinks",
+                            "type": "dynamic"
+                        },
+                        {
+                            "name": "ExtendedProperties",
+                            "type": "dynamic"
+                        },
+                        {
+                            "name": "Id",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RuleConfigVersion",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RuleId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RuleName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RuleStatus",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Score",
+                            "type": "real"
+                        },
+                        {
+                            "name": "SourceDevice",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SourceIpAddress",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SourceLocation",
+                            "type": "dynamic"
+                        },
+                        {
+                            "name": "SourceSystem",
+                            "type": "string"
+                        },
+                        {
+                            "name": "StartTime",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "Tactics",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Techniques",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TimeGenerated",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "UserInsights",
+                            "type": "dynamic"
+                        },
+                        {
+                            "name": "UserName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "UserPrincipalName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "VendorName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "WorkspaceId",
+                            "type": "string"
+                        }
+                    ]
+                }
+            },
+            "destinations": {
+                "logAnalytics": [{
+                    "workspaceResourceId": "[parameters('workspaceResourceId')]",
+                    "name": "logAnalyticsWorkspace"
+                }]
+            },
+            "dataFlows": [{
+                    "streams": [
+                        "Custom-Anomalies"
+                    ],
+                    "destinations": [
+                        "logAnalyticsWorkspace"
+                    ],
+                    "transformKql": "source",
+                    "outputStream": "Microsoft-Anomalies"
+                }
+            ]
+        }
+    }],
+    "outputs": {
+        "dataCollectionRuleId": {
+            "type": "string",
+            "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+        }
+    }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/AzureActivity.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/AzureActivity.json
@@ -1,0 +1,186 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "dataCollectionRuleName": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the name of the Data Collection Rule to create."
+            }
+        },
+        "location": {
+            "defaultValue": "[resourceGroup().location]",
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the location in which to create the Data Collection Rule."
+            }
+        },
+        "workspaceResourceId": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+            }
+        }
+    },
+    "resources": [{
+        "type": "Microsoft.Insights/dataCollectionRules",
+        "apiVersion": "2023-03-11",
+        "name": "[parameters('dataCollectionRuleName')]",
+        "location": "[parameters('location')]",
+        "kind": "Direct",
+        "properties": {
+            "streamDeclarations": {
+                "Custom-AzureActivity": {
+                    "columns": [{
+                            "name": "ActivityStatus",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActivityStatusValue",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActivitySubstatus",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActivitySubstatusValue",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Authorization",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Authorization_d",
+                            "type": "dynamic"
+                        },
+                        {
+                            "name": "Caller",
+                            "type": "string"
+                        },
+                        {
+                            "name": "CallerIpAddress",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Category",
+                            "type": "string"
+                        },
+                        {
+                            "name": "CategoryValue",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Claims",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Claims_d",
+                            "type": "dynamic"
+                        },
+                        {
+                            "name": "CorrelationId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventDataId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventSubmissionTimestamp",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "Hierarchy",
+                            "type": "string"
+                        },
+                        {
+                            "name": "HTTPRequest",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Level",
+                            "type": "string"
+                        },
+                        {
+                            "name": "OperationId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "OperationName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "OperationNameValue",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Properties",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Properties_d",
+                            "type": "dynamic"
+                        },
+                        {
+                            "name": "Resource",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ResourceGroup",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ResourceId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ResourceProvider",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ResourceProviderValue",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SourceSystem",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SubscriptionId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TimeGenerated",
+                            "type": "datetime"
+                        }
+                    ]
+                }
+            },
+            "destinations": {
+                "logAnalytics": [{
+                    "workspaceResourceId": "[parameters('workspaceResourceId')]",
+                    "name": "logAnalyticsWorkspace"
+                }]
+            },
+            "dataFlows": [{
+                    "streams": [
+                        "Custom-AzureActivity"
+                    ],
+                    "destinations": [
+                        "logAnalyticsWorkspace"
+                    ],
+                    "transformKql": "source",
+                    "outputStream": "Microsoft-AzureActivity"
+                }
+            ]
+        }
+    }],
+    "outputs": {
+        "dataCollectionRuleId": {
+            "type": "string",
+            "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+        }
+    }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/AzureAssessmentRecommendation.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/AzureAssessmentRecommendation.json
@@ -1,0 +1,146 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "dataCollectionRuleName": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the name of the Data Collection Rule to create."
+            }
+        },
+        "location": {
+            "defaultValue": "[resourceGroup().location]",
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the location in which to create the Data Collection Rule."
+            }
+        },
+        "workspaceResourceId": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+            }
+        }
+    },
+    "resources": [{
+        "type": "Microsoft.Insights/dataCollectionRules",
+        "apiVersion": "2023-03-11",
+        "name": "[parameters('dataCollectionRuleName')]",
+        "location": "[parameters('location')]",
+        "kind": "Direct",
+        "properties": {
+            "streamDeclarations": {
+                "Custom-AzureAssessmentRecommendation": {
+                    "columns": [{
+                            "name": "AADTenantDomain",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AADTenantId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AADTenantName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActionArea",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActionAreaId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AffectedObjectName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AffectedObjectType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AssessmentId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Computer",
+                            "type": "string"
+                        },
+                        {
+                            "name": "CustomData",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Description",
+                            "type": "string"
+                        },
+                        {
+                            "name": "FocusArea",
+                            "type": "string"
+                        },
+                        {
+                            "name": "FocusAreaId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Recommendation",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RecommendationId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RecommendationResult",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RecommendationWeight",
+                            "type": "real"
+                        },
+                        {
+                            "name": "Resource",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SourceSystem",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Technology",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TimeGenerated",
+                            "type": "datetime"
+                        }
+                    ]
+                }
+            },
+            "destinations": {
+                "logAnalytics": [{
+                    "workspaceResourceId": "[parameters('workspaceResourceId')]",
+                    "name": "logAnalyticsWorkspace"
+                }]
+            },
+            "dataFlows": [{
+                    "streams": [
+                        "Custom-AzureAssessmentRecommendation"
+                    ],
+                    "destinations": [
+                        "logAnalyticsWorkspace"
+                    ],
+                    "transformKql": "source",
+                    "outputStream": "Microsoft-AzureAssessmentRecommendation"
+                }
+            ]
+        }
+    }],
+    "outputs": {
+        "dataCollectionRuleId": {
+            "type": "string",
+            "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+        }
+    }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/AzureDiagnostics.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/AzureDiagnostics.json
@@ -1,0 +1,150 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "dataCollectionRuleName": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the name of the Data Collection Rule to create."
+            }
+        },
+        "location": {
+            "defaultValue": "[resourceGroup().location]",
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the location in which to create the Data Collection Rule."
+            }
+        },
+        "workspaceResourceId": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+            }
+        }
+    },
+    "resources": [{
+        "type": "Microsoft.Insights/dataCollectionRules",
+        "apiVersion": "2023-03-11",
+        "name": "[parameters('dataCollectionRuleName')]",
+        "location": "[parameters('location')]",
+        "kind": "Direct",
+        "properties": {
+            "streamDeclarations": {
+                "Custom-AzureDiagnostics": {
+                    "columns": [{
+                            "name": "AdditionalFields",
+                            "type": "dynamic"
+                        },
+                        {
+                            "name": "CallerIPAddress",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Category",
+                            "type": "string"
+                        },
+                        {
+                            "name": "CorrelationId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DurationMs",
+                            "type": "long"
+                        },
+                        {
+                            "name": "Level",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Location",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Message",
+                            "type": "string"
+                        },
+                        {
+                            "name": "OperationName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "OperationVersion",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Resource",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ResourceGroup",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ResourceProvider",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ResourceType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ResultDescription",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ResultSignature",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ResultType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SourceSystem",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SubscriptionId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TimeGenerated",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "TenantId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Type",
+                            "type": "string"
+                        }
+                    ]
+                }
+            },
+            "destinations": {
+                "logAnalytics": [{
+                    "workspaceResourceId": "[parameters('workspaceResourceId')]",
+                    "name": "logAnalyticsWorkspace"
+                }]
+            },
+            "dataFlows": [{
+                    "streams": [
+                        "Custom-AzureDiagnostics"
+                    ],
+                    "destinations": [
+                        "logAnalyticsWorkspace"
+                    ],
+                    "transformKql": "source",
+                    "outputStream": "Microsoft-AzureDiagnostics"
+                }
+            ]
+        }
+    }],
+    "outputs": {
+        "dataCollectionRuleId": {
+            "type": "string",
+            "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+        }
+    }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/CommonSecurityLog.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/CommonSecurityLog.json
@@ -1,0 +1,690 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "dataCollectionRuleName": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the name of the Data Collection Rule to create."
+            }
+        },
+        "location": {
+            "defaultValue": "[resourceGroup().location]",
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the location in which to create the Data Collection Rule."
+            }
+        },
+        "workspaceResourceId": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+            }
+        }
+    },
+    "resources": [{
+        "type": "Microsoft.Insights/dataCollectionRules",
+        "apiVersion": "2023-03-11",
+        "name": "[parameters('dataCollectionRuleName')]",
+        "location": "[parameters('location')]",
+        "kind": "Direct",
+        "properties": {
+            "streamDeclarations": {
+                "Custom-CommonSecurityLog": {
+                    "columns": [{
+                            "name": "Activity",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AdditionalExtensions",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ApplicationProtocol",
+                            "type": "string"
+                        },
+                        {
+                            "name": "CollectorHostName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "CommunicationDirection",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Computer",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DestinationDnsDomain",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DestinationHostName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DestinationIP",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DestinationMACAddress",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DestinationNTDomain",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DestinationPort",
+                            "type": "int"
+                        },
+                        {
+                            "name": "DestinationProcessId",
+                            "type": "int"
+                        },
+                        {
+                            "name": "DestinationProcessName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DestinationServiceName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DestinationTranslatedAddress",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DestinationTranslatedPort",
+                            "type": "int"
+                        },
+                        {
+                            "name": "DestinationUserID",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DestinationUserName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DestinationUserPrivileges",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DeviceAction",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DeviceAddress",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DeviceCustomDate1",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DeviceCustomDate1Label",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DeviceCustomDate2",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DeviceCustomDate2Label",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DeviceCustomFloatingPoint1",
+                            "type": "real"
+                        },
+                        {
+                            "name": "DeviceCustomFloatingPoint1Label",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DeviceCustomFloatingPoint2",
+                            "type": "real"
+                        },
+                        {
+                            "name": "DeviceCustomFloatingPoint2Label",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DeviceCustomFloatingPoint3",
+                            "type": "real"
+                        },
+                        {
+                            "name": "DeviceCustomFloatingPoint3Label",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DeviceCustomFloatingPoint4",
+                            "type": "real"
+                        },
+                        {
+                            "name": "DeviceCustomFloatingPoint4Label",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DeviceCustomIPv6Address1",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DeviceCustomIPv6Address1Label",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DeviceCustomIPv6Address2",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DeviceCustomIPv6Address2Label",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DeviceCustomIPv6Address3",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DeviceCustomIPv6Address3Label",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DeviceCustomIPv6Address4",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DeviceCustomIPv6Address4Label",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DeviceCustomNumber1",
+                            "type": "int"
+                        },
+                        {
+                            "name": "DeviceCustomNumber1Label",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DeviceCustomNumber2",
+                            "type": "int"
+                        },
+                        {
+                            "name": "DeviceCustomNumber2Label",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DeviceCustomNumber3",
+                            "type": "int"
+                        },
+                        {
+                            "name": "DeviceCustomNumber3Label",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DeviceCustomString1",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DeviceCustomString1Label",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DeviceCustomString2",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DeviceCustomString2Label",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DeviceCustomString3",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DeviceCustomString3Label",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DeviceCustomString4",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DeviceCustomString4Label",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DeviceCustomString5",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DeviceCustomString5Label",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DeviceCustomString6",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DeviceCustomString6Label",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DeviceDnsDomain",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DeviceEventCategory",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DeviceEventClassID",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DeviceExternalID",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DeviceFacility",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DeviceInboundInterface",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DeviceMacAddress",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DeviceName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DeviceNtDomain",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DeviceOutboundInterface",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DevicePayloadId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DeviceProduct",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DeviceTimeZone",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DeviceTranslatedAddress",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DeviceVendor",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DeviceVersion",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EndTime",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "EventCount",
+                            "type": "int"
+                        },
+                        {
+                            "name": "EventOutcome",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventType",
+                            "type": "int"
+                        },
+                        {
+                            "name": "ExternalID",
+                            "type": "int"
+                        },
+                        {
+                            "name": "ExtID",
+                            "type": "string"
+                        },
+                        {
+                            "name": "FieldDeviceCustomNumber1",
+                            "type": "long"
+                        },
+                        {
+                            "name": "FieldDeviceCustomNumber2",
+                            "type": "long"
+                        },
+                        {
+                            "name": "FieldDeviceCustomNumber3",
+                            "type": "long"
+                        },
+                        {
+                            "name": "FileCreateTime",
+                            "type": "string"
+                        },
+                        {
+                            "name": "FileHash",
+                            "type": "string"
+                        },
+                        {
+                            "name": "FileID",
+                            "type": "string"
+                        },
+                        {
+                            "name": "FileModificationTime",
+                            "type": "string"
+                        },
+                        {
+                            "name": "FileName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "FilePath",
+                            "type": "string"
+                        },
+                        {
+                            "name": "FilePermission",
+                            "type": "string"
+                        },
+                        {
+                            "name": "FileSize",
+                            "type": "int"
+                        },
+                        {
+                            "name": "FileType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "FlexDate1",
+                            "type": "string"
+                        },
+                        {
+                            "name": "FlexDate1Label",
+                            "type": "string"
+                        },
+                        {
+                            "name": "FlexNumber1",
+                            "type": "int"
+                        },
+                        {
+                            "name": "FlexNumber1Label",
+                            "type": "string"
+                        },
+                        {
+                            "name": "FlexNumber2",
+                            "type": "int"
+                        },
+                        {
+                            "name": "FlexNumber2Label",
+                            "type": "string"
+                        },
+                        {
+                            "name": "FlexString1",
+                            "type": "string"
+                        },
+                        {
+                            "name": "FlexString1Label",
+                            "type": "string"
+                        },
+                        {
+                            "name": "FlexString2",
+                            "type": "string"
+                        },
+                        {
+                            "name": "FlexString2Label",
+                            "type": "string"
+                        },
+                        {
+                            "name": "IndicatorThreatType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "LogSeverity",
+                            "type": "string"
+                        },
+                        {
+                            "name": "MaliciousIP",
+                            "type": "string"
+                        },
+                        {
+                            "name": "MaliciousIPCountry",
+                            "type": "string"
+                        },
+                        {
+                            "name": "MaliciousIPLatitude",
+                            "type": "real"
+                        },
+                        {
+                            "name": "MaliciousIPLongitude",
+                            "type": "real"
+                        },
+                        {
+                            "name": "Message",
+                            "type": "string"
+                        },
+                        {
+                            "name": "OldFileCreateTime",
+                            "type": "string"
+                        },
+                        {
+                            "name": "OldFileHash",
+                            "type": "string"
+                        },
+                        {
+                            "name": "OldFileID",
+                            "type": "string"
+                        },
+                        {
+                            "name": "OldFileModificationTime",
+                            "type": "string"
+                        },
+                        {
+                            "name": "OldFileName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "OldFilePath",
+                            "type": "string"
+                        },
+                        {
+                            "name": "OldFilePermission",
+                            "type": "string"
+                        },
+                        {
+                            "name": "OldFileSize",
+                            "type": "int"
+                        },
+                        {
+                            "name": "OldFileType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "OriginalLogSeverity",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ProcessID",
+                            "type": "int"
+                        },
+                        {
+                            "name": "ProcessName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Protocol",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Reason",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ReceiptTime",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ReceivedBytes",
+                            "type": "long"
+                        },
+                        {
+                            "name": "RemoteIP",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RemotePort",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ReportReferenceLink",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RequestClientApplication",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RequestContext",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RequestCookies",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RequestMethod",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RequestURL",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SentBytes",
+                            "type": "long"
+                        },
+                        {
+                            "name": "SimplifiedDeviceAction",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SourceDnsDomain",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SourceHostName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SourceIP",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SourceMACAddress",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SourceNTDomain",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SourcePort",
+                            "type": "int"
+                        },
+                        {
+                            "name": "SourceProcessId",
+                            "type": "int"
+                        },
+                        {
+                            "name": "SourceProcessName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SourceServiceName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SourceSystem",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SourceTranslatedAddress",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SourceTranslatedPort",
+                            "type": "int"
+                        },
+                        {
+                            "name": "SourceUserID",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SourceUserName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SourceUserPrivileges",
+                            "type": "string"
+                        },
+                        {
+                            "name": "StartTime",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "ThreatConfidence",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ThreatDescription",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ThreatSeverity",
+                            "type": "int"
+                        },
+                        {
+                            "name": "TimeGenerated",
+                            "type": "datetime"
+                        }
+                    ]
+                }
+            },
+            "destinations": {
+                "logAnalytics": [{
+                    "workspaceResourceId": "[parameters('workspaceResourceId')]",
+                    "name": "logAnalyticsWorkspace"
+                }]
+            },
+            "dataFlows": [{
+                    "streams": [
+                        "Custom-CommonSecurityLog"
+                    ],
+                    "destinations": [
+                        "logAnalyticsWorkspace"
+                    ],
+                    "transformKql": "source",
+                    "outputStream": "Microsoft-CommonSecurityLog"
+                }
+            ]
+        }
+    }],
+    "outputs": {
+        "dataCollectionRuleId": {
+            "type": "string",
+            "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+        }
+    }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/DeviceEvents.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/DeviceEvents.json
@@ -1,0 +1,330 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "dataCollectionRuleName": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the name of the Data Collection Rule to create."
+            }
+        },
+        "location": {
+            "defaultValue": "[resourceGroup().location]",
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the location in which to create the Data Collection Rule."
+            }
+        },
+        "workspaceResourceId": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+            }
+        }
+    },
+    "resources": [{
+        "type": "Microsoft.Insights/dataCollectionRules",
+        "apiVersion": "2023-03-11",
+        "name": "[parameters('dataCollectionRuleName')]",
+        "location": "[parameters('location')]",
+        "kind": "Direct",
+        "properties": {
+            "streamDeclarations": {
+                "Custom-DeviceEvents": {
+                    "columns": [{
+                            "name": "AccountDomain",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AccountName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AccountSid",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActionType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AdditionalFields",
+                            "type": "dynamic"
+                        },
+                        {
+                            "name": "AppGuardContainerId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "CreatedProcessSessionId",
+                            "type": "long"
+                        },
+                        {
+                            "name": "DeviceId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DeviceName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "FileName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "FileOriginIP",
+                            "type": "string"
+                        },
+                        {
+                            "name": "FileOriginUrl",
+                            "type": "string"
+                        },
+                        {
+                            "name": "FileSize",
+                            "type": "long"
+                        },
+                        {
+                            "name": "FolderPath",
+                            "type": "string"
+                        },
+                        {
+                            "name": "InitiatingProcessAccountDomain",
+                            "type": "string"
+                        },
+                        {
+                            "name": "InitiatingProcessAccountName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "InitiatingProcessAccountObjectId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "InitiatingProcessAccountSid",
+                            "type": "string"
+                        },
+                        {
+                            "name": "InitiatingProcessAccountUpn",
+                            "type": "string"
+                        },
+                        {
+                            "name": "InitiatingProcessCommandLine",
+                            "type": "string"
+                        },
+                        {
+                            "name": "InitiatingProcessCreationTime",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "InitiatingProcessFileName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "InitiatingProcessFileSize",
+                            "type": "long"
+                        },
+                        {
+                            "name": "InitiatingProcessFolderPath",
+                            "type": "string"
+                        },
+                        {
+                            "name": "InitiatingProcessId",
+                            "type": "long"
+                        },
+                        {
+                            "name": "InitiatingProcessLogonId",
+                            "type": "long"
+                        },
+                        {
+                            "name": "InitiatingProcessMD5",
+                            "type": "string"
+                        },
+                        {
+                            "name": "InitiatingProcessParentCreationTime",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "InitiatingProcessParentFileName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "InitiatingProcessParentId",
+                            "type": "long"
+                        },
+                        {
+                            "name": "InitiatingProcessRemoteSessionDeviceName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "InitiatingProcessRemoteSessionIP",
+                            "type": "string"
+                        },
+                        {
+                            "name": "InitiatingProcessSessionId",
+                            "type": "long"
+                        },
+                        {
+                            "name": "InitiatingProcessSHA1",
+                            "type": "string"
+                        },
+                        {
+                            "name": "InitiatingProcessSHA256",
+                            "type": "string"
+                        },
+                        {
+                            "name": "InitiatingProcessUniqueId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "InitiatingProcessVersionInfoCompanyName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "InitiatingProcessVersionInfoFileDescription",
+                            "type": "string"
+                        },
+                        {
+                            "name": "InitiatingProcessVersionInfoInternalFileName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "InitiatingProcessVersionInfoOriginalFileName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "InitiatingProcessVersionInfoProductName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "InitiatingProcessVersionInfoProductVersion",
+                            "type": "string"
+                        },
+                        {
+                            "name": "IsInitiatingProcessRemoteSession",
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "IsProcessRemoteSession",
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "LocalIP",
+                            "type": "string"
+                        },
+                        {
+                            "name": "LocalPort",
+                            "type": "int"
+                        },
+                        {
+                            "name": "LogonId",
+                            "type": "long"
+                        },
+                        {
+                            "name": "MachineGroup",
+                            "type": "string"
+                        },
+                        {
+                            "name": "MD5",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ProcessCommandLine",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ProcessCreationTime",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "ProcessId",
+                            "type": "long"
+                        },
+                        {
+                            "name": "ProcessRemoteSessionDeviceName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ProcessRemoteSessionIP",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ProcessTokenElevation",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RegistryKey",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RegistryValueData",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RegistryValueName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RemoteDeviceName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RemoteIP",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RemotePort",
+                            "type": "int"
+                        },
+                        {
+                            "name": "RemoteUrl",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ReportId",
+                            "type": "long"
+                        },
+                        {
+                            "name": "SHA1",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SHA256",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SourceSystem",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TimeGenerated",
+                            "type": "datetime"
+                        }
+                    ]
+                }
+            },
+            "destinations": {
+                "logAnalytics": [{
+                    "workspaceResourceId": "[parameters('workspaceResourceId')]",
+                    "name": "logAnalyticsWorkspace"
+                }]
+            },
+            "dataFlows": [{
+                    "streams": [
+                        "Custom-DeviceEvents"
+                    ],
+                    "destinations": [
+                        "logAnalyticsWorkspace"
+                    ],
+                    "transformKql": "source",
+                    "outputStream": "Microsoft-DeviceEvents"
+                }
+            ]
+        }
+    }],
+    "outputs": {
+        "dataCollectionRuleId": {
+            "type": "string",
+            "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+        }
+    }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/DeviceFileEvents.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/DeviceFileEvents.json
@@ -1,0 +1,302 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "dataCollectionRuleName": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the name of the Data Collection Rule to create."
+            }
+        },
+        "location": {
+            "defaultValue": "[resourceGroup().location]",
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the location in which to create the Data Collection Rule."
+            }
+        },
+        "workspaceResourceId": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+            }
+        }
+    },
+    "resources": [{
+        "type": "Microsoft.Insights/dataCollectionRules",
+        "apiVersion": "2023-03-11",
+        "name": "[parameters('dataCollectionRuleName')]",
+        "location": "[parameters('location')]",
+        "kind": "Direct",
+        "properties": {
+            "streamDeclarations": {
+                "Custom-DeviceFileEvents": {
+                    "columns": [{
+                            "name": "ActionType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AdditionalFields",
+                            "type": "dynamic"
+                        },
+                        {
+                            "name": "AppGuardContainerId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DeviceId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DeviceName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "FileName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "FileOriginIP",
+                            "type": "string"
+                        },
+                        {
+                            "name": "FileOriginReferrerUrl",
+                            "type": "string"
+                        },
+                        {
+                            "name": "FileOriginUrl",
+                            "type": "string"
+                        },
+                        {
+                            "name": "FileSize",
+                            "type": "long"
+                        },
+                        {
+                            "name": "FolderPath",
+                            "type": "string"
+                        },
+                        {
+                            "name": "InitiatingProcessAccountDomain",
+                            "type": "string"
+                        },
+                        {
+                            "name": "InitiatingProcessAccountName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "InitiatingProcessAccountObjectId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "InitiatingProcessAccountSid",
+                            "type": "string"
+                        },
+                        {
+                            "name": "InitiatingProcessAccountUpn",
+                            "type": "string"
+                        },
+                        {
+                            "name": "InitiatingProcessCommandLine",
+                            "type": "string"
+                        },
+                        {
+                            "name": "InitiatingProcessCreationTime",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "InitiatingProcessFileName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "InitiatingProcessFileSize",
+                            "type": "long"
+                        },
+                        {
+                            "name": "InitiatingProcessFolderPath",
+                            "type": "string"
+                        },
+                        {
+                            "name": "InitiatingProcessId",
+                            "type": "long"
+                        },
+                        {
+                            "name": "InitiatingProcessIntegrityLevel",
+                            "type": "string"
+                        },
+                        {
+                            "name": "InitiatingProcessMD5",
+                            "type": "string"
+                        },
+                        {
+                            "name": "InitiatingProcessParentCreationTime",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "InitiatingProcessParentFileName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "InitiatingProcessParentId",
+                            "type": "long"
+                        },
+                        {
+                            "name": "InitiatingProcessRemoteSessionDeviceName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "InitiatingProcessRemoteSessionIP",
+                            "type": "string"
+                        },
+                        {
+                            "name": "InitiatingProcessSessionId",
+                            "type": "long"
+                        },
+                        {
+                            "name": "InitiatingProcessSHA1",
+                            "type": "string"
+                        },
+                        {
+                            "name": "InitiatingProcessSHA256",
+                            "type": "string"
+                        },
+                        {
+                            "name": "InitiatingProcessTokenElevation",
+                            "type": "string"
+                        },
+                        {
+                            "name": "InitiatingProcessUniqueId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "InitiatingProcessVersionInfoCompanyName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "InitiatingProcessVersionInfoFileDescription",
+                            "type": "string"
+                        },
+                        {
+                            "name": "InitiatingProcessVersionInfoInternalFileName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "InitiatingProcessVersionInfoOriginalFileName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "InitiatingProcessVersionInfoProductName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "InitiatingProcessVersionInfoProductVersion",
+                            "type": "string"
+                        },
+                        {
+                            "name": "IsAzureInfoProtectionApplied",
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "IsInitiatingProcessRemoteSession",
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "MachineGroup",
+                            "type": "string"
+                        },
+                        {
+                            "name": "MD5",
+                            "type": "string"
+                        },
+                        {
+                            "name": "PreviousFileName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "PreviousFolderPath",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ReportId",
+                            "type": "long"
+                        },
+                        {
+                            "name": "RequestAccountDomain",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RequestAccountName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RequestAccountSid",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RequestProtocol",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RequestSourceIP",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RequestSourcePort",
+                            "type": "int"
+                        },
+                        {
+                            "name": "SensitivityLabel",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SensitivitySubLabel",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SHA1",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SHA256",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ShareName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SourceSystem",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TimeGenerated",
+                            "type": "datetime"
+                        }
+                    ]
+                }
+            },
+            "destinations": {
+                "logAnalytics": [{
+                    "workspaceResourceId": "[parameters('workspaceResourceId')]",
+                    "name": "logAnalyticsWorkspace"
+                }]
+            },
+            "dataFlows": [{
+                    "streams": [
+                        "Custom-DeviceFileEvents"
+                    ],
+                    "destinations": [
+                        "logAnalyticsWorkspace"
+                    ],
+                    "transformKql": "source",
+                    "outputStream": "Microsoft-DeviceFileEvents"
+                }
+            ]
+        }
+    }],
+    "outputs": {
+        "dataCollectionRuleId": {
+            "type": "string",
+            "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+        }
+    }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/DeviceTvmSecureConfigurationAssessmentKB.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/DeviceTvmSecureConfigurationAssessmentKB.json
@@ -1,0 +1,106 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "dataCollectionRuleName": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the name of the Data Collection Rule to create."
+            }
+        },
+        "location": {
+            "defaultValue": "[resourceGroup().location]",
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the location in which to create the Data Collection Rule."
+            }
+        },
+        "workspaceResourceId": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+            }
+        }
+    },
+    "resources": [{
+        "type": "Microsoft.Insights/dataCollectionRules",
+        "apiVersion": "2023-03-11",
+        "name": "[parameters('dataCollectionRuleName')]",
+        "location": "[parameters('location')]",
+        "kind": "Direct",
+        "properties": {
+            "streamDeclarations": {
+                "Custom-DeviceTvmSecureConfigurationAssessmentKB": {
+                    "columns": [{
+                            "name": "ConfigurationId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ConfigurationImpact",
+                            "type": "real"
+                        },
+                        {
+                            "name": "ConfigurationName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ConfigurationDescription",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RiskDescription",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ConfigurationCategory",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ConfigurationSubcategory",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ConfigurationBenchmarks",
+                            "type": "dynamic"
+                        },
+                        {
+                            "name": "Tags",
+                            "type": "dynamic"
+                        },
+                        {
+                            "name": "RemediationOptions",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TimeGenerated",
+                            "type": "datetime"
+                        }
+                    ]
+                }
+            },
+            "destinations": {
+                "logAnalytics": [{
+                    "workspaceResourceId": "[parameters('workspaceResourceId')]",
+                    "name": "logAnalyticsWorkspace"
+                }]
+            },
+            "dataFlows": [{
+                    "streams": [
+                        "Custom-DeviceTvmSecureConfigurationAssessmentKB"
+                    ],
+                    "destinations": [
+                        "logAnalyticsWorkspace"
+                    ],
+                    "transformKql": "source",
+                    "outputStream": "Microsoft-DeviceTvmSecureConfigurationAssessmentKB"
+                }
+            ]
+        }
+    }],
+    "outputs": {
+        "dataCollectionRuleId": {
+            "type": "string",
+            "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+        }
+    }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/DeviceTvmSoftwareVulnerabilitiesKB.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/DeviceTvmSoftwareVulnerabilitiesKB.json
@@ -1,0 +1,106 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "dataCollectionRuleName": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the name of the Data Collection Rule to create."
+            }
+        },
+        "location": {
+            "defaultValue": "[resourceGroup().location]",
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the location in which to create the Data Collection Rule."
+            }
+        },
+        "workspaceResourceId": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+            }
+        }
+    },
+    "resources": [{
+        "type": "Microsoft.Insights/dataCollectionRules",
+        "apiVersion": "2023-03-11",
+        "name": "[parameters('dataCollectionRuleName')]",
+        "location": "[parameters('location')]",
+        "kind": "Direct",
+        "properties": {
+            "streamDeclarations": {
+                "Custom-DeviceTvmSoftwareVulnerabilitiesKB": {
+                    "columns": [{
+                            "name": "AffectedSoftware",
+                            "type": "dynamic"
+                        },
+                        {
+                            "name": "CveId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "CvssScore",
+                            "type": "real"
+                        },
+                        {
+                            "name": "IsExploitAvailable",
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "LastModifiedTime",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "PublishedDate",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "SourceSystem",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TimeGenerated",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "Timestamp",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "VulnerabilityDescription",
+                            "type": "string"
+                        },
+                        {
+                            "name": "VulnerabilitySeverityLevel",
+                            "type": "string"
+                        }
+                    ]
+                }
+            },
+            "destinations": {
+                "logAnalytics": [{
+                    "workspaceResourceId": "[parameters('workspaceResourceId')]",
+                    "name": "logAnalyticsWorkspace"
+                }]
+            },
+            "dataFlows": [{
+                    "streams": [
+                        "Custom-DeviceTvmSoftwareVulnerabilitiesKB"
+                    ],
+                    "destinations": [
+                        "logAnalyticsWorkspace"
+                    ],
+                    "transformKql": "source",
+                    "outputStream": "Microsoft-DeviceTvmSoftwareVulnerabilitiesKB"
+                }
+            ]
+        }
+    }],
+    "outputs": {
+        "dataCollectionRuleId": {
+            "type": "string",
+            "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+        }
+    }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/Event.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/Event.json
@@ -1,0 +1,130 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "dataCollectionRuleName": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the name of the Data Collection Rule to create."
+            }
+        },
+        "location": {
+            "defaultValue": "[resourceGroup().location]",
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the location in which to create the Data Collection Rule."
+            }
+        },
+        "workspaceResourceId": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+            }
+        }
+    },
+    "resources": [{
+        "type": "Microsoft.Insights/dataCollectionRules",
+        "apiVersion": "2023-03-11",
+        "name": "[parameters('dataCollectionRuleName')]",
+        "location": "[parameters('location')]",
+        "kind": "Direct",
+        "properties": {
+            "streamDeclarations": {
+                "Custom-Event": {
+                    "columns": [{
+                            "name": "AzureDeploymentID",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Computer",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventCategory",
+                            "type": "int"
+                        },
+                        {
+                            "name": "EventData",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventID",
+                            "type": "int"
+                        },
+                        {
+                            "name": "EventLevel",
+                            "type": "int"
+                        },
+                        {
+                            "name": "EventLevelName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventLog",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ManagementGroupName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Message",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ParameterXml",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RenderedDescription",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Role",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Source",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SourceSystem",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TimeGenerated",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "UserName",
+                            "type": "string"
+                        }
+                    ]
+                }
+            },
+            "destinations": {
+                "logAnalytics": [{
+                    "workspaceResourceId": "[parameters('workspaceResourceId')]",
+                    "name": "logAnalyticsWorkspace"
+                }]
+            },
+            "dataFlows": [{
+                    "streams": [
+                        "Custom-Event"
+                    ],
+                    "destinations": [
+                        "logAnalyticsWorkspace"
+                    ],
+                    "transformKql": "source",
+                    "outputStream": "Microsoft-Event"
+                }
+            ]
+        }
+    }],
+    "outputs": {
+        "dataCollectionRuleId": {
+            "type": "string",
+            "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+        }
+    }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/ExchangeAssessmentRecommendation.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/ExchangeAssessmentRecommendation.json
@@ -1,0 +1,158 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "dataCollectionRuleName": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the name of the Data Collection Rule to create."
+            }
+        },
+        "location": {
+            "defaultValue": "[resourceGroup().location]",
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the location in which to create the Data Collection Rule."
+            }
+        },
+        "workspaceResourceId": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+            }
+        }
+    },
+    "resources": [{
+        "type": "Microsoft.Insights/dataCollectionRules",
+        "apiVersion": "2023-03-11",
+        "name": "[parameters('dataCollectionRuleName')]",
+        "location": "[parameters('location')]",
+        "kind": "Direct",
+        "properties": {
+            "streamDeclarations": {
+                "Custom-ExchangeAssessmentRecommendation": {
+                    "columns": [{
+                            "name": "ActionArea",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActionAreaId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActiveDirectorySite",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AffectedObjectName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AffectedObjectType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AssessmentId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Computer",
+                            "type": "string"
+                        },
+                        {
+                            "name": "CustomData",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Description",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ExchangeAdminGroup",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ExchangeDAG",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ExchangeMailboxDatabase",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ExchangeOrganization",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ExchangePublicFolderDatabase",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ExchangeServer",
+                            "type": "string"
+                        },
+                        {
+                            "name": "FocusArea",
+                            "type": "string"
+                        },
+                        {
+                            "name": "FocusAreaId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Recommendation",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RecommendationId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RecommendationResult",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RecommendationWeight",
+                            "type": "real"
+                        },
+                        {
+                            "name": "SourceSystem",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Technology",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TimeGenerated",
+                            "type": "datetime"
+                        }
+                    ]
+                }
+            },
+            "destinations": {
+                "logAnalytics": [{
+                    "workspaceResourceId": "[parameters('workspaceResourceId')]",
+                    "name": "logAnalyticsWorkspace"
+                }]
+            },
+            "dataFlows": [{
+                    "streams": [
+                        "Custom-ExchangeAssessmentRecommendation"
+                    ],
+                    "destinations": [
+                        "logAnalyticsWorkspace"
+                    ],
+                    "transformKql": "source",
+                    "outputStream": "Microsoft-ExchangeAssessmentRecommendation"
+                }
+            ]
+        }
+    }],
+    "outputs": {
+        "dataCollectionRuleId": {
+            "type": "string",
+            "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+        }
+    }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/ExchangeOnlineAssessmentRecommendation.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/ExchangeOnlineAssessmentRecommendation.json
@@ -1,0 +1,134 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "dataCollectionRuleName": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the name of the Data Collection Rule to create."
+            }
+        },
+        "location": {
+            "defaultValue": "[resourceGroup().location]",
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the location in which to create the Data Collection Rule."
+            }
+        },
+        "workspaceResourceId": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+            }
+        }
+    },
+    "resources": [{
+        "type": "Microsoft.Insights/dataCollectionRules",
+        "apiVersion": "2023-03-11",
+        "name": "[parameters('dataCollectionRuleName')]",
+        "location": "[parameters('location')]",
+        "kind": "Direct",
+        "properties": {
+            "streamDeclarations": {
+                "Custom-ExchangeOnlineAssessmentRecommendation": {
+                    "columns": [{
+                            "name": "ActionArea",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActionAreaId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AffectedObjectName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AffectedObjectType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AssessmentId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Computer",
+                            "type": "string"
+                        },
+                        {
+                            "name": "CustomData",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Description",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ExchangeOnlineOrganization",
+                            "type": "string"
+                        },
+                        {
+                            "name": "FocusArea",
+                            "type": "string"
+                        },
+                        {
+                            "name": "FocusAreaId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Recommendation",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RecommendationId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RecommendationResult",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RecommendationWeight",
+                            "type": "real"
+                        },
+                        {
+                            "name": "SourceSystem",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Technology",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TimeGenerated",
+                            "type": "datetime"
+                        }
+                    ]
+                }
+            },
+            "destinations": {
+                "logAnalytics": [{
+                    "workspaceResourceId": "[parameters('workspaceResourceId')]",
+                    "name": "logAnalyticsWorkspace"
+                }]
+            },
+            "dataFlows": [{
+                    "streams": [
+                        "Custom-ExchangeOnlineAssessmentRecommendation"
+                    ],
+                    "destinations": [
+                        "logAnalyticsWorkspace"
+                    ],
+                    "transformKql": "source",
+                    "outputStream": "Microsoft-ExchangeOnlineAssessmentRecommendation"
+                }
+            ]
+        }
+    }],
+    "outputs": {
+        "dataCollectionRuleId": {
+            "type": "string",
+            "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+        }
+    }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/GCPAuditLogs.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/GCPAuditLogs.json
@@ -1,0 +1,162 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "dataCollectionRuleName": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the name of the Data Collection Rule to create."
+            }
+        },
+        "location": {
+            "defaultValue": "[resourceGroup().location]",
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the location in which to create the Data Collection Rule."
+            }
+        },
+        "workspaceResourceId": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+            }
+        }
+    },
+    "resources": [{
+        "type": "Microsoft.Insights/dataCollectionRules",
+        "apiVersion": "2023-03-11",
+        "name": "[parameters('dataCollectionRuleName')]",
+        "location": "[parameters('location')]",
+        "kind": "Direct",
+        "properties": {
+            "streamDeclarations": {
+                "Custom-GCPAuditLogs": {
+                    "columns": [{
+                            "name": "AuthenticationInfo",
+                            "type": "dynamic"
+                        },
+                        {
+                            "name": "AuthorizationInfo",
+                            "type": "dynamic"
+                        },
+                        {
+                            "name": "GCPResourceName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "GCPResourceType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "InsertId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "LogName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Metadata",
+                            "type": "dynamic"
+                        },
+                        {
+                            "name": "MethodName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "NumResponseItems",
+                            "type": "string"
+                        },
+                        {
+                            "name": "PrincipalEmail",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ProjectId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Request",
+                            "type": "dynamic"
+                        },
+                        {
+                            "name": "RequestMetadata",
+                            "type": "dynamic"
+                        },
+                        {
+                            "name": "ResourceLocation",
+                            "type": "dynamic"
+                        },
+                        {
+                            "name": "ResourceOriginalState",
+                            "type": "dynamic"
+                        },
+                        {
+                            "name": "Response",
+                            "type": "dynamic"
+                        },
+                        {
+                            "name": "ServiceData",
+                            "type": "dynamic"
+                        },
+                        {
+                            "name": "ServiceName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Severity",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SourceSystem",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Status",
+                            "type": "dynamic"
+                        },
+                        {
+                            "name": "StatusMessage",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Subscription",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TimeGenerated",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "Timestamp",
+                            "type": "datetime"
+                        }
+                    ]
+                }
+            },
+            "destinations": {
+                "logAnalytics": [{
+                    "workspaceResourceId": "[parameters('workspaceResourceId')]",
+                    "name": "logAnalyticsWorkspace"
+                }]
+            },
+            "dataFlows": [{
+                    "streams": [
+                        "Custom-GCPAuditLogs"
+                    ],
+                    "destinations": [
+                        "logAnalyticsWorkspace"
+                    ],
+                    "transformKql": "source",
+                    "outputStream": "Microsoft-GCPAuditLogs"
+                }
+            ]
+        }
+    }],
+    "outputs": {
+        "dataCollectionRuleId": {
+            "type": "string",
+            "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+        }
+    }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/GoogleCloudSCC.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/GoogleCloudSCC.json
@@ -1,0 +1,82 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "dataCollectionRuleName": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the name of the Data Collection Rule to create."
+            }
+        },
+        "location": {
+            "defaultValue": "[resourceGroup().location]",
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the location in which to create the Data Collection Rule."
+            }
+        },
+        "workspaceResourceId": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+            }
+        }
+    },
+    "resources": [{
+        "type": "Microsoft.Insights/dataCollectionRules",
+        "apiVersion": "2023-03-11",
+        "name": "[parameters('dataCollectionRuleName')]",
+        "location": "[parameters('location')]",
+        "kind": "Direct",
+        "properties": {
+            "streamDeclarations": {
+                "Custom-GoogleCloudSCC": {
+                    "columns": [{
+                            "name": "Findings",
+                            "type": "dynamic"
+                        },
+                        {
+                            "name": "FindingsResource",
+                            "type": "dynamic"
+                        },
+                        {
+                            "name": "SourceProperties",
+                            "type": "dynamic"
+                        },
+                        {
+                            "name": "SourceSystem",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TimeGenerated",
+                            "type": "datetime"
+                        }
+                    ]
+                }
+            },
+            "destinations": {
+                "logAnalytics": [{
+                    "workspaceResourceId": "[parameters('workspaceResourceId')]",
+                    "name": "logAnalyticsWorkspace"
+                }]
+            },
+            "dataFlows": [{
+                    "streams": [
+                        "Custom-GoogleCloudSCC"
+                    ],
+                    "destinations": [
+                        "logAnalyticsWorkspace"
+                    ],
+                    "transformKql": "source",
+                    "outputStream": "Microsoft-GoogleCloudSCC"
+                }
+            ]
+        }
+    }],
+    "outputs": {
+        "dataCollectionRuleId": {
+            "type": "string",
+            "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+        }
+    }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/SCCMAssessmentRecommendation.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/SCCMAssessmentRecommendation.json
@@ -1,0 +1,138 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "dataCollectionRuleName": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the name of the Data Collection Rule to create."
+            }
+        },
+        "location": {
+            "defaultValue": "[resourceGroup().location]",
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the location in which to create the Data Collection Rule."
+            }
+        },
+        "workspaceResourceId": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+            }
+        }
+    },
+    "resources": [{
+        "type": "Microsoft.Insights/dataCollectionRules",
+        "apiVersion": "2023-03-11",
+        "name": "[parameters('dataCollectionRuleName')]",
+        "location": "[parameters('location')]",
+        "kind": "Direct",
+        "properties": {
+            "streamDeclarations": {
+                "Custom-SCCMAssessmentRecommendation": {
+                    "columns": [{
+                            "name": "ActionArea",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActionAreaId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AffectedObjectName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AffectedObjectType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AssessmentId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Computer",
+                            "type": "string"
+                        },
+                        {
+                            "name": "CustomData",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Description",
+                            "type": "string"
+                        },
+                        {
+                            "name": "FocusArea",
+                            "type": "string"
+                        },
+                        {
+                            "name": "FocusAreaId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Recommendation",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RecommendationId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RecommendationResult",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RecommendationWeight",
+                            "type": "real"
+                        },
+                        {
+                            "name": "SiteCode",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SiteServer",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SourceSystem",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Technology",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TimeGenerated",
+                            "type": "datetime"
+                        }
+                    ]
+                }
+            },
+            "destinations": {
+                "logAnalytics": [{
+                    "workspaceResourceId": "[parameters('workspaceResourceId')]",
+                    "name": "logAnalyticsWorkspace"
+                }]
+            },
+            "dataFlows": [{
+                    "streams": [
+                        "Custom-SCCMAssessmentRecommendation"
+                    ],
+                    "destinations": [
+                        "logAnalyticsWorkspace"
+                    ],
+                    "transformKql": "source",
+                    "outputStream": "Microsoft-SCCMAssessmentRecommendation"
+                }
+            ]
+        }
+    }],
+    "outputs": {
+        "dataCollectionRuleId": {
+            "type": "string",
+            "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+        }
+    }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/SCOMAssessmentRecommendation.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/SCOMAssessmentRecommendation.json
@@ -1,0 +1,138 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "dataCollectionRuleName": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the name of the Data Collection Rule to create."
+            }
+        },
+        "location": {
+            "defaultValue": "[resourceGroup().location]",
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the location in which to create the Data Collection Rule."
+            }
+        },
+        "workspaceResourceId": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+            }
+        }
+    },
+    "resources": [{
+        "type": "Microsoft.Insights/dataCollectionRules",
+        "apiVersion": "2023-03-11",
+        "name": "[parameters('dataCollectionRuleName')]",
+        "location": "[parameters('location')]",
+        "kind": "Direct",
+        "properties": {
+            "streamDeclarations": {
+                "Custom-SCOMAssessmentRecommendation": {
+                    "columns": [{
+                            "name": "ActionArea",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActionAreaId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AffectedObjectName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AffectedObjectType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AssessmentId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Computer",
+                            "type": "string"
+                        },
+                        {
+                            "name": "CustomData",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Description",
+                            "type": "string"
+                        },
+                        {
+                            "name": "FocusArea",
+                            "type": "string"
+                        },
+                        {
+                            "name": "FocusAreaId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ManagementGroup",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ManagementServer",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Recommendation",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RecommendationId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RecommendationResult",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RecommendationWeight",
+                            "type": "real"
+                        },
+                        {
+                            "name": "SourceSystem",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Technology",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TimeGenerated",
+                            "type": "datetime"
+                        }
+                    ]
+                }
+            },
+            "destinations": {
+                "logAnalytics": [{
+                    "workspaceResourceId": "[parameters('workspaceResourceId')]",
+                    "name": "logAnalyticsWorkspace"
+                }]
+            },
+            "dataFlows": [{
+                    "streams": [
+                        "Custom-SCOMAssessmentRecommendation"
+                    ],
+                    "destinations": [
+                        "logAnalyticsWorkspace"
+                    ],
+                    "transformKql": "source",
+                    "outputStream": "Microsoft-SCOMAssessmentRecommendation"
+                }
+            ]
+        }
+    }],
+    "outputs": {
+        "dataCollectionRuleId": {
+            "type": "string",
+            "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+        }
+    }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/SPAssessmentRecommendation.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/SPAssessmentRecommendation.json
@@ -1,0 +1,142 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "dataCollectionRuleName": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the name of the Data Collection Rule to create."
+            }
+        },
+        "location": {
+            "defaultValue": "[resourceGroup().location]",
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the location in which to create the Data Collection Rule."
+            }
+        },
+        "workspaceResourceId": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+            }
+        }
+    },
+    "resources": [{
+        "type": "Microsoft.Insights/dataCollectionRules",
+        "apiVersion": "2023-03-11",
+        "name": "[parameters('dataCollectionRuleName')]",
+        "location": "[parameters('location')]",
+        "kind": "Direct",
+        "properties": {
+            "streamDeclarations": {
+                "Custom-SPAssessmentRecommendation": {
+                    "columns": [{
+                            "name": "ActionArea",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActionAreaId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AffectedObjectName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AffectedObjectType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AssessmentId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Computer",
+                            "type": "string"
+                        },
+                        {
+                            "name": "CustomData",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Description",
+                            "type": "string"
+                        },
+                        {
+                            "name": "FocusArea",
+                            "type": "string"
+                        },
+                        {
+                            "name": "FocusAreaId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Recommendation",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RecommendationId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RecommendationResult",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RecommendationWeight",
+                            "type": "real"
+                        },
+                        {
+                            "name": "SharePointFarm",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SharePointServer",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SourceSystem",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Technology",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TimeGenerated",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "WebApplication",
+                            "type": "string"
+                        }
+                    ]
+                }
+            },
+            "destinations": {
+                "logAnalytics": [{
+                    "workspaceResourceId": "[parameters('workspaceResourceId')]",
+                    "name": "logAnalyticsWorkspace"
+                }]
+            },
+            "dataFlows": [{
+                    "streams": [
+                        "Custom-SPAssessmentRecommendation"
+                    ],
+                    "destinations": [
+                        "logAnalyticsWorkspace"
+                    ],
+                    "transformKql": "source",
+                    "outputStream": "Microsoft-SPAssessmentRecommendation"
+                }
+            ]
+        }
+    }],
+    "outputs": {
+        "dataCollectionRuleId": {
+            "type": "string",
+            "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+        }
+    }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/SQLAssessmentRecommendation.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/SQLAssessmentRecommendation.json
@@ -1,0 +1,138 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "dataCollectionRuleName": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the name of the Data Collection Rule to create."
+            }
+        },
+        "location": {
+            "defaultValue": "[resourceGroup().location]",
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the location in which to create the Data Collection Rule."
+            }
+        },
+        "workspaceResourceId": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+            }
+        }
+    },
+    "resources": [{
+        "type": "Microsoft.Insights/dataCollectionRules",
+        "apiVersion": "2023-03-11",
+        "name": "[parameters('dataCollectionRuleName')]",
+        "location": "[parameters('location')]",
+        "kind": "Direct",
+        "properties": {
+            "streamDeclarations": {
+                "Custom-SQLAssessmentRecommendation": {
+                    "columns": [{
+                            "name": "ActionArea",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActionAreaId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AffectedObjectName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AffectedObjectType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AssessmentId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Computer",
+                            "type": "string"
+                        },
+                        {
+                            "name": "CustomData",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DatabaseName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Description",
+                            "type": "string"
+                        },
+                        {
+                            "name": "FocusArea",
+                            "type": "string"
+                        },
+                        {
+                            "name": "FocusAreaId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Recommendation",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RecommendationId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RecommendationResult",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RecommendationWeight",
+                            "type": "real"
+                        },
+                        {
+                            "name": "SourceSystem",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SqlInstanceName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Technology",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TimeGenerated",
+                            "type": "datetime"
+                        }
+                    ]
+                }
+            },
+            "destinations": {
+                "logAnalytics": [{
+                    "workspaceResourceId": "[parameters('workspaceResourceId')]",
+                    "name": "logAnalyticsWorkspace"
+                }]
+            },
+            "dataFlows": [{
+                    "streams": [
+                        "Custom-SQLAssessmentRecommendation"
+                    ],
+                    "destinations": [
+                        "logAnalyticsWorkspace"
+                    ],
+                    "transformKql": "source",
+                    "outputStream": "Microsoft-SQLAssessmentRecommendation"
+                }
+            ]
+        }
+    }],
+    "outputs": {
+        "dataCollectionRuleId": {
+            "type": "string",
+            "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+        }
+    }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/SecurityEvent.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/SecurityEvent.json
@@ -1,0 +1,935 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "dataCollectionRuleName": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the name of the Data Collection Rule to create."
+            }
+        },
+        "location": {
+            "defaultValue": "[resourceGroup().location]",
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the location in which to create the Data Collection Rule."
+            }
+        },
+        "workspaceResourceId": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+            }
+        }
+    },
+    "resources": [{
+        "type": "Microsoft.Insights/dataCollectionRules",
+        "apiVersion": "2023-03-11",
+        "name": "[parameters('dataCollectionRuleName')]",
+        "location": "[parameters('location')]",
+        "kind": "Direct",
+        "properties": {
+            "streamDeclarations": {
+                "Custom-SecurityEvent": {
+                    "columns": [
+                        {
+                            "name": "AccessMask",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Account",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AccountDomain",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AccountExpires",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AccountName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AccountSessionIdentifier",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AccountType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Activity",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AdditionalInfo",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AdditionalInfo2",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AllowedToDelegateTo",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Attributes",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AuditPolicyChanges",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AuditsDiscarded",
+                            "type": "int"
+                        },
+                        {
+                            "name": "AuthenticationLevel",
+                            "type": "int"
+                        },
+                        {
+                            "name": "AuthenticationPackageName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AuthenticationProvider",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AuthenticationServer",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AuthenticationService",
+                            "type": "int"
+                        },
+                        {
+                            "name": "AuthenticationType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AzureDeploymentID",
+                            "type": "string"
+                        },
+                        {
+                            "name": "CACertificateHash",
+                            "type": "string"
+                        },
+                        {
+                            "name": "CalledStationID",
+                            "type": "string"
+                        },
+                        {
+                            "name": "CallerProcessId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "CallerProcessName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "CallingStationID",
+                            "type": "string"
+                        },
+                        {
+                            "name": "CAPublicKeyHash",
+                            "type": "string"
+                        },
+                        {
+                            "name": "CategoryId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "CertificateDatabaseHash",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Channel",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ClassId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ClassName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ClientAddress",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ClientIPAddress",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ClientName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "CommandLine",
+                            "type": "string"
+                        },
+                        {
+                            "name": "CompatibleIds",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Computer",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Correlation",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DCDNSName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DeviceDescription",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DeviceId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DisplayName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Disposition",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DomainBehaviorVersion",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DomainName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DomainPolicyChanged",
+                            "type": "string"
+                        },
+                        {
+                            "name": "DomainSid",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EAPType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ElevatedToken",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ErrorCode",
+                            "type": "int"
+                        },
+                        {
+                            "name": "EventData",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventID",
+                            "type": "int"
+                        },
+                        {
+                            "name": "EventLevelName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventRecordId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventSourceName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ExtendedQuarantineState",
+                            "type": "string"
+                        },
+                        {
+                            "name": "FailureReason",
+                            "type": "string"
+                        },
+                        {
+                            "name": "FileHash",
+                            "type": "string"
+                        },
+                        {
+                            "name": "FilePath",
+                            "type": "string"
+                        },
+                        {
+                            "name": "FilePathNoUser",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Filter",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ForceLogoff",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Fqbn",
+                            "type": "string"
+                        },
+                        {
+                            "name": "FullyQualifiedSubjectMachineName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "FullyQualifiedSubjectUserName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "GroupMembership",
+                            "type": "string"
+                        },
+                        {
+                            "name": "HandleId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "HardwareIds",
+                            "type": "string"
+                        },
+                        {
+                            "name": "HomeDirectory",
+                            "type": "string"
+                        },
+                        {
+                            "name": "HomePath",
+                            "type": "string"
+                        },
+                        {
+                            "name": "IpAddress",
+                            "type": "string"
+                        },
+                        {
+                            "name": "IpPort",
+                            "type": "string"
+                        },
+                        {
+                            "name": "KeyLength",
+                            "type": "int"
+                        },
+                        {
+                            "name": "Keywords",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Level",
+                            "type": "string"
+                        },
+                        {
+                            "name": "LmPackageName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "LocationInformation",
+                            "type": "string"
+                        },
+                        {
+                            "name": "LockoutDuration",
+                            "type": "string"
+                        },
+                        {
+                            "name": "LockoutObservationWindow",
+                            "type": "string"
+                        },
+                        {
+                            "name": "LockoutThreshold",
+                            "type": "string"
+                        },
+                        {
+                            "name": "LoggingResult",
+                            "type": "string"
+                        },
+                        {
+                            "name": "LogonHours",
+                            "type": "string"
+                        },
+                        {
+                            "name": "LogonID",
+                            "type": "string"
+                        },
+                        {
+                            "name": "LogonProcessName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "LogonType",
+                            "type": "int"
+                        },
+                        {
+                            "name": "LogonTypeName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "MachineAccountQuota",
+                            "type": "string"
+                        },
+                        {
+                            "name": "MachineInventory",
+                            "type": "string"
+                        },
+                        {
+                            "name": "MachineLogon",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ManagementGroupName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "MandatoryLabel",
+                            "type": "string"
+                        },
+                        {
+                            "name": "MaxPasswordAge",
+                            "type": "string"
+                        },
+                        {
+                            "name": "MemberName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "MemberSid",
+                            "type": "string"
+                        },
+                        {
+                            "name": "MinPasswordAge",
+                            "type": "string"
+                        },
+                        {
+                            "name": "MinPasswordLength",
+                            "type": "string"
+                        },
+                        {
+                            "name": "MixedDomainMode",
+                            "type": "string"
+                        },
+                        {
+                            "name": "NASIdentifier",
+                            "type": "string"
+                        },
+                        {
+                            "name": "NASIPv4Address",
+                            "type": "string"
+                        },
+                        {
+                            "name": "NASIPv6Address",
+                            "type": "string"
+                        },
+                        {
+                            "name": "NASPort",
+                            "type": "string"
+                        },
+                        {
+                            "name": "NASPortType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "NetworkPolicyName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "NewDate",
+                            "type": "string"
+                        },
+                        {
+                            "name": "NewMaxUsers",
+                            "type": "string"
+                        },
+                        {
+                            "name": "NewProcessId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "NewProcessName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "NewRemark",
+                            "type": "string"
+                        },
+                        {
+                            "name": "NewShareFlags",
+                            "type": "string"
+                        },
+                        {
+                            "name": "NewTime",
+                            "type": "string"
+                        },
+                        {
+                            "name": "NewUacValue",
+                            "type": "string"
+                        },
+                        {
+                            "name": "NewValue",
+                            "type": "string"
+                        },
+                        {
+                            "name": "NewValueType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ObjectName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ObjectServer",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ObjectType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ObjectValueName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "OemInformation",
+                            "type": "string"
+                        },
+                        {
+                            "name": "OldMaxUsers",
+                            "type": "string"
+                        },
+                        {
+                            "name": "OldRemark",
+                            "type": "string"
+                        },
+                        {
+                            "name": "OldShareFlags",
+                            "type": "string"
+                        },
+                        {
+                            "name": "OldUacValue",
+                            "type": "string"
+                        },
+                        {
+                            "name": "OldValue",
+                            "type": "string"
+                        },
+                        {
+                            "name": "OldValueType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Opcode",
+                            "type": "string"
+                        },
+                        {
+                            "name": "OperationType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "PackageName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ParentProcessName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "PasswordHistoryLength",
+                            "type": "string"
+                        },
+                        {
+                            "name": "PasswordLastSet",
+                            "type": "string"
+                        },
+                        {
+                            "name": "PasswordProperties",
+                            "type": "string"
+                        },
+                        {
+                            "name": "PreviousDate",
+                            "type": "string"
+                        },
+                        {
+                            "name": "PreviousTime",
+                            "type": "string"
+                        },
+                        {
+                            "name": "PrimaryGroupId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "PrivateKeyUsageCount",
+                            "type": "string"
+                        },
+                        {
+                            "name": "PrivilegeList",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Process",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ProcessId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ProcessName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ProfilePath",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Properties",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ProtocolSequence",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ProxyPolicyName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "QuarantineHelpURL",
+                            "type": "string"
+                        },
+                        {
+                            "name": "QuarantineSessionID",
+                            "type": "string"
+                        },
+                        {
+                            "name": "QuarantineSessionIdentifier",
+                            "type": "string"
+                        },
+                        {
+                            "name": "QuarantineState",
+                            "type": "string"
+                        },
+                        {
+                            "name": "QuarantineSystemHealthResult",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RelativeTargetName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RemoteIpAddress",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RemotePort",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Requester",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RequestId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RestrictedAdminMode",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RowsDeleted",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SamAccountName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ScriptPath",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SecurityDescriptor",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ServiceAccount",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ServiceFileName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ServiceName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ServiceStartType",
+                            "type": "int"
+                        },
+                        {
+                            "name": "ServiceType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SessionName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ShareLocalPath",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ShareName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SidHistory",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SourceSystem",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Status",
+                            "type": "string"
+                        },
+                        {
+                            "name": "StorageAccount",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SubcategoryId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Subject",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SubjectAccount",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SubjectDomainName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SubjectKeyIdentifier",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SubjectLogonId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SubjectMachineName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SubjectMachineSID",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SubjectUserName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SubjectUserSid",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SubStatus",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SystemProcessId",
+                            "type": "int"
+                        },
+                        {
+                            "name": "SystemThreadId",
+                            "type": "int"
+                        },
+                        {
+                            "name": "SystemUserId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TableId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetAccount",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetDomainName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetInfo",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetLinkedLogonId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetLogonId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetOutboundDomainName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetOutboundUserName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetServerName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetSid",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetUser",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetUserName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetUserSid",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Task",
+                            "type": "int"
+                        },
+                        {
+                            "name": "TemplateContent",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TemplateDSObjectFQDN",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TemplateInternalName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TemplateOID",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TemplateSchemaVersion",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TemplateVersion",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TimeGenerated",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "TokenElevationType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TransmittedServices",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Type",
+                            "type": "string"
+                        },
+                        {
+                            "name": "UserAccountControl",
+                            "type": "string"
+                        },
+                        {
+                            "name": "UserParameters",
+                            "type": "string"
+                        },
+                        {
+                            "name": "UserPrincipalName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "UserWorkstations",
+                            "type": "string"
+                        },
+                        {
+                            "name": "VendorIds",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Version",
+                            "type": "int"
+                        },
+                        {
+                            "name": "VirtualAccount",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Workstation",
+                            "type": "string"
+                        },
+                        {
+                            "name": "WorkstationName",
+                            "type": "string"
+                        }
+                    ]
+                }
+            },
+            "destinations": {
+                "logAnalytics": [{
+                    "workspaceResourceId": "[parameters('workspaceResourceId')]",
+                    "name": "logAnalyticsWorkspace"
+                }]
+            },
+            "dataFlows": [{
+                    "streams": [
+                        "Custom-SecurityEvent"
+                    ],
+                    "destinations": [
+                        "logAnalyticsWorkspace"
+                    ],
+                    "transformKql": "source",
+                    "outputStream": "Microsoft-SecurityEvent"
+                }
+            ]
+        }
+    }],
+    "outputs": {
+        "dataCollectionRuleId": {
+            "type": "string",
+            "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+        }
+    }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/SfBAssessmentRecommendation.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/SfBAssessmentRecommendation.json
@@ -1,0 +1,138 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "dataCollectionRuleName": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the name of the Data Collection Rule to create."
+            }
+        },
+        "location": {
+            "defaultValue": "[resourceGroup().location]",
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the location in which to create the Data Collection Rule."
+            }
+        },
+        "workspaceResourceId": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+            }
+        }
+    },
+    "resources": [{
+        "type": "Microsoft.Insights/dataCollectionRules",
+        "apiVersion": "2023-03-11",
+        "name": "[parameters('dataCollectionRuleName')]",
+        "location": "[parameters('location')]",
+        "kind": "Direct",
+        "properties": {
+            "streamDeclarations": {
+                "Custom-SfBAssessmentRecommendation": {
+                    "columns": [{
+                            "name": "ActionArea",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActionAreaId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AffectedObjectName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AffectedObjectType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AssessmentId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Computer",
+                            "type": "string"
+                        },
+                        {
+                            "name": "CustomData",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Description",
+                            "type": "string"
+                        },
+                        {
+                            "name": "FocusArea",
+                            "type": "string"
+                        },
+                        {
+                            "name": "FocusAreaId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Recommendation",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RecommendationId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RecommendationResult",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RecommendationWeight",
+                            "type": "real"
+                        },
+                        {
+                            "name": "SfBPool",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SfBServer",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SourceSystem",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Technology",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TimeGenerated",
+                            "type": "datetime"
+                        }
+                    ]
+                }
+            },
+            "destinations": {
+                "logAnalytics": [{
+                    "workspaceResourceId": "[parameters('workspaceResourceId')]",
+                    "name": "logAnalyticsWorkspace"
+                }]
+            },
+            "dataFlows": [{
+                    "streams": [
+                        "Custom-SfBAssessmentRecommendation"
+                    ],
+                    "destinations": [
+                        "logAnalyticsWorkspace"
+                    ],
+                    "transformKql": "source",
+                    "outputStream": "Microsoft-SfBAssessmentRecommendation"
+                }
+            ]
+        }
+    }],
+    "outputs": {
+        "dataCollectionRuleId": {
+            "type": "string",
+            "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+        }
+    }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/SfBOnlineAssessmentRecommendation.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/SfBOnlineAssessmentRecommendation.json
@@ -1,0 +1,134 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "dataCollectionRuleName": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the name of the Data Collection Rule to create."
+            }
+        },
+        "location": {
+            "defaultValue": "[resourceGroup().location]",
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the location in which to create the Data Collection Rule."
+            }
+        },
+        "workspaceResourceId": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+            }
+        }
+    },
+    "resources": [{
+        "type": "Microsoft.Insights/dataCollectionRules",
+        "apiVersion": "2023-03-11",
+        "name": "[parameters('dataCollectionRuleName')]",
+        "location": "[parameters('location')]",
+        "kind": "Direct",
+        "properties": {
+            "streamDeclarations": {
+                "Custom-SfBOnlineAssessmentRecommendation": {
+                    "columns": [{
+                            "name": "ActionArea",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActionAreaId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AffectedObjectName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AffectedObjectType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AssessmentId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Computer",
+                            "type": "string"
+                        },
+                        {
+                            "name": "CustomData",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Description",
+                            "type": "string"
+                        },
+                        {
+                            "name": "FocusArea",
+                            "type": "string"
+                        },
+                        {
+                            "name": "FocusAreaId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Recommendation",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RecommendationId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RecommendationResult",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RecommendationWeight",
+                            "type": "real"
+                        },
+                        {
+                            "name": "SfBOnlineOrganization",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SourceSystem",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Technology",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TimeGenerated",
+                            "type": "datetime"
+                        }
+                    ]
+                }
+            },
+            "destinations": {
+                "logAnalytics": [{
+                    "workspaceResourceId": "[parameters('workspaceResourceId')]",
+                    "name": "logAnalyticsWorkspace"
+                }]
+            },
+            "dataFlows": [{
+                    "streams": [
+                        "Custom-SfBOnlineAssessmentRecommendation"
+                    ],
+                    "destinations": [
+                        "logAnalyticsWorkspace"
+                    ],
+                    "transformKql": "source",
+                    "outputStream": "Microsoft-SfBOnlineAssessmentRecommendation"
+                }
+            ]
+        }
+    }],
+    "outputs": {
+        "dataCollectionRuleId": {
+            "type": "string",
+            "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+        }
+    }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/SharePointOnlineAssessmentRecommendation.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/SharePointOnlineAssessmentRecommendation.json
@@ -1,0 +1,134 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "dataCollectionRuleName": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the name of the Data Collection Rule to create."
+            }
+        },
+        "location": {
+            "defaultValue": "[resourceGroup().location]",
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the location in which to create the Data Collection Rule."
+            }
+        },
+        "workspaceResourceId": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+            }
+        }
+    },
+    "resources": [{
+        "type": "Microsoft.Insights/dataCollectionRules",
+        "apiVersion": "2023-03-11",
+        "name": "[parameters('dataCollectionRuleName')]",
+        "location": "[parameters('location')]",
+        "kind": "Direct",
+        "properties": {
+            "streamDeclarations": {
+                "Custom-SharePointOnlineAssessmentRecommendation": {
+                    "columns": [{
+                            "name": "ActionArea",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActionAreaId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AffectedObjectName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AffectedObjectType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AssessmentId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Computer",
+                            "type": "string"
+                        },
+                        {
+                            "name": "CustomData",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Description",
+                            "type": "string"
+                        },
+                        {
+                            "name": "FocusArea",
+                            "type": "string"
+                        },
+                        {
+                            "name": "FocusAreaId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Recommendation",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RecommendationId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RecommendationResult",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RecommendationWeight",
+                            "type": "real"
+                        },
+                        {
+                            "name": "SharePointOnlineOrganization",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SourceSystem",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Technology",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TimeGenerated",
+                            "type": "datetime"
+                        }
+                    ]
+                }
+            },
+            "destinations": {
+                "logAnalytics": [{
+                    "workspaceResourceId": "[parameters('workspaceResourceId')]",
+                    "name": "logAnalyticsWorkspace"
+                }]
+            },
+            "dataFlows": [{
+                    "streams": [
+                        "Custom-SharePointOnlineAssessmentRecommendation"
+                    ],
+                    "destinations": [
+                        "logAnalyticsWorkspace"
+                    ],
+                    "transformKql": "source",
+                    "outputStream": "Microsoft-SharePointOnlineAssessmentRecommendation"
+                }
+            ]
+        }
+    }],
+    "outputs": {
+        "dataCollectionRuleId": {
+            "type": "string",
+            "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+        }
+    }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/Syslog.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/Syslog.json
@@ -1,0 +1,110 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "dataCollectionRuleName": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the name of the Data Collection Rule to create."
+            }
+        },
+        "location": {
+            "defaultValue": "[resourceGroup().location]",
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the location in which to create the Data Collection Rule."
+            }
+        },
+        "workspaceResourceId": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+            }
+        }
+    },
+    "resources": [{
+        "type": "Microsoft.Insights/dataCollectionRules",
+        "apiVersion": "2023-03-11",
+        "name": "[parameters('dataCollectionRuleName')]",
+        "location": "[parameters('location')]",
+        "kind": "Direct",
+        "properties": {
+            "streamDeclarations": {
+                "Custom-Syslog": {
+                    "columns": [{
+                            "name": "CollectorHostName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Computer",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventTime",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "Facility",
+                            "type": "string"
+                        },
+                        {
+                            "name": "HostIP",
+                            "type": "string"
+                        },
+                        {
+                            "name": "HostName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ProcessID",
+                            "type": "int"
+                        },
+                        {
+                            "name": "ProcessName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SeverityLevel",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SourceSystem",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SyslogMessage",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TimeGenerated",
+                            "type": "datetime"
+                        }
+                    ]
+                }
+            },
+            "destinations": {
+                "logAnalytics": [{
+                    "workspaceResourceId": "[parameters('workspaceResourceId')]",
+                    "name": "logAnalyticsWorkspace"
+                }]
+            },
+            "dataFlows": [{
+                    "streams": [
+                        "Custom-Syslog"
+                    ],
+                    "destinations": [
+                        "logAnalyticsWorkspace"
+                    ],
+                    "transformKql": "source",
+                    "outputStream": "Microsoft-Syslog"
+                }
+            ]
+        }
+    }],
+    "outputs": {
+        "dataCollectionRuleId": {
+            "type": "string",
+            "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+        }
+    }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/UCClient.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/UCClient.json
@@ -1,0 +1,114 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "dataCollectionRuleName": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the name of the Data Collection Rule to create."
+            }
+        },
+        "location": {
+            "defaultValue": "[resourceGroup().location]",
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the location in which to create the Data Collection Rule."
+            }
+        },
+        "workspaceResourceId": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+            }
+        }
+    },
+    "resources": [{
+        "type": "Microsoft.Insights/dataCollectionRules",
+        "apiVersion": "2023-03-11",
+        "name": "[parameters('dataCollectionRuleName')]",
+        "location": "[parameters('location')]",
+        "kind": "Direct",
+        "properties": {
+            "streamDeclarations": {
+                "Custom-UCClient": {
+                    "columns": [{
+                            "name": "AzureADDeviceId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AzureADTenantId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Computer",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ComputerID",
+                            "type": "string"
+                        },
+                        {
+                            "name": "GlobalDeviceID",
+                            "type": "string"
+                        },
+                        {
+                            "name": "OSArchitecture",
+                            "type": "string"
+                        },
+                        {
+                            "name": "OSBuild",
+                            "type": "string"
+                        },
+                        {
+                            "name": "OSFamily",
+                            "type": "string"
+                        },
+                        {
+                            "name": "OSName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "OSServicingBranch",
+                            "type": "string"
+                        },
+                        {
+                            "name": "OSVersion",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SourceSystem",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TimeGenerated",
+                            "type": "datetime"
+                        }
+                    ]
+                }
+            },
+            "destinations": {
+                "logAnalytics": [{
+                    "workspaceResourceId": "[parameters('workspaceResourceId')]",
+                    "name": "logAnalyticsWorkspace"
+                }]
+            },
+            "dataFlows": [{
+                    "streams": [
+                        "Custom-UCClient"
+                    ],
+                    "destinations": [
+                        "logAnalyticsWorkspace"
+                    ],
+                    "transformKql": "source",
+                    "outputStream": "Microsoft-UCClient"
+                }
+            ]
+        }
+    }],
+    "outputs": {
+        "dataCollectionRuleId": {
+            "type": "string",
+            "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+        }
+    }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/UCClientReadinessStatus.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/UCClientReadinessStatus.json
@@ -1,0 +1,106 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "dataCollectionRuleName": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the name of the Data Collection Rule to create."
+            }
+        },
+        "location": {
+            "defaultValue": "[resourceGroup().location]",
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the location in which to create the Data Collection Rule."
+            }
+        },
+        "workspaceResourceId": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+            }
+        }
+    },
+    "resources": [{
+        "type": "Microsoft.Insights/dataCollectionRules",
+        "apiVersion": "2023-03-11",
+        "name": "[parameters('dataCollectionRuleName')]",
+        "location": "[parameters('location')]",
+        "kind": "Direct",
+        "properties": {
+            "streamDeclarations": {
+                "Custom-UCClientReadinessStatus": {
+                    "columns": [{
+                            "name": "AzureADDeviceId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AzureADTenantId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Computer",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ComputerID",
+                            "type": "string"
+                        },
+                        {
+                            "name": "GlobalDeviceID",
+                            "type": "string"
+                        },
+                        {
+                            "name": "OSVersion",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ReadinessReason",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ReadinessStatus",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SourceSystem",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetVersion",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TimeGenerated",
+                            "type": "datetime"
+                        }
+                    ]
+                }
+            },
+            "destinations": {
+                "logAnalytics": [{
+                    "workspaceResourceId": "[parameters('workspaceResourceId')]",
+                    "name": "logAnalyticsWorkspace"
+                }]
+            },
+            "dataFlows": [{
+                    "streams": [
+                        "Custom-UCClientReadinessStatus"
+                    ],
+                    "destinations": [
+                        "logAnalyticsWorkspace"
+                    ],
+                    "transformKql": "source",
+                    "outputStream": "Microsoft-UCClientReadinessStatus"
+                }
+            ]
+        }
+    }],
+    "outputs": {
+        "dataCollectionRuleId": {
+            "type": "string",
+            "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+        }
+    }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/UCClientUpdateStatus.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/UCClientUpdateStatus.json
@@ -1,0 +1,118 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "dataCollectionRuleName": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the name of the Data Collection Rule to create."
+            }
+        },
+        "location": {
+            "defaultValue": "[resourceGroup().location]",
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the location in which to create the Data Collection Rule."
+            }
+        },
+        "workspaceResourceId": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+            }
+        }
+    },
+    "resources": [{
+        "type": "Microsoft.Insights/dataCollectionRules",
+        "apiVersion": "2023-03-11",
+        "name": "[parameters('dataCollectionRuleName')]",
+        "location": "[parameters('location')]",
+        "kind": "Direct",
+        "properties": {
+            "streamDeclarations": {
+                "Custom-UCClientUpdateStatus": {
+                    "columns": [{
+                            "name": "AzureADDeviceId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AzureADTenantId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Computer",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ComputerID",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventData",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventID",
+                            "type": "int"
+                        },
+                        {
+                            "name": "GlobalDeviceID",
+                            "type": "string"
+                        },
+                        {
+                            "name": "OSVersion",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SourceSystem",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TimeGenerated",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "UpdateCategory",
+                            "type": "string"
+                        },
+                        {
+                            "name": "UpdateClassification",
+                            "type": "string"
+                        },
+                        {
+                            "name": "UpdateID",
+                            "type": "string"
+                        },
+                        {
+                            "name": "UpdateTitle",
+                            "type": "string"
+                        }
+                    ]
+                }
+            },
+            "destinations": {
+                "logAnalytics": [{
+                    "workspaceResourceId": "[parameters('workspaceResourceId')]",
+                    "name": "logAnalyticsWorkspace"
+                }]
+            },
+            "dataFlows": [{
+                    "streams": [
+                        "Custom-UCClientUpdateStatus"
+                    ],
+                    "destinations": [
+                        "logAnalyticsWorkspace"
+                    ],
+                    "transformKql": "source",
+                    "outputStream": "Microsoft-UCClientUpdateStatus"
+                }
+            ]
+        }
+    }],
+    "outputs": {
+        "dataCollectionRuleId": {
+            "type": "string",
+            "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+        }
+    }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/UCDOAggregatedStatus.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/UCDOAggregatedStatus.json
@@ -1,0 +1,98 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "dataCollectionRuleName": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the name of the Data Collection Rule to create."
+            }
+        },
+        "location": {
+            "defaultValue": "[resourceGroup().location]",
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the location in which to create the Data Collection Rule."
+            }
+        },
+        "workspaceResourceId": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+            }
+        }
+    },
+    "resources": [{
+        "type": "Microsoft.Insights/dataCollectionRules",
+        "apiVersion": "2023-03-11",
+        "name": "[parameters('dataCollectionRuleName')]",
+        "location": "[parameters('location')]",
+        "kind": "Direct",
+        "properties": {
+            "streamDeclarations": {
+                "Custom-UCDOAggregatedStatus": {
+                    "columns": [{
+                            "name": "AzureADTenantId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "BytesFromGroupPeers",
+                            "type": "long"
+                        },
+                        {
+                            "name": "BytesFromHttp",
+                            "type": "long"
+                        },
+                        {
+                            "name": "BytesFromInternetPeers",
+                            "type": "long"
+                        },
+                        {
+                            "name": "GlobalDeviceID",
+                            "type": "string"
+                        },
+                        {
+                            "name": "NoPeersForDownload",
+                            "type": "int"
+                        },
+                        {
+                            "name": "SourceSystem",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TimeGenerated",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "TotalTimeForDownload",
+                            "type": "long"
+                        }
+                    ]
+                }
+            },
+            "destinations": {
+                "logAnalytics": [{
+                    "workspaceResourceId": "[parameters('workspaceResourceId')]",
+                    "name": "logAnalyticsWorkspace"
+                }]
+            },
+            "dataFlows": [{
+                    "streams": [
+                        "Custom-UCDOAggregatedStatus"
+                    ],
+                    "destinations": [
+                        "logAnalyticsWorkspace"
+                    ],
+                    "transformKql": "source",
+                    "outputStream": "Microsoft-UCDOAggregatedStatus"
+                }
+            ]
+        }
+    }],
+    "outputs": {
+        "dataCollectionRuleId": {
+            "type": "string",
+            "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+        }
+    }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/UCDOStatus.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/UCDOStatus.json
@@ -1,0 +1,110 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "dataCollectionRuleName": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the name of the Data Collection Rule to create."
+            }
+        },
+        "location": {
+            "defaultValue": "[resourceGroup().location]",
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the location in which to create the Data Collection Rule."
+            }
+        },
+        "workspaceResourceId": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+            }
+        }
+    },
+    "resources": [{
+        "type": "Microsoft.Insights/dataCollectionRules",
+        "apiVersion": "2023-03-11",
+        "name": "[parameters('dataCollectionRuleName')]",
+        "location": "[parameters('location')]",
+        "kind": "Direct",
+        "properties": {
+            "streamDeclarations": {
+                "Custom-UCDOStatus": {
+                    "columns": [{
+                            "name": "AzureADTenantId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "BytesFromGroupPeers",
+                            "type": "long"
+                        },
+                        {
+                            "name": "BytesFromHttp",
+                            "type": "long"
+                        },
+                        {
+                            "name": "BytesFromInternetPeers",
+                            "type": "long"
+                        },
+                        {
+                            "name": "Computer",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ComputerID",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ContentID",
+                            "type": "string"
+                        },
+                        {
+                            "name": "GlobalDeviceID",
+                            "type": "string"
+                        },
+                        {
+                            "name": "NoPeersForDownload",
+                            "type": "int"
+                        },
+                        {
+                            "name": "SourceSystem",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TimeGenerated",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "TotalTimeForDownload",
+                            "type": "long"
+                        }
+                    ]
+                }
+            },
+            "destinations": {
+                "logAnalytics": [{
+                    "workspaceResourceId": "[parameters('workspaceResourceId')]",
+                    "name": "logAnalyticsWorkspace"
+                }]
+            },
+            "dataFlows": [{
+                    "streams": [
+                        "Custom-UCDOStatus"
+                    ],
+                    "destinations": [
+                        "logAnalyticsWorkspace"
+                    ],
+                    "transformKql": "source",
+                    "outputStream": "Microsoft-UCDOStatus"
+                }
+            ]
+        }
+    }],
+    "outputs": {
+        "dataCollectionRuleId": {
+            "type": "string",
+            "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+        }
+    }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/UCDeviceAlert.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/UCDeviceAlert.json
@@ -1,0 +1,126 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "dataCollectionRuleName": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the name of the Data Collection Rule to create."
+            }
+        },
+        "location": {
+            "defaultValue": "[resourceGroup().location]",
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the location in which to create the Data Collection Rule."
+            }
+        },
+        "workspaceResourceId": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+            }
+        }
+    },
+    "resources": [{
+        "type": "Microsoft.Insights/dataCollectionRules",
+        "apiVersion": "2023-03-11",
+        "name": "[parameters('dataCollectionRuleName')]",
+        "location": "[parameters('location')]",
+        "kind": "Direct",
+        "properties": {
+            "streamDeclarations": {
+                "Custom-UCDeviceAlert": {
+                    "columns": [{
+                            "name": "AlertClassification",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AlertData",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AlertID",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AlertRank",
+                            "type": "int"
+                        },
+                        {
+                            "name": "AlertStatus",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AlertSubtype",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AlertType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AzureADDeviceId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AzureADTenantId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Computer",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ComputerID",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Description",
+                            "type": "string"
+                        },
+                        {
+                            "name": "GlobalDeviceID",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ResolvedTime",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "SourceSystem",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TimeGenerated",
+                            "type": "datetime"
+                        }
+                    ]
+                }
+            },
+            "destinations": {
+                "logAnalytics": [{
+                    "workspaceResourceId": "[parameters('workspaceResourceId')]",
+                    "name": "logAnalyticsWorkspace"
+                }]
+            },
+            "dataFlows": [{
+                    "streams": [
+                        "Custom-UCDeviceAlert"
+                    ],
+                    "destinations": [
+                        "logAnalyticsWorkspace"
+                    ],
+                    "transformKql": "source",
+                    "outputStream": "Microsoft-UCDeviceAlert"
+                }
+            ]
+        }
+    }],
+    "outputs": {
+        "dataCollectionRuleId": {
+            "type": "string",
+            "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+        }
+    }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/UCServiceUpdateStatus.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/UCServiceUpdateStatus.json
@@ -1,0 +1,102 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "dataCollectionRuleName": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the name of the Data Collection Rule to create."
+            }
+        },
+        "location": {
+            "defaultValue": "[resourceGroup().location]",
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the location in which to create the Data Collection Rule."
+            }
+        },
+        "workspaceResourceId": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+            }
+        }
+    },
+    "resources": [{
+        "type": "Microsoft.Insights/dataCollectionRules",
+        "apiVersion": "2023-03-11",
+        "name": "[parameters('dataCollectionRuleName')]",
+        "location": "[parameters('location')]",
+        "kind": "Direct",
+        "properties": {
+            "streamDeclarations": {
+                "Custom-UCServiceUpdateStatus": {
+                    "columns": [{
+                            "name": "AzureADTenantId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventData",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventID",
+                            "type": "int"
+                        },
+                        {
+                            "name": "ServiceName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SourceSystem",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TimeGenerated",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "UpdateCategory",
+                            "type": "string"
+                        },
+                        {
+                            "name": "UpdateClassification",
+                            "type": "string"
+                        },
+                        {
+                            "name": "UpdateID",
+                            "type": "string"
+                        },
+                        {
+                            "name": "UpdateTitle",
+                            "type": "string"
+                        }
+                    ]
+                }
+            },
+            "destinations": {
+                "logAnalytics": [{
+                    "workspaceResourceId": "[parameters('workspaceResourceId')]",
+                    "name": "logAnalyticsWorkspace"
+                }]
+            },
+            "dataFlows": [{
+                    "streams": [
+                        "Custom-UCServiceUpdateStatus"
+                    ],
+                    "destinations": [
+                        "logAnalyticsWorkspace"
+                    ],
+                    "transformKql": "source",
+                    "outputStream": "Microsoft-UCServiceUpdateStatus"
+                }
+            ]
+        }
+    }],
+    "outputs": {
+        "dataCollectionRuleId": {
+            "type": "string",
+            "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+        }
+    }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/UCUpdateAlert.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/UCUpdateAlert.json
@@ -1,0 +1,126 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "dataCollectionRuleName": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the name of the Data Collection Rule to create."
+            }
+        },
+        "location": {
+            "defaultValue": "[resourceGroup().location]",
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the location in which to create the Data Collection Rule."
+            }
+        },
+        "workspaceResourceId": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+            }
+        }
+    },
+    "resources": [{
+        "type": "Microsoft.Insights/dataCollectionRules",
+        "apiVersion": "2023-03-11",
+        "name": "[parameters('dataCollectionRuleName')]",
+        "location": "[parameters('location')]",
+        "kind": "Direct",
+        "properties": {
+            "streamDeclarations": {
+                "Custom-UCUpdateAlert": {
+                    "columns": [{
+                            "name": "AlertClassification",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AlertData",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AlertID",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AlertRank",
+                            "type": "int"
+                        },
+                        {
+                            "name": "AlertStatus",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AlertSubtype",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AlertType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AzureADTenantId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Description",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ResolvedTime",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "SourceSystem",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TimeGenerated",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "UpdateCategory",
+                            "type": "string"
+                        },
+                        {
+                            "name": "UpdateClassification",
+                            "type": "string"
+                        },
+                        {
+                            "name": "UpdateID",
+                            "type": "string"
+                        },
+                        {
+                            "name": "UpdateTitle",
+                            "type": "string"
+                        }
+                    ]
+                }
+            },
+            "destinations": {
+                "logAnalytics": [{
+                    "workspaceResourceId": "[parameters('workspaceResourceId')]",
+                    "name": "logAnalyticsWorkspace"
+                }]
+            },
+            "dataFlows": [{
+                    "streams": [
+                        "Custom-UCUpdateAlert"
+                    ],
+                    "destinations": [
+                        "logAnalyticsWorkspace"
+                    ],
+                    "transformKql": "source",
+                    "outputStream": "Microsoft-UCUpdateAlert"
+                }
+            ]
+        }
+    }],
+    "outputs": {
+        "dataCollectionRuleId": {
+            "type": "string",
+            "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+        }
+    }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/WindowsClientAssessmentRecommendation.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/WindowsClientAssessmentRecommendation.json
@@ -1,0 +1,130 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "dataCollectionRuleName": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the name of the Data Collection Rule to create."
+            }
+        },
+        "location": {
+            "defaultValue": "[resourceGroup().location]",
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the location in which to create the Data Collection Rule."
+            }
+        },
+        "workspaceResourceId": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+            }
+        }
+    },
+    "resources": [{
+        "type": "Microsoft.Insights/dataCollectionRules",
+        "apiVersion": "2023-03-11",
+        "name": "[parameters('dataCollectionRuleName')]",
+        "location": "[parameters('location')]",
+        "kind": "Direct",
+        "properties": {
+            "streamDeclarations": {
+                "Custom-WindowsClientAssessmentRecommendation": {
+                    "columns": [{
+                            "name": "ActionArea",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActionAreaId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AffectedObjectName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AffectedObjectType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AssessmentId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Computer",
+                            "type": "string"
+                        },
+                        {
+                            "name": "CustomData",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Description",
+                            "type": "string"
+                        },
+                        {
+                            "name": "FocusArea",
+                            "type": "string"
+                        },
+                        {
+                            "name": "FocusAreaId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Recommendation",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RecommendationId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RecommendationResult",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RecommendationWeight",
+                            "type": "real"
+                        },
+                        {
+                            "name": "SourceSystem",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Technology",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TimeGenerated",
+                            "type": "datetime"
+                        }
+                    ]
+                }
+            },
+            "destinations": {
+                "logAnalytics": [{
+                    "workspaceResourceId": "[parameters('workspaceResourceId')]",
+                    "name": "logAnalyticsWorkspace"
+                }]
+            },
+            "dataFlows": [{
+                    "streams": [
+                        "Custom-WindowsClientAssessmentRecommendation"
+                    ],
+                    "destinations": [
+                        "logAnalyticsWorkspace"
+                    ],
+                    "transformKql": "source",
+                    "outputStream": "Microsoft-WindowsClientAssessmentRecommendation"
+                }
+            ]
+        }
+    }],
+    "outputs": {
+        "dataCollectionRuleId": {
+            "type": "string",
+            "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+        }
+    }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/WindowsEvent.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/WindowsEvent.json
@@ -1,0 +1,142 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "dataCollectionRuleName": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the name of the Data Collection Rule to create."
+            }
+        },
+        "location": {
+            "defaultValue": "[resourceGroup().location]",
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the location in which to create the Data Collection Rule."
+            }
+        },
+        "workspaceResourceId": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+            }
+        }
+    },
+    "resources": [{
+        "type": "Microsoft.Insights/dataCollectionRules",
+        "apiVersion": "2023-03-11",
+        "name": "[parameters('dataCollectionRuleName')]",
+        "location": "[parameters('location')]",
+        "kind": "Direct",
+        "properties": {
+            "streamDeclarations": {
+                "Custom-WindowsEvent": {
+                    "columns": [{
+                            "name": "Channel",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Computer",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Correlation",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventData",
+                            "type": "dynamic"
+                        },
+                        {
+                            "name": "EventID",
+                            "type": "int"
+                        },
+                        {
+                            "name": "EventLevel",
+                            "type": "int"
+                        },
+                        {
+                            "name": "EventLevelName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventOriginId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EventRecordId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Keywords",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ManagementGroupName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Opcode",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Provider",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RawEventData",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SystemProcessId",
+                            "type": "int"
+                        },
+                        {
+                            "name": "SystemThreadId",
+                            "type": "int"
+                        },
+                        {
+                            "name": "SystemUserId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Task",
+                            "type": "int"
+                        },
+                        {
+                            "name": "TimeGenerated",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "Version",
+                            "type": "int"
+                        }
+                    ]
+                }
+            },
+            "destinations": {
+                "logAnalytics": [{
+                    "workspaceResourceId": "[parameters('workspaceResourceId')]",
+                    "name": "logAnalyticsWorkspace"
+                }]
+            },
+            "dataFlows": [{
+                    "streams": [
+                        "Custom-WindowsEvent"
+                    ],
+                    "destinations": [
+                        "logAnalyticsWorkspace"
+                    ],
+                    "transformKql": "source",
+                    "outputStream": "Microsoft-WindowsEvent"
+                }
+            ]
+        }
+    }],
+    "outputs": {
+        "dataCollectionRuleId": {
+            "type": "string",
+            "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+        }
+    }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/WindowsServerAssessmentRecommendation.json
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/WindowsServerAssessmentRecommendation.json
@@ -1,0 +1,130 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "dataCollectionRuleName": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the name of the Data Collection Rule to create."
+            }
+        },
+        "location": {
+            "defaultValue": "[resourceGroup().location]",
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the location in which to create the Data Collection Rule."
+            }
+        },
+        "workspaceResourceId": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
+            }
+        }
+    },
+    "resources": [{
+        "type": "Microsoft.Insights/dataCollectionRules",
+        "apiVersion": "2023-03-11",
+        "name": "[parameters('dataCollectionRuleName')]",
+        "location": "[parameters('location')]",
+        "kind": "Direct",
+        "properties": {
+            "streamDeclarations": {
+                "Custom-WindowsServerAssessmentRecommendation": {
+                    "columns": [{
+                            "name": "ActionArea",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ActionAreaId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AffectedObjectName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AffectedObjectType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "AssessmentId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Computer",
+                            "type": "string"
+                        },
+                        {
+                            "name": "CustomData",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Description",
+                            "type": "string"
+                        },
+                        {
+                            "name": "FocusArea",
+                            "type": "string"
+                        },
+                        {
+                            "name": "FocusAreaId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Recommendation",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RecommendationId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RecommendationResult",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RecommendationWeight",
+                            "type": "real"
+                        },
+                        {
+                            "name": "SourceSystem",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Technology",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TimeGenerated",
+                            "type": "datetime"
+                        }
+                    ]
+                }
+            },
+            "destinations": {
+                "logAnalytics": [{
+                    "workspaceResourceId": "[parameters('workspaceResourceId')]",
+                    "name": "logAnalyticsWorkspace"
+                }]
+            },
+            "dataFlows": [{
+                    "streams": [
+                        "Custom-WindowsServerAssessmentRecommendation"
+                    ],
+                    "destinations": [
+                        "logAnalyticsWorkspace"
+                    ],
+                    "transformKql": "source",
+                    "outputStream": "Microsoft-WindowsServerAssessmentRecommendation"
+                }
+            ]
+        }
+    }],
+    "outputs": {
+        "dataCollectionRuleId": {
+            "type": "string",
+            "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+        }
+    }
+}

--- a/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/README.md
+++ b/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/README.md
@@ -1,0 +1,201 @@
+# Sentinel Native Tables - DCR Templates
+
+Pre-built Azure Resource Manager (ARM) templates for creating Data Collection Rules (DCRs) for Microsoft Sentinel native tables. These templates include complete schema definitions for all supported native tables.
+
+## Directory Structure
+
+```
+SentinelNativeTables/
+ DataCollectionRules(DCE)/ # Templates requiring Data Collection Endpoints
+ [50 table templates] # DCE-based DCRs for advanced routing
+ DataCollectionRules(NoDCE)/ # Direct DCR templates
+ [50 table templates] # Simple, cost-effective Direct DCRs
+```
+
+## Template Types
+
+### Direct DCRs (`DataCollectionRules(NoDCE)/`)
+- **Type**: `"kind": "Direct"`
+- **Use Case**: Simple data ingestion directly to Log Analytics
+- **Cost**: Lower (no DCE charges)
+- **Complexity**: Simple deployment
+- **Name Limit**: 30 characters
+
+### DCE-based DCRs (`DataCollectionRules(DCE)/`)
+- **Type**: Requires Data Collection Endpoint
+- **Use Case**: Advanced routing, private endpoints
+- **Cost**: Higher (DCE + DCR charges)
+- **Complexity**: Requires DCE creation first
+- **Name Limit**: 64 characters
+
+## Available Templates
+
+### Core Security Tables
+- `CommonSecurityLog.json` - CEF/Syslog security events
+- `SecurityEvent.json` - Windows security events
+- `Syslog.json` - Linux/Unix syslog data
+- `WindowsEvent.json` - Windows event logs
+- `Event.json` - Legacy Windows events
+
+### Azure Native Tables
+- `AzureActivity.json` - Azure resource activity logs
+- `AzureDiagnostics.json` - Azure resource diagnostics
+- `AzureAssessmentRecommendation.json` - Azure assessments
+
+### Microsoft Defender Tables
+- `DeviceEvents.json` - Defender for Endpoint events
+- `DeviceFileEvents.json` - File activity events
+- `DeviceTvmSecureConfigurationAssessmentKB.json` - TVM assessments
+- `DeviceTvmSoftwareVulnerabilitiesKB.json` - Vulnerability data
+
+### Cloud Provider Tables
+- `AWSCloudTrail.json` - AWS audit logs
+- `AWSCloudWatch.json` - AWS metrics and logs
+- `AWSGuardDuty.json` - AWS threat detection
+- `AWSVPCFlow.json` - AWS network flow logs
+- `GCPAuditLogs.json` - Google Cloud audit logs
+- `GoogleCloudSCC.json` - Google Security Command Center
+
+### ASIM (Advanced Security Information Model) Tables
+- `ASimAuthenticationEventLogs.json` - Normalized authentication events
+- `ASimNetworkSessionLogs.json` - Normalized network sessions
+- `ASimProcessEventLogs.json` - Normalized process events
+- `ASimDnsActivityLogs.json` - Normalized DNS queries
+- `ASimFileEventLogs.json` - Normalized file events
+- And more ASIM normalized tables...
+
+### Assessment & Recommendation Tables
+- `ADAssessmentRecommendation.json` - Active Directory assessments
+- `SQLAssessmentRecommendation.json` - SQL Server assessments
+- `ExchangeAssessmentRecommendation.json` - Exchange assessments
+- `WindowsServerAssessmentRecommendation.json` - Windows Server assessments
+- And more assessment tables...
+
+### Update Management Tables
+- `UCClient.json` - Update Compliance client data
+- `UCUpdateAlert.json` - Update alerts
+- `UCServiceUpdateStatus.json` - Service update status
+- And more UC tables...
+
+## Deployment Guide
+
+### Prerequisites
+- Azure subscription with appropriate permissions
+- Log Analytics workspace created
+- For DCE templates: Data Collection Endpoint created
+
+### Option 1: Azure Portal
+1. Navigate to Azure Portal → "Deploy a custom template"
+2. Click "Build your own template in the editor"
+3. Copy the content from your chosen template
+4. Click Save
+5. Fill in parameters:
+ - `dataCollectionRuleName`: Your DCR name
+ - `location`: Azure region (must match workspace)
+ - `workspaceResourceId`: Full resource ID of workspace
+ - `endpointResourceId`: DCE resource ID (DCE templates only)
+6. Review and Create
+
+### Option 2: Azure CLI
+```bash
+# For Direct DCR (no DCE)
+az deployment group create \
+ --resource-group "your-rg" \
+ --template-file "DataCollectionRules(NoDCE)/SecurityEvent.json" \
+ --parameters \
+ dataCollectionRuleName="dcr-security-events" \
+ workspaceResourceId="/subscriptions/.../workspaces/your-workspace"
+
+# For DCE-based DCR
+az deployment group create \
+ --resource-group "your-rg" \
+ --template-file "DataCollectionRules(DCE)/SecurityEvent.json" \
+ --parameters \
+ dataCollectionRuleName="dcr-security-events" \
+ workspaceResourceId="/subscriptions/.../workspaces/your-workspace" \
+ endpointResourceId="/subscriptions/.../dataCollectionEndpoints/your-dce"
+```
+
+### Option 3: PowerShell
+```powershell
+# For Direct DCR
+New-AzResourceGroupDeployment `
+ -ResourceGroupName "your-rg" `
+ -TemplateFile "DataCollectionRules(NoDCE)/SecurityEvent.json" `
+ -dataCollectionRuleName "dcr-security-events" `
+ -workspaceResourceId "/subscriptions/.../workspaces/your-workspace"
+
+# For DCE-based DCR
+New-AzResourceGroupDeployment `
+ -ResourceGroupName "your-rg" `
+ -TemplateFile "DataCollectionRules(DCE)/SecurityEvent.json" `
+ -dataCollectionRuleName "dcr-security-events" `
+ -workspaceResourceId "/subscriptions/.../workspaces/your-workspace" `
+ -endpointResourceId "/subscriptions/.../dataCollectionEndpoints/your-dce"
+```
+
+## Template Parameters
+
+### Common Parameters (All Templates)
+| Parameter | Type | Description | Example |
+|-----------|------|-------------|---------|
+| dataCollectionRuleName | string | Name for the DCR | "dcr-security-events" |
+| location | string | Azure region | "eastus" |
+| workspaceResourceId | string | Full resource ID of Log Analytics workspace | "/subscriptions/..." |
+
+### Additional for DCE Templates
+| Parameter | Type | Description | Example |
+|-----------|------|-------------|---------|
+| endpointResourceId | string | Full resource ID of DCE | "/subscriptions/..." |
+
+## Template Structure
+
+Each template contains:
+- **Stream Declarations**: Column definitions with names and types
+- **Destinations**: Target Log Analytics workspace
+- **Data Flows**: Routing from input stream to output table
+- **Transform KQL**: Set to "source" (no transformation)
+
+Example stream naming:
+- Input: `Custom-{TableName}` (e.g., "Custom-SecurityEvent")
+- Output: `Microsoft-{TableName}` (e.g., "Microsoft-SecurityEvent")
+
+## Choosing Between DCE and Direct
+
+### Use Direct DCRs When:
+- Simple ingestion requirements
+- Cost optimization is important
+- No need for private endpoints
+- Single destination workspace
+
+### Use DCE-based DCRs When:
+- Need private link/endpoints
+- Advanced routing required
+- Multiple destinations
+- Enhanced security requirements
+
+## Important Notes
+
+1. **Name Length Limits**: Direct DCRs limited to 30 characters
+2. **Region Matching**: DCR location must match workspace location
+3. **Schema Immutability**: Column definitions cannot be changed after creation
+4. **DCE Requirement**: DCE must exist before deploying DCE-based templates
+5. **Cost Implications**: DCEs incur additional charges
+
+## Related Resources
+
+For automated deployment with dynamic schema retrieval:
+- See [DCR-Automation](../../DCR-Automation/) for PowerShell automation
+- Supports both template types
+- Automatically retrieves current schemas from Azure
+- Generates Cribl Stream configurations
+
+## Additional Information
+
+- [Azure Monitor DCR Documentation](https://docs.microsoft.com/azure/azure-monitor/essentials/data-collection-rule)
+- [Sentinel Tables Reference](https://docs.microsoft.com/azure/sentinel/data-source-schema)
+- [DCE Overview](https://docs.microsoft.com/azure/azure-monitor/essentials/data-collection-endpoint)
+
+---
+
+**Note**: These templates contain static schemas. For dynamic schema retrieval and automated deployment, use the [DCR-Automation](../../DCR-Automation/) PowerShell solution.

--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -2,9 +2,11 @@
 
 The active project is the SOC Optimization Toolkit in
 `soc-optimizationtoolkit/` - a Cribl App for the Cribl Apps platform
-(Cribl.Cloud), with a local Node-hosted variant for customer-managed
-deployments. This page gets the app installed and producing value; the
+(Cribl.Cloud). This page gets the app installed and producing value; the
 [repository README](README.md) describes what it does.
+
+On a customer-managed leader, where Cribl Apps is not available, use the
+[DCR templates](README.md#choosing-a-path) instead.
 
 ## Install the app in Cribl.Cloud (recommended)
 
@@ -60,19 +62,16 @@ analyze samples, deploy DCRs + Cribl pack) - **DCR Automation** -
 `.tgz` - confirm. KV store data and settings are preserved, so the Azure
 connection and app state survive upgrades; access permissions are kept.
 
-## Local app (customer-managed Cribl)
+## Customer-managed Cribl (no Cribl Apps)
 
-For self-hosted leaders where Cribl Apps is not available:
-
-```bash
-cd soc-optimizationtoolkit
-npm install
-npm run local     # builds and starts the local Node host
-```
-
-The first run is an onboarding GUI that walks through connecting the
-leader and Azure. Configuration lives in
-`apps/local-app/config/local-config.json`.
+Cribl Apps install on Cribl.Cloud leaders only, so the toolkit cannot run
+against a customer-managed leader. Deploy the DCR by hand instead: pick the
+table's template from
+[`Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/`](Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/)
+- `DataCollectionRules(NoDCE)/` for a Direct DCR, which is the right default
+- deploy it through the Azure Portal or CLI, then point a Cribl **Microsoft
+Sentinel** destination at the DCR it creates. The
+[README](README.md#the-manual-option) compares the two paths.
 
 ## Build the package from source
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
 # Cribl-Microsoft Integration
 
 Tooling for integrating Cribl Stream with Microsoft Sentinel and Azure
-Monitor. The active project is the **SOC Optimization Toolkit** in
+Monitor. There are two ways to use this repository: the **SOC Optimization
+Toolkit**, which automates the whole path, and the **DCR templates**, which
+you deploy yourself. See [Choosing a path](#choosing-a-path) below.
+
+The active project is the **SOC Optimization Toolkit** in
 [`soc-optimizationtoolkit/`](soc-optimizationtoolkit/) - a Cribl.Cloud app
-(plus a local Node-hosted variant) that takes a Sentinel solution from
-selection to production:
+that takes a Sentinel solution from selection to production:
 
 - **Setup** - one page for every setup task: connect the Entra app
   registration (with verified secret storage), discover and select Azure
@@ -28,6 +31,40 @@ selection to production:
   the analyzer identifies the data sources the rules depend on, maps them to
   Sentinel solutions and tables with confidence scoring and MITRE coverage,
   and pivots each mapped solution straight into Sentinel Integration.
+
+## Choosing a path
+
+| | SOC Optimization Toolkit | DCR templates (manual) |
+| --- | --- | --- |
+| What you get | Gap analysis, field mapping, generated Cribl pack, DCR and destination deployed for you | An ARM template per table; you deploy it and wire Cribl up yourself |
+| Where it runs | Cribl.Cloud only - Cribl Apps do not install on customer-managed leaders | Anywhere: Azure Portal, CLI, or your own IaC |
+| Who installs it | Cribl.Cloud Organization administrator | Anyone with rights to deploy a DCR |
+| Coverage | Native and custom `_CL` tables, including CCF solutions with no published schema | 50 Sentinel native tables, Direct and DCE variants |
+| Best when | You want the whole integration built and maintained for you | You run a customer-managed leader, need one table, or want the DCR under your own IaC |
+
+The two are not exclusive - the toolkit generates the same kind of DCR the
+templates describe, so a template is also a reasonable way to see what the
+toolkit will produce before running it.
+
+### The manual option
+
+[`Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/`](Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/)
+holds 100 pre-built ARM templates - 50 Sentinel native tables in two
+variants, with the full schema for each:
+
+- **`DataCollectionRules(NoDCE)/`** - Direct DCRs (`"kind": "Direct"`). No
+  Data Collection Endpoint, so no DCE charges, and the simpler deployment.
+  DCR names are limited to 30 characters. Requires Cribl Stream 4.14+.
+- **`DataCollectionRules(DCE)/`** - DCE-based DCRs for advanced routing and
+  private endpoints. Needs a DCE created first, costs more, and allows
+  64-character names.
+
+Start with Direct unless you specifically need private endpoints or DCE
+routing. Deploy the template, then point a Cribl **Microsoft Sentinel**
+destination at the resulting DCR - see
+[Cribl's Sentinel destination docs](https://docs.cribl.io/stream/destinations-sentinel/)
+for the destination side. Per-table details are in the
+[templates README](Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/README.md).
 
 ## Getting started
 
@@ -62,7 +99,8 @@ Development gates: `npm run typecheck`, `npm run lint`, `npm test`,
 
 | Path | Contents |
 | --- | --- |
-| `soc-optimizationtoolkit/` | The active toolkit: `packages/core` (pure domain + usecases), `packages/ui` (shared React screens), `apps/cribl-app` (Cribl.Cloud shell), `apps/local-app` (local Node host) |
+| `soc-optimizationtoolkit/` | The active toolkit: `packages/core` (pure domain + usecases), `packages/ui` (shared React screens), `apps/cribl-app` (Cribl.Cloud shell) |
+| `Azure/CustomDeploymentTemplates/DCR-Templates/` | Pre-built ARM templates for Sentinel native tables - the manual path, and the target of Cribl's published documentation links |
 | `KnowledgeArticles/` | Integration knowledge base articles |
 | `Dev/` | Development scratch area |
 | `deprecated/` | Superseded components (PowerShell automation, the Electron GUI, v1 toolkit) - see [deprecated/README.md](deprecated/README.md) |


### PR DESCRIPTION
## Why

Commit 2653069 (2026-07-13, *Move superseded components to deprecated/*) moved `Azure/` under `deprecated/`. Twelve published Cribl Docs pages link to a file inside that tree, so those links currently 404.

The linked path is:

```
Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/DataCollectionRules(NoDCE)/Syslog.json
```

GitHub does not redirect deleted paths, and the docs pages are not ours to edit, so the path has to exist in this repo again.

## Affected docs pages

Found by sweeping all 2,074 current pages plus every versioned Azure/Sentinel page in `docs.cribl.io/sitemap.xml`.

| Page | Link |
|---|---|
| `stream/destinations-sentinel` | deep - **broken** |
| `edge/destinations-sentinel` | deep - **broken** |
| `stream/usecase-azure-workspace` | deep - **broken** |
| `stream/{4.16,4.17,4.18}/destinations-sentinel` | deep - **broken** |
| `edge/{4.16,4.17,4.18}/destinations-sentinel` | deep - **broken** |
| `stream/{4.16,4.17,4.18}/usecase-azure-workspace` | deep - **broken** |
| `stream/usecase-azure-sentinel` (+ 4.14-4.18) | repo root only - unaffected |

Only one deep path is linked anywhere in the docs. Root-level links keep working regardless.

## What this does

Restores `DCR-Templates/` (101 files) to its documented root path. The `deprecated/` copy is retained, so anything referencing the newer path keeps resolving.

Content is byte-identical to what the docs have always pointed at - the restored `Syslog.json` hashes to `f996d1dd3246029928a8e3286596120f2473838e`, the same blob as before the move. The original move was a clean `R100` rename with no content change, so nothing was reconstructed.

## Note for reviewers

Eight Defender templates required `git add -f`. The unanchored `dev*` rule at `.gitignore:6` matches `Device*.json` wherever `core.ignorecase` is true, so a plain `git add` staged 93 of 101 and reported success. Their counterparts under `deprecated/` are tracked, so this restores parity rather than adding anything new.

That `dev*` rule is worth narrowing separately - it will silently exclude any future `Device*` file on Windows and macOS checkouts.

## Out of scope

Left deliberately untouched: stale in-repo path references in `CLAUDE.md`, `CONTRIBUTORS.md`, and `KnowledgeArticles/PrivateLinkConfiguration/`, and the 15 root-anchored `.gitignore` rules that stopped matching after the move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NZKhaf1w5WQ1tcmcLpej2w