### PR TITLE
Point the manual path at its instructions

### DIFF
--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -70,8 +70,12 @@ table's template from
 [`Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/`](Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/)
 - `DataCollectionRules(NoDCE)/` for a Direct DCR, which is the right default
 - deploy it through the Azure Portal or CLI, then point a Cribl **Microsoft
-Sentinel** destination at the DCR it creates. The
-[README](README.md#the-manual-option) compares the two paths.
+Sentinel** destination at the DCR it creates.
+
+Step-by-step instructions, including the CLI and PowerShell commands and the
+parameters each template takes, are in
+[`DCR-Templates/SentinelNativeTables/README.md`](https://github.com/criblio/Cribl-Microsoft/blob/main/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/README.md).
+The [README](README.md#the-manual-option) compares the two paths.
 
 ## Build the package from source
 

--- a/README.md
+++ b/README.md
@@ -60,11 +60,19 @@ variants, with the full schema for each:
   64-character names.
 
 Start with Direct unless you specifically need private endpoints or DCE
-routing. Deploy the template, then point a Cribl **Microsoft Sentinel**
-destination at the resulting DCR - see
+routing.
+
+**Instructions:
+[`DCR-Templates/SentinelNativeTables/README.md`](https://github.com/criblio/Cribl-Microsoft/blob/main/Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/README.md).**
+That is the how-to for this path and the authority on it: prerequisites,
+deployment three ways (Azure Portal, Azure CLI, PowerShell), the parameters
+every template takes, a table-by-table index, and the full DCE-versus-Direct
+comparison the summary above condenses.
+
+Once the DCR exists, point a Cribl **Microsoft Sentinel** destination at it -
+see
 [Cribl's Sentinel destination docs](https://docs.cribl.io/stream/destinations-sentinel/)
-for the destination side. Per-table details are in the
-[templates README](Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/README.md).
+for that side.
 
 ## Getting started
 


### PR DESCRIPTION
Follow-up to #120.

`Azure/CustomDeploymentTemplates/DCR-Templates/SentinelNativeTables/README.md` is a complete usage guide for the manual path - prerequisites, deployment three ways (Azure Portal, Azure CLI, PowerShell), the parameters every template takes, a table-by-table index, and a DCE-versus-Direct comparison.

Both top-level docs linked it only as a trailing "per-table details" aside, so it read as reference material rather than as the instructions for that path.

## Changes

- **README.md** - the templates README is now called out as the instructions step under *The manual option*, and named as the authority on that path, so the condensed variant summary above it cannot be mistaken for the whole story if the two drift.
- **QUICK_START.md** - added to the customer-managed section, which is where the reader who cannot install the app ends up.

Absolute `blob/main` URLs rather than relative links: this is a stable public entry point, and the same file Cribl's published documentation sends people to. Every other link in both files was left relative and still resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NZKhaf1w5WQ1tcmcLpej2w