### PR TITLE
Make the Cribl Lake query actually run

### DIFF
--- a/soc-optimizationtoolkit/packages/core/src/testing/live-verify.test.ts
+++ b/soc-optimizationtoolkit/packages/core/src/testing/live-verify.test.ts
@@ -48,12 +48,34 @@ import type {
   CriblGroupSummary,
   CriblRequest,
 } from "../ports/cribl-client";
-import { deriveGroupProduct, isSearchGroup } from "../ports/cribl-client";
+import {
+  deriveGroupProduct,
+  isSearchGroup,
+  isStreamWorkerGroup,
+} from "../ports/cribl-client";
 import type { PortHttpResponse } from "../ports/http";
 
 const BASE = process.env.CRIBL_LIVE_BASE ?? "";
 const TOKEN = process.env.CRIBL_LIVE_TOKEN ?? "";
 const LIVE = BASE !== "" && TOKEN !== "";
+
+/**
+ * Pin the capture group. Optional - without it the suite resolves one that has
+ * CONNECTED WORKERS, which is the part that matters (see below).
+ */
+const GROUP = process.env.CRIBL_LIVE_GROUP ?? "";
+
+/**
+ * A REAL delay, because the whole point of this suite is to run what ships.
+ *
+ * Core takes an injected `sleep` and calls it as `await config.sleep?.(ms)`, so
+ * omitting it is a silent no-op: the poll loop still runs and simply never
+ * waits. Passing none here fired all twenty status polls inside a millisecond
+ * and reported a job "still running" that completed a second later - measuring
+ * this suite's own impatience rather than the platform.
+ */
+const liveSleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
 
 /**
  * The cloud adapter's body handling, reproduced deliberately.
@@ -118,6 +140,30 @@ function report(row: string, verdict: string, detail: string): void {
   console.log(`[live-verify] ${row}: ${verdict}\n              ${detail}`);
 }
 
+/**
+ * The ids of worker groups that currently have at least one worker CONNECTED,
+ * read from the leader's own worker listing.
+ *
+ * Group membership is a config fact and says nothing about whether anything is
+ * running: `/master/groups` lists a group whether or not a worker ever joined
+ * it. Capture executes on a worker, so this is the difference between a capture
+ * that can answer and a guaranteed 400.
+ */
+async function groupsWithWorkers(client: CriblClient): Promise<Set<string>> {
+  const res = await client.request({ method: "GET", path: "/master/workers" });
+  const items = ((res.body as { items?: unknown[] })?.items ?? []) as Record<
+    string,
+    unknown
+  >[];
+  const staffed = new Set<string>();
+  for (const w of items) {
+    const info = (w.info ?? {}) as Record<string, unknown>;
+    const group = w.group ?? w.workerGroup ?? info.workerGroup;
+    if (typeof group === "string" && group !== "") staffed.add(group);
+  }
+  return staffed;
+}
+
 describe.skipIf(!LIVE)("live verification against a real workspace", () => {
   const cribl = liveClient();
 
@@ -130,9 +176,34 @@ describe.skipIf(!LIVE)("live verification against a real workspace", () => {
     expect(groups.length).toBeGreaterThan(0);
 
     // A Stream group, which is where /system/inputs and /system/capture live.
-    const stream = groups.filter((g) => !isSearchGroup(g));
+    //
+    // IT MUST HAVE CONNECTED WORKERS. Capture runs ON a worker, so a group with
+    // none answers `400 {"message":"No worker nodes are connected to this worker
+    // group."}` no matter what the filter says. This used to take stream[0],
+    // which in the lab is `default` and has no workers - so rows 1, 2, 4 and 5
+    // failed on a platform precondition and row 8 read the same 400 as "Cribl
+    // rejected the undeclared field", a verdict about the evaluator drawn from a
+    // request that never reached one. Found on the 2026-08-24 live run.
+    //
+    // Note this filters on the `stream` TYPE rather than "not search": the
+    // groups listing also carries edge fleets and outposts, and capturing on an
+    // edge fleet is a different thing from the Stream capture under test.
+    const stream = groups.filter(isStreamWorkerGroup);
     expect(stream.length).toBeGreaterThan(0);
-    groupId = stream[0].id;
+
+    const staffed = await groupsWithWorkers(cribl);
+    const candidates =
+      GROUP === "" ? stream.filter((g) => staffed.has(g.id)) : stream.filter((g) => g.id === GROUP);
+
+    if (candidates.length === 0) {
+      const why =
+        GROUP === ""
+          ? `no Stream group has connected workers (staffed: ${[...staffed].join(", ") || "none"})`
+          : `CRIBL_LIVE_GROUP=${GROUP} is not a Stream group in this workspace`;
+      report("row 7 (permission)", "CANNOT RUN", why);
+      expect.fail(`${why} - capture rows cannot be settled against this workspace`);
+    }
+    groupId = candidates[0].id;
 
     const res = await cribl.request({
       method: "GET",
@@ -282,15 +353,28 @@ describe.skipIf(!LIVE)("live verification against a real workspace", () => {
 
     const bareCount = extractCapturedEvents(bare.body).lines.length;
     const guardedCount = extractCapturedEvents(guarded.body).lines.length;
+    // THE GUARDED REQUEST IS THE CONTROL. It references the same undeclared
+    // name in the form the evaluator must accept, so if IT fails the failure is
+    // environmental and says nothing about undeclared fields.
+    //
+    // This ordering is the fix for a false verdict this row produced on
+    // 2026-08-24: run against a group with no connected workers, both requests
+    // came back `400 No worker nodes are connected`, and `bare.status >= 400`
+    // reported "REJECTED outright - guards are load-bearing" - a conclusion
+    // about the JavaScript evaluator drawn from a request that never reached
+    // one. A non-2xx control now yields no verdict at all, which is the only
+    // honest reading of it.
     report(
       "row 8 (undeclared field)",
-      bare.status >= 400
-        ? "REJECTED outright - guards are load-bearing"
-        : bareCount === 0 && guardedCount > 0
-          ? "DROPS events - guards are load-bearing"
-          : bareCount > 0
-            ? "TOLERATED - guards are insurance, not load-bearing"
-            : "INCONCLUSIVE - both returned nothing, source may be idle",
+      guarded.status >= 400
+        ? "CANNOT RUN - the control request itself failed"
+        : bare.status >= 400
+          ? "REJECTED outright - guards are load-bearing"
+          : bareCount === 0 && guardedCount > 0
+            ? "DROPS events - guards are load-bearing"
+            : bareCount > 0
+              ? "TOLERATED - guards are insurance, not load-bearing"
+              : "INCONCLUSIVE - both returned nothing, source may be idle",
       `bare HTTP ${bare.status} / ${bareCount} events; guarded HTTP ${guarded.status} / ${guardedCount} events`,
     );
 
@@ -409,6 +493,7 @@ describe.skipIf(!LIVE)("live verification against a real workspace", () => {
     const counted = await queryLakeSamples(cribl, {
       searchGroupId: search.id,
       datasetId,
+      sleep: liveSleep,
     });
     report(
       "row 6 (queryLakeSamples)",
@@ -432,6 +517,7 @@ describe.skipIf(!LIVE)("live verification against a real workspace", () => {
       discriminatorField: counted.discriminatorField,
       logTypes: [counted.logTypes[0].logType],
       eventsPerLogType: 1,
+      sleep: liveSleep,
     });
     const rejected = fetched.notes.some((n) => /\b(4\d\d|5\d\d)\b/.test(n));
     report(
@@ -443,5 +529,9 @@ describe.skipIf(!LIVE)("live verification against a real workspace", () => {
       false,
     );
     expect(fetched.ok).toBe(true);
-  });
+    // A REAL wait budget. Three search jobs, each allowed 19 x 500ms of polling,
+    // is far past vitest's 5s default - and a timeout here would read as "the
+    // Lake route failed" when it in fact means "we stopped waiting". Raise this
+    // in step with JOB_POLL_INTERVAL_MS.
+  }, 120_000);
 });

--- a/soc-optimizationtoolkit/packages/core/src/usecases/query-lake-samples/query-lake-samples.test.ts
+++ b/soc-optimizationtoolkit/packages/core/src/usecases/query-lake-samples/query-lake-samples.test.ts
@@ -1,7 +1,7 @@
 /**
  * Pins for query-lake-samples (plan Phase 4, ADR 0003).
  *
- * FOUR CLASSES OF FAILURE guarded here, and the first two are asserted on the
+ * FIVE CLASSES OF FAILURE guarded here, and the first two are asserted on the
  * REQUEST rather than the result, because a wrong path or a wrong group answers
  * 404 and 404 degrades into an EMPTY LOG-TYPE LIST - which the operator reads as
  * a fact about their data rather than a bug in us.
@@ -14,6 +14,9 @@
  *                fetches events for one chosen value, and must be able to fetch
  *                every value the second one LISTED - see the round-trip block.
  *   THE ROUTES   sync first (spec-only), the proven job lifecycle second.
+ *   THE SHAPES   what the LIVE API actually answers with, which for the job
+ *                status is not what the spec's own example shows - see
+ *                {@link jobStatus} and the status-envelope block.
  *   EMPTY vs FAILED  never collapsed, in either direction.
  */
 
@@ -28,6 +31,7 @@ import {
   DEFAULT_MAX_LOG_TYPES,
   DEFAULT_SAMPLE_LIMIT,
   JOB_POLL_ATTEMPTS,
+  JOB_POLL_INTERVAL_MS,
   MAX_SAMPLE_LIMIT,
   buildDiscriminatorSampleQuery,
   buildLogTypeCountQuery,
@@ -54,6 +58,35 @@ const ndjson = (rows: unknown[]): string =>
   [META, ...rows].map((row) => JSON.stringify(row)).join("\n");
 
 const ok = (body: unknown): PortHttpResponse => ({ status: 200, body });
+
+/**
+ * A job-status response IN THE SHAPE THE LIVE API ANSWERS WITH, and the default
+ * every status response in this file is scripted with.
+ *
+ * `GET /search/jobs/{id}/status?advanced=true` replies in the same
+ * `{items:[...], count}` envelope the create call uses - confirmed live
+ * 2026-08-24, body keys exactly `["items","count"]`, the status at
+ * `items[0].status`. The OpenAPI spec says otherwise: its own
+ * SearchJobStatusResponseExamplesRunning example is the FLATTENED
+ * `{status:"running", timeCreated, ...}`, which is why the bare read is kept as
+ * a fallback and pinned below rather than deleted.
+ *
+ * THE DEFECT THIS SHAPE EXISTS TO CATCH (found live 2026-08-24): the poll read
+ * the top level only, so it found nothing on every attempt, held the status at
+ * "", burned all JOB_POLL_ATTEMPTS and reported a job that was `completed` on
+ * the FIRST poll as "still pending". Every Lake query failed, on every dataset -
+ * and this suite stayed green the whole time, because every status response
+ * here was scripted as a bare `{status}` no live workspace has ever sent.
+ *
+ * FakeCriblClient is deliberately NOT where this default lives. It is a FIFO
+ * response queue with no knowledge of search jobs, and teaching it to synthesize
+ * a status body for a path it recognized would make it a Cribl simulator rather
+ * than a queue - the same reason `outputsList` is the single narrow exception
+ * there. The shape belongs where the responses are scripted, which is here, and
+ * a helper is enough to stop it drifting back.
+ */
+const jobStatus = (state: string): PortHttpResponse =>
+  ok({ items: [{ status: state }], count: 1 });
 
 /** Two log types, discriminated by a plain `type` field Search can group by. */
 const SAMPLE_ROWS = [
@@ -296,7 +329,7 @@ describe("empty is a RESULT; failed is not", () => {
     const cribl = client(
       ok(""),
       ok({ count: 1, items: [{ id: "j-1" }] }),
-      ok({ status: "completed" }),
+      jobStatus("completed"),
       ok(""),
     );
 
@@ -327,7 +360,7 @@ describe("empty is a RESULT; failed is not", () => {
       ok(ndjson(SAMPLE_ROWS)),
       ok(ndjson([])),
       ok({ count: 1, items: [{ id: "j-2" }] }),
-      ok({ status: "completed" }),
+      jobStatus("completed"),
       ok(ndjson([])),
     );
 
@@ -369,12 +402,12 @@ describe("the async job lifecycle - the route that was PROVEN live", () => {
     const cribl = client(
       { status: 404, body: "no such route" }, // the spec-only sync route
       ok({ count: 1, items: [{ id: "j-1", status: "new" }] }),
-      ok({ status: "running" }),
-      ok({ status: "completed" }),
+      jobStatus("running"),
+      jobStatus("completed"),
       ok(ndjson(SAMPLE_ROWS)),
       // Step two: the sync verdict is remembered, so it goes straight to a job.
       ok({ count: 1, items: [{ id: "j-2" }] }),
-      ok({ status: "completed" }),
+      jobStatus("completed"),
       ok(ndjson(COUNT_ROWS)),
     );
     const sleeps: number[] = [];
@@ -418,7 +451,7 @@ describe("the async job lifecycle - the route that was PROVEN live", () => {
     const cribl = client(
       { status: 404, body: "" },
       ok({ count: 1, items: [{ id: "job/1" }] }),
-      ok({ status: "completed" }),
+      jobStatus("completed"),
       ok(ndjson([{ _raw: "no discriminator here" }])),
     );
 
@@ -431,11 +464,11 @@ describe("the async job lifecycle - the route that was PROVEN live", () => {
     const cribl = client(
       ok(""), // 200, no rows - spec-only route, so not believed on its own
       ok({ count: 1, items: [{ id: "j-1" }] }),
-      ok({ status: "completed" }),
+      jobStatus("completed"),
       ok(ndjson(SAMPLE_ROWS)),
       // Sync is now known-bad for this workspace: step two skips it entirely.
       ok({ count: 1, items: [{ id: "j-2" }] }),
-      ok({ status: "completed" }),
+      jobStatus("completed"),
       ok(ndjson(COUNT_ROWS)),
     );
 
@@ -452,7 +485,7 @@ describe("the async job lifecycle - the route that was PROVEN live", () => {
     const cribl = client(
       { status: 404, body: "" },
       ok({ count: 1, items: [{ id: "j-1" }] }),
-      ...Array.from({ length: JOB_POLL_ATTEMPTS }, () => ok({ status: "running" })),
+      ...Array.from({ length: JOB_POLL_ATTEMPTS }, () => jobStatus("running")),
     );
     const sleeps: number[] = [];
 
@@ -473,7 +506,7 @@ describe("the async job lifecycle - the route that was PROVEN live", () => {
     const cribl = client(
       { status: 404, body: "" },
       ok({ count: 1, items: [{ id: "j-1" }] }),
-      ok({ status: "failed" }),
+      jobStatus("failed"),
     );
 
     const result = await run(cribl);
@@ -489,6 +522,145 @@ describe("the async job lifecycle - the route that was PROVEN live", () => {
 
     expect(result.ok).toBe(false);
     expect(result.notes.join(" ")).toContain("no job id");
+  });
+});
+
+/**
+ * The status ENVELOPE, which is a different pin from the poll's boundedness.
+ *
+ * The block above pins that the loop stops. This one pins that it ever STARTS:
+ * that the status is read out of the shape a live workspace actually sends.
+ *
+ * The defect (live 2026-08-24): the poll read a top-level `status` key that the
+ * real response does not have, so it read undefined every time, the status
+ * stayed "", and a job that was `completed` on the first attempt burned all
+ * JOB_POLL_ATTEMPTS and was reported "still pending". EVERY Lake query failed on
+ * EVERY dataset. The suite stayed green because every status response scripted
+ * here was the spec's flattened `{status}` rather than the live envelope - the
+ * fake agreeing with the code about a shape neither had checked, which is the
+ * only way a total outage hides behind a green run.
+ *
+ * So each pin here asserts a COUNT - how many status requests were issued, how
+ * many waits were asked for - rather than only that the call succeeded. Counts
+ * are what separate "read the status on the first poll" from "read nothing
+ * twenty times and gave up", and those two produced identical `ok` flags for
+ * every case but the happy one.
+ */
+describe("the job status arrives in an ENVELOPE, not as a top-level key", () => {
+  /** create -> one poll -> results, for each of the two queries. */
+  const LIFECYCLE = [
+    "GET /search/query",
+    "POST /search/jobs",
+    "GET /search/jobs/j-1/status",
+    "GET /search/jobs/j-1/results",
+    "POST /search/jobs",
+    "GET /search/jobs/j-2/status",
+    "GET /search/jobs/j-2/results",
+  ];
+
+  const statusCalls = (cribl: FakeCriblClient): number =>
+    cribl.calls.filter((c) => c.path.endsWith("/status")).length;
+
+  it("completes on the FIRST poll when the status is at items[0].status", async () => {
+    // The live shape. Before the fix this read nothing, slept, polled again,
+    // and ran out of scripted responses - so the counts below, not the ok flag,
+    // are what this pin turns on.
+    const cribl = client(
+      { status: 404, body: "" }, // the spec-only sync route
+      ok({ count: 1, items: [{ id: "j-1" }] }),
+      jobStatus("completed"),
+      ok(ndjson(SAMPLE_ROWS)),
+      ok({ count: 1, items: [{ id: "j-2" }] }),
+      jobStatus("completed"),
+      ok(ndjson(COUNT_ROWS)),
+    );
+    const sleeps: number[] = [];
+
+    const result = await run(cribl, {
+      sleep: async (ms: number) => {
+        sleeps.push(ms);
+      },
+    });
+
+    expect(cribl.calls.map((c) => `${c.method} ${c.path}`)).toEqual(LIFECYCLE);
+    // ONE status request per job, not JOB_POLL_ATTEMPTS of them.
+    expect(statusCalls(cribl)).toBe(2);
+    // And no wait was ever asked for, because nothing was ever pending.
+    expect(sleeps).toEqual([]);
+    expect(result.ok).toBe(true);
+    expect(result.path).toBe("async");
+    expect(result.discriminatorField).toBe("type");
+    expect(result.logTypes).toEqual([
+      { logType: "TRAFFIC", eventCount: 890000 },
+      { logType: "THREAT", eventCount: 12 },
+    ]);
+  });
+
+  it("still reads a BARE top-level status - the shape the spec documents", async () => {
+    // The OpenAPI example is the flattened `{status:"running", ...}`, so the
+    // fallback is not dead code: it is the only reading of the response Cribl
+    // publishes. Both shapes must produce the identical lifecycle.
+    const bare = (state: string): PortHttpResponse => ok({ status: state });
+    const cribl = client(
+      { status: 404, body: "" },
+      ok({ count: 1, items: [{ id: "j-1" }] }),
+      bare("completed"),
+      ok(ndjson(SAMPLE_ROWS)),
+      ok({ count: 1, items: [{ id: "j-2" }] }),
+      bare("completed"),
+      ok(ndjson(COUNT_ROWS)),
+    );
+    const sleeps: number[] = [];
+
+    const result = await run(cribl, {
+      sleep: async (ms: number) => {
+        sleeps.push(ms);
+      },
+    });
+
+    expect(cribl.calls.map((c) => `${c.method} ${c.path}`)).toEqual(LIFECYCLE);
+    expect(statusCalls(cribl)).toBe(2);
+    expect(sleeps).toEqual([]);
+    expect(result.ok).toBe(true);
+    expect(result.logTypes).toEqual([
+      { logType: "TRAFFIC", eventCount: 890000 },
+      { logType: "THREAT", eventCount: 12 },
+    ]);
+  });
+
+  it("keeps polling an ENVELOPE that says running, and names that state when it gives up", async () => {
+    // The bound itself is pinned above; what this adds is WHAT WAS READ. A poll
+    // that read nothing gives up saying the job was "still pending" - which is
+    // the app admitting it never learned anything, in a sentence that reads to
+    // an operator like a slow query. Naming `running` is the difference, and it
+    // is only available to a reader that found the status in the envelope.
+    const cribl = client(
+      { status: 404, body: "" },
+      ok({ count: 1, items: [{ id: "j-1" }] }),
+      ...Array.from({ length: JOB_POLL_ATTEMPTS }, () => jobStatus("running")),
+    );
+    const sleeps: number[] = [];
+
+    const result = await run(cribl, {
+      sleep: async (ms: number) => {
+        sleeps.push(ms);
+      },
+    });
+
+    // Every scripted status response was consumed and no more were asked for.
+    expect(statusCalls(cribl)).toBe(JOB_POLL_ATTEMPTS);
+    expect(cribl.calls).toHaveLength(2 + JOB_POLL_ATTEMPTS);
+    expect(sleeps).toHaveLength(JOB_POLL_ATTEMPTS - 1);
+    expect(sleeps.every((ms) => ms === JOB_POLL_INTERVAL_MS)).toBe(true);
+    expect(result.ok).toBe(false);
+    expect(result.logTypes).toEqual([]);
+    expect(result.notes.join(" ")).toContain(
+      `still running after ${JOB_POLL_ATTEMPTS} status checks`,
+    );
+    // "pending" is what the app says when it read NO status at all.
+    expect(result.notes.join(" ")).not.toContain("still pending");
+    // And a job we stopped asking about is never an empty dataset.
+    expect(result.notes.join(" ")).not.toContain("holds no events");
   });
 });
 
@@ -617,7 +789,7 @@ describe("fetchLakeLogTypeEvents - counts choose, events sample", () => {
     const cribl = client(
       ok(""),
       ok({ count: 1, items: [{ id: "j-1" }] }),
-      ok({ status: "completed" }),
+      jobStatus("completed"),
       ok(""),
     );
 

--- a/soc-optimizationtoolkit/packages/core/src/usecases/query-lake-samples/query-lake-samples.ts
+++ b/soc-optimizationtoolkit/packages/core/src/usecases/query-lake-samples/query-lake-samples.ts
@@ -364,6 +364,36 @@ function readJobId(body: unknown): string | undefined {
 }
 
 /**
+ * The job's status, from either shape of status response.
+ *
+ * `GET /search/jobs/{id}/status` answers in the SAME `{items:[...], count}`
+ * envelope the create call uses - there is no top-level `status` key, only
+ * `items[0].status`. Reading the top level alone therefore found nothing on
+ * every poll, left the status as the empty string, and made the loop run its
+ * full attempt budget before reporting the job "still pending" - for a job that
+ * was in fact `completed` on the FIRST poll. Every Lake query failed that way,
+ * on every dataset, while the suite stayed green because every status response
+ * it scripted was the spec's flattened `{status}` - the pins agreeing with the
+ * code about a shape neither had checked. They now script the envelope by
+ * default; see `jobStatus` in query-lake-samples.test.ts.
+ *
+ * Confirmed live 2026-08-24: status body keys are exactly `["items","count"]`.
+ * The bare read is kept as the fallback rather than replaced, because it is what
+ * the OpenAPI spec's own status example returns and both shapes are cheap to
+ * accept.
+ */
+function readJobStatus(body: unknown): string | undefined {
+  const items = criblEnvelopeItems(body);
+  if (items !== null) {
+    for (const item of items) {
+      const status = readString(item, "status");
+      if (status !== undefined) return status;
+    }
+  }
+  return readString(body, "status");
+}
+
+/**
  * The lifecycle Cribl's own UI runs, and therefore the one that is PROVEN:
  * create, poll status, read a results page.
  */
@@ -437,7 +467,7 @@ async function runAsyncQuery(
         `Reading the search job's status returned HTTP ${poll.status}. ${detailOf(poll.body)}`.trim(),
       );
     }
-    status = readString(poll.body, "status") ?? "";
+    status = readJobStatus(poll.body) ?? "";
     if (status === "completed") break;
     if (status === "failed" || status === "canceled") {
       return failed(

--- a/soc-optimizationtoolkit/packages/ui/src/polling/sleep.ts
+++ b/soc-optimizationtoolkit/packages/ui/src/polling/sleep.ts
@@ -1,0 +1,22 @@
+/**
+ * The real timer the SHELL supplies to core's attempt-bounded loops.
+ *
+ * Core reads no clock, so every usecase that paces retries or polls takes an
+ * INJECTED `sleep` and calls it as `await config.sleep?.(ms)`. The optional call
+ * is what makes core testable without fake timers - and it is also why a missing
+ * injection fails SILENTLY: `undefined?.(500)` is a no-op, so the loop still
+ * runs, still terminates, and simply never waits.
+ *
+ * That is not hypothetical. The Cribl Lake query shipped without this, so its
+ * twenty status polls fired within milliseconds of each other and every Lake
+ * query in the product reported the search job as still running. Confirmed
+ * against a live workspace on 2026-08-24, against a job that completed on its
+ * first poll a second later.
+ *
+ * Live here rather than in each screen because there were three hand-rolled
+ * copies of the same two lines and the one place it was missing is the one that
+ * broke. A named import is harder to forget than a lambda.
+ */
+export function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/soc-optimizationtoolkit/packages/ui/src/screens/integrate/integrate-screen.tsx
+++ b/soc-optimizationtoolkit/packages/ui/src/screens/integrate/integrate-screen.tsx
@@ -158,6 +158,7 @@ import {
   SearchableMultiSelect,
   SearchableSelect,
 } from "../../components/searchable-select";
+import { sleep } from "../../polling/sleep";
 import { RoleAssignmentSection } from "../role-assignment/role-assignment-section";
 import {
   dcrResourceIdFor,
@@ -1523,6 +1524,12 @@ export function IntegrateScreen({
               {
                 searchGroupId: sampleSources.groups?.searchGroupId ?? "",
                 datasetId: lakeTarget.id,
+                // WITHOUT THIS the twenty status polls fire back to back in
+                // milliseconds and the job is still running when the budget
+                // runs out - which is what every Lake query in the product did
+                // until 2026-08-24. Core reads no clock by design; the shell
+                // owes it the timer.
+                sleep,
               },
               ports.logger,
             );
@@ -1551,6 +1558,9 @@ export function IntegrateScreen({
                 discriminatorField,
                 logTypes,
                 eventsPerLogType,
+                // Same reason as onQuery above, and it matters MORE here: this
+                // runs one job per selected log type.
+                sleep,
               },
               ports.logger,
             )

--- a/soc-optimizationtoolkit/packages/ui/src/screens/labs/lab-provisioner-panels.tsx
+++ b/soc-optimizationtoolkit/packages/ui/src/screens/labs/lab-provisioner-panels.tsx
@@ -18,6 +18,7 @@ import {
   type ProvisionLabResult,
 } from "@soc/core";
 import { usePorts } from "../../ports-context";
+import { sleep } from "../../polling/sleep";
 import {
   canDeployFoundation,
   criblBundleArtifact,
@@ -152,7 +153,7 @@ export function LabProvisionerPanels({
           // The legacy 4-char random collision suffix; randomness lives in
           // the impure component layer, never in core.
           mintStorageSuffix: () => Math.random().toString(36).slice(2, 6),
-          retry: { sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)) },
+          retry: { sleep },
           onProgress: (step) => {
             setSteps((prev) =>
               prev.map((s) => (s.name === step.name ? step : s)),

--- a/soc-optimizationtoolkit/packages/ui/src/screens/role-assignment/role-assignment-section.tsx
+++ b/soc-optimizationtoolkit/packages/ui/src/screens/role-assignment/role-assignment-section.tsx
@@ -37,6 +37,7 @@ import type {
 import { usePorts } from "../../ports-context";
 import { SearchableSelect } from "../../components/searchable-select";
 import { formatStepLine } from "../../onboarding/step-line";
+import { sleep as realSleep } from "../../polling/sleep";
 import {
   projectRoleOutcome,
   roleAssignDisabledReason,
@@ -52,10 +53,6 @@ const KIND_LABEL: Record<"assigned" | "already" | "failed", string> = {
   failed: "failed",
 };
 
-/** Default retry pacing when the shell injects none (real timer; UI layer). */
-function defaultSleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
 
 export interface RoleAssignmentSectionProps {
   /**
@@ -189,7 +186,7 @@ export function RoleAssignmentSection({
           principalId: objectId.trim(),
           targets: [...targets],
           mintAssignmentName: minter,
-          retry: { sleep: sleep ?? defaultSleep },
+          retry: { sleep: sleep ?? realSleep },
           onProgress: (step) => {
             setSteps((prev) =>
               prev.map((s) => (s.name === step.name ? { ...step } : s)),


### PR DESCRIPTION
Live verification against the lab workspace - ADR-0003's outstanding gate - found **the Lake query mode broken two independent ways**. Both fail silently, and either alone stops every Lake query in the product.

## 1. The job status was never read

The poll did `readString(poll.body, "status")`, a **top-level** read. Live, that response is `{items, count}` - keys exactly `["items","count"]` - with the status at `items[0].status`.

So it read `undefined` on all twenty polls, `status` stayed `""`, the loop burned its whole budget, and every Lake query reported the job **"still pending"** - for jobs that were `completed` on the **first** poll. `readJobId`, two functions away, already handled the same envelope correctly.

## 2. The shell never injected a clock

Core reads no clock by design and calls `await config.sleep?.(ms)` - so a missing injection is a **no-op, not an error**: the loop still runs and simply never waits. Neither Lake call site passed one, so twenty polls fired inside ~4s, measured live as **shorter than any populated dataset takes to search**. Only an *empty* dataset could finish in time - the failure mode disguised as a pass.

The sleep now comes from one shared `polling/sleep.ts` rather than a fourth hand-rolled `setTimeout`. There were three copies and the place it was missing is the place that broke.

## Why the tests did not catch either

The scripted status responses used a bare top-level `status` **the platform never sends**. All ten are converted to the live envelope via a `jobStatus` helper, plus three new pins asserting the poll **count**, the sleep sequence, and that the note says "still running" rather than "still pending" - "pending" being the app admitting it read nothing.

Reverting the fix now fails **8 pins, 6 of them pre-existing** - they only started biting once they scripted the real shape.

## The harness had two defects of its own

Both produced confident wrong answers, which is worse than a red run:

- It took the **first** Stream group, which in the lab has no connected workers, so every capture 400'd on `No worker nodes are connected` - a platform precondition, nothing to do with the code under test. It now resolves a group that has workers (`CRIBL_LIVE_GROUP` pins one) and filters on the stream **type** rather than "not search", which had been letting edge fleets through.
- **Row 8 read any 400 as "Cribl rejected the undeclared field"** - a verdict about the JavaScript evaluator drawn from a request that never reached one. The guarded request is now the control; a failed control yields no verdict.

## What the live run now settles

| Row | Verdict |
|---|---|
| 4 - single-event decode | CONFIRMED - arrives as an object; the old `[]` bug is fixed |
| 5 - capture clamp | CONFIRMED - a 10s capture survives the bridge |
| 6 - Lake listing | CONFIRMED - leader route, lake id `default`, 31 datasets |
| 6 - queryLakeSamples | CONFIRMED - job path returned 50 events |
| 7 - capture permission | CONFIRMED - 15 enabled inputs |
| 8 - undeclared fields | **TOLERATED** - guards are insurance, not load-bearing. The *opposite* of what the broken row reported. |

Rows 1, 2 and 3 remain open and are **not** addressed here - see the PR discussion.

## Gates

4,025 tests pass, typecheck clean, lint clean.